### PR TITLE
Added specific OCRed pages from Brown, LoC, and Peel Texts

### DIFF
--- a/OCR/Brown/289.txt
+++ b/OCR/Brown/289.txt
@@ -1,0 +1,116 @@
+AKW 
+
+
+
+LKWEKISIW, ok, la. a.) il est 
+dwci, il est amoindri par la sé- 
+cheresse. 
+
+lKWEKAN, wa, (a. in.) idem. 
+lKOTEWISIW, ok, (a. a.) il est 
+Vtuel, rude, dur. 
+
+.KOTEWAN, wa, (a. in.) idem. 
+LWÂWAN, a, [n. r.) grille, écha- 
+faudage pour faire sécher la vian- 
+le. 
+
+iKWÂ (rac.) profondément, én- 
+oncé bien avant, loin. 
+KWÂTCH, (ad.) profondément, 
+oin, en avant ; v. g. , âkwâtchis- 
+>ayiw, ça s'enfonce loin avant; 
+m dirait aussi: sâsay osâm âk- 
+vâtchispayiw, l'affaire est déjà 
+rop avancé ; âkwâtch ni pimiti- 
+ahwaw, je le poursuis loin; âk- 
+vâtch payipaham, il le perce bien 
+vant ; âkwâkijikaw, jour avan- 
+
+
+
+é; âkwâtibiskaw, nuit avancé, 
+l signifie aussi: avec peine, com- 
+ic akâwâtch; v. g., âkwâtch 
+imâ'isiw, il vit à peine, ou, sa 
+ie vient de loin, par ex. quelqu'un 
+ui s'échappe avec peine d'un dan- 
+er ; sâsay âkwâtch kiskeyittam, 
+sait déjà beaucoup; âkwâtch 
+inakatchihitin, je suis beaucoup 
+ccoutumé à ta façon. . 
+ECWÂSIN, wok, (a. a.) il est 
+iaucoup enfoncé, il est beaucoup 
+rrivé loin. 
+
+CWÂTTIN, wa, [a. in.) idem. 
+ÎWÂSImew, {v. a.) c'est avee 
+me qu'il h fait vivre. 
+£WÂSK, (ad.) au devant, par 
+'want. 
+
+ÉWÂSkawew, (v. a.) KAM, KÂ- 
+EW, tchikew. il lui coupe le che- 1 
+
+
+
+min pour passer devant lui; v. g., 
+kakwe âkwâskaw mayowes wâ- 
+yo e ayât, tâche de lui couper 
+chemin avant qu'il soit loin. 
+ÂKWASKAM, (ad.) davantage, 
+plus; v. g., âkwâskam musta- 
+Winam, il en désire davantage. 
+
+k AKWASKISPAYIW, ok, a, (a. 
+v. an. et in.) il, ou, ça agit comme 
+voulant couper chemin, voulant 
+passer par devant. 
+
+«AKWASKInew,(u. a.) nam, ni- 
+wew, nikew, il le lient dans ses 
+bras, il le tient à brassées; v. g., 
+âbittasiyaw âkwaskinaw, il est 
+tenu par le milieu du corps. 
+
+« ÂKWASKITInew, (v. a.) nam, ni- 
+
+
+
+wew, nikew, idem. 
+ÂKWASKISkawew, (if. a.) kam, 
+
+KÂKEW, TCHIKEW, U lui COUpe U 
+
+chemin en passant devant lui, en 
+
+faisant un détour. 
+
+: AKWAN, (rac.) couvrir y abriter^ 
+
+mettre un couvercle. 
+« AKWANÂhwew, (v. a.) ham, hu- 
+
+wew, hikew, il le couvre, recou- 
+vre. 
+« AKWANInew, (v. a.) nam, ni- 
+
+wew, nikew, idem. 
+« AKWANÂsimew, (p. a.) ttitaw 
+
+simiwew, sitchikew, idem. 
+« AKWANÂHUW, ok, (v. r.) il se 
+
+couvre. 
+« AKWANÂHUWIN, a, (n. f.) cou- 
+verture, chale, couverte. 
+« AKWANAhyew, (v. a.) staw, 
+
+yiwew, tchikew, il le place en le 
+
+couvrant. 
+« AKWANABOhwew, (v. a.) ham, 
+
+huwew, hikew, il le couvre, v. g., 
+
+un vase. 

--- a/OCR/Brown/290.txt
+++ b/OCR/Brown/290.txt
@@ -1,0 +1,126 @@
+290 
+
+
+
+AKW 
+
+
+
+« AKWANiBOHIGAN, a,, {n. f.) 
+
+couvercle d'un vase, d'une chau 
+
+diere, etc. 
+«AKWANiBOWESIN,wok, 
+
+{a. a.) il est couvert. 
+« AKWANÂBQWETTIN, wa, [a. 
+
+'in.) idem. 
+« AKWANÂKKWEW, ok, {v. n.) 
+
+il se couvre le visage. 
+« AKWANÂKKWEhwew, ham, 
+
+huwew, hikew, ou, akokkweh- 
+
+wew, ou, akokkwepi tew, il lui 
+
+couvre le visage. 
+«AKWANÂKKWEPItew, {v. a.) 
+
+TAM, SIWEW, TCHIKEW,, U lui 
+
+bande le visage. 
+« AKWANÂKKWEPISUWIN, a 
+
+(n. f.) couverture du visage. 
+
+«AKAWÂYIK, {ad.) à l'abri, à 
+couvert, v. g. akawâyik pimut- 
+tew, il marche à F abri, akawâtik, 
+à f abri du bois, de la forêt, aka- 
+wâmatin, à F abri de la montagne, 
+akawâtiu, à F abri de la colline. 
+
+« AKAWÂBIKKWEW, ok, {a. v.) 
+il a les yeux couverts. 
+
+« AKAWÂBIKKWEhwew, [v. a.) 
+
+HAM, HUWEW, HIKEW, U lui COUVre 
+
+la vue. 
+« AKAWÂKKWEPItew, {v. a.) 
+
+tam, siwew, tchikew, iF lui bande 
+
+les yeux. 
+« AKAWAWESIMOW, ok, {a. v.) 
+
+il se meta F abri de quelque chose. 
+« AKaWÂWEsimew, [v. a.) tti- 
+
+TAW, MIWEW, TCHIKEW, U le place 
+
+à F abri. 
+«AKGSIMOW, ok, (a. v.) comme, 
+
+akawâwesimow. 
+« AKOSkawew, (v, a. ) kam. kâkew, 
+
+tchikew, il le couvre complète- 
+
+
+
+ment^, g. mustuswok mishv 
+akoskamok askïy, les buffli 
+couvrent la terre. 
+
+xAKWEB, [rac.) embarrassan 
+qui prend beaucoup de plac 
+beaucoup, en grande quantité. 
+« AKWEBÉS,{ad.)quandona bea\ 
+coup de choses, jusqu'à en M 
+embarrasse, v. g. akwébés ïi'J 
+yâwâwok kiuusewok, fai d 
+poissons en abondance. 
+
+« AKWEBISIW, ok, {a. a.) il e 
+embarrassant, et,il est embarrasi 
+il a beaucoup de choses qui Fei 
+barrassent, v. g. awiyak wey 
+sitji mistahi akwebisiw mân 
+celui qui est riche a beaucoup 
+choses à son usage. 
+
+«AKWEBAN, wa, [a. in.) J 
+embarrassant. 
+
+« AKWEBEYImew, {v. a.) tta 
+miwew, tchikew' il le trouve t\ 
+ban • assaut. 
+
+« AKWEPAPIW, ok, {a. v.) il 
+embarrassant, v. g. quelqu'un q 
+occupe trop de place. 
+
+« AKWEPASTEW, a, {a. v. h 
+c'est embarrassant par le volun 
+etc. 
+
+« AKWEPInew, {v. a.) nam, : 
+wew, nikew, il ne sait trop coi 
+ment le placer à cause de Fc 
+barras. 
+
+x AKW AN, {rac.) la même que ci 
+ci-dessus, à couvert, etc. 
+
+« AKWANOKIJOWEW,ok,(iv 
+il parle à mots couverts, il pa 
+en paraboles. 
+
+(cAKWANOKIJvVÂtew, {v. 
+tam, siwew, tchikew, il lui pa 
+à mots couverts, en paraboles. 

--- a/OCR/Brown/291.txt
+++ b/OCR/Brown/291.txt
@@ -1,0 +1,130 @@
+AMA 
+
+
+
+AKWANOKIJOWEWIN, a, (n. 
+
+f.) parole à couvert, parabole. 
+<ÂKWETTAW, [rac.) doubler, 
+
+mettre l'un sur l'autre, 
+ÂKWETTÂWAHYEw,(y.a.) staw, 
+
+yiwew, tghikew, il les met Vun 
+
+sur Vautre, 
+ÂKWETTAWIKWÂtew, {v. a.) 
+
+TAM, SIWEW, TGHIKEW, U \Us COUd 
+
+Vun sur Vautre, il le double. 
+ÂKWETTÂWESKISINEW, ok, 
+
+(v. n.) il met double paire de sou- 
+liers, ou, ayâkwettâweskisinew, 
+Wed.) 
+
+ÂKWETTÂWESiKEW, ok, {v. 
+
+n.) il met double habit, capot. 
+
+ÂKWETTÂWEWEYONISEW, 
+
+ok, (v. n.) il revet double habille- 
+ment. 
+
+ÂKWETTÂWAPIW, ok, (a. r.) 
+v. g. mustusweyânak âkwetta- 
+wapiwok, les robes de buffles sont 
+en tas les unes sur les autres. 
+
+AKWETTÂWaSTEW, a, (a. in.) 
+c'est doublé, c'est Vun sur Vautre. 
+
+■ ÂKUST, {rac.) tremper dans Veau, 
+mouiller. 
+
+AKUSTImew, [v. a.)TAW, miwew, 
+tghikew, il le met dans Veau. 
+
+AKUSTÂBAWAyew, {v. a.) taw, 
+yiwew, tghikew, idem. 
+
+ÂKUSTIMOW, ok, {n. a.) il est 
+mouillé. 
+
+iKUSTIN, wa, {a. in.) c'est 
+mouillé. 
+
+:AJIW, (rac.) incapable, qui ne 
+réussit pas. 
+
+ijIWISIW, ok, [a. a. ) il ne réus- 
+sit pas, (synonimes) nayoyuw, 
+akawisiw. 
+
+
+
+« AJIWAN, wa, [a. in.) ça n'arrive 
+pas, ça ne réussit pas, naraa aji- 
+wan, ça arrive toujours, sans 
+faute, v. g. ekuyikok mânanama 
+âjiwan eka kitchi mispuk, c'est 
+le temps qu'il neige sans faute. 
+
+« ÂJIWE YImew, {v. a. ) ttam, mi- 
+wew, tchikew, il le pense inca- 
+pable de faire telle chose, de réus- 
+sir, etc., nama kekway n't'âjiwe- 
+yimaw Kijemamto, je pense 
+Dieu capable de réussir en toutes 
+choses. 
+
+« ÂMAK, wok, [n. r. ) aiguille pour 
+lacer les raquettes. 
+
+x AM, (rac.) faire fuir, faire peur. 
+
+« AMÂMEW, [V. a. ) TAM, MIWEW, 
+
+tghikew, il le fait fuir, v. g. quel- 
+qu'un qui veut approcher un ani- 
+mal sauvage, et en faisant quel- 
+que bruit, il le fait fuir, il l'épou- 
+vante. 
+
+(( AMÂHEW, [V. a.) TTAW, HIWEW, 
+
+tghikew, idem. 
+« AMÂHAMÂwew, [v. a.) tam, 
+
+kew, tghikew, il lui fait fuii\ il 
+
+est la cause que l'animal d'un 
+
+autre fuit. 
+« AMÂWEHAMÂwew, (v. a.) tam, 
+
+kew, tghikew, idem. 
+« AMiTAMiWEW, [v. a.) idem. 
+« AMÂWEKAHIKE W, ok, [v. ind.) 
+
+il le fait fuir, en frappant avec 
+
+une hache. 
+« AMAWEswew, (u. a ) sam, siwew, 
+
+sikew, il le fait fuir en tirant du 
+
+fusil. 
+« AMATISUW, ok, [v. n.) il est aux 
+
+aguets, il craint quelque surprise, 
+
+il est sur ses gardes. 
+
+
+
+
+
+AMA 

--- a/OCR/Brown/292.txt
+++ b/OCR/Brown/292.txt
@@ -1,0 +1,117 @@
+292 
+
+
+
+AMI 
+
+
+
+« AMATISUWIN, a, (o. f.) crainte 
+d'être surpris. 
+
+« AMATISUStawew, [v. a.) tam, 
+tâkew, tchikew, il craint quel- 
+que surprise de sa part, il se 
+garde contre lui. 
+
+« AMATISUSTAMiwEW, [fi. a.) 
+
+TAM, KEW, ^TCHIKEW, U est aUX 
+
+aguets sur son compte, v. g. eoko 
+iskwew amatisustamâwew oko 
+sissa, cette femme craint pour son 
+fils. Note. Toute cette racine in- 
+dique qu'on est effrayé, qu'on est 
+aux aguets parce qu'on a ru, ou 
+qu'on croit avoir vu quelque 
+chose; ce qui est bien différent 
+d'un autre mot, astâsiw, qui pa- 
+rait signifier la même chose, et 
+qui cependant est bien différent. 
+
+x ÂMAT, frac.) monter une côte, 
+une élévation , hauteur. 
+
+«ÂMATCHIWEW, ok, [v. n.) il 
+monte une côte, une colline. Note. 
+La terminaison tchiwew, indique 
+une colline,' montagne, v. g. frit 
+tatchiwew, il descend une colline. 
+
+ÂMATCHIWEYAW, {a. in.) c'est 
+en montant, c'est une hauteur. 
+
+« ÂMATGHIWETCHAW, [a. in.) 
+c'est une hauteur de. terre, qui va 
+en montant. 
+
+« ÂMATGHIWEhew, (u. a.) ttaw, 
+hiwew, hikew, il le monte. 
+
+a ÂMATGHIWEPItew, [y. a.) tam, 
+siwew, tchikew, il le monte en 
+le tirant à lui. 
+
+a ÂMATGHIWETISAhwew, [v. a.) 
+
+HAM, HUWEW, HIKEW, U H fait 
+
+monter promptement. 
+« ÂMATCHIWEWIN, a, (n. f.) une 
+montée. 
+
+
+
+« ÂMATGHIWESKANAW, a, (n 
+f.) chemin pour monter. 
+
+«ÂMATIN, terminaison qui design 
+une montagne, butte, colline, v. g 
+takkutchâmatiu, sur la monta 
+gne, awasâmatin, de Vautre côt 
+de la butte, astamâmatin, de c 
+côté de la colline; alors ces mot 
+sont des adverbes, et ne se déch 
+nent vas. 
+
+AMATITTE, {ad.) de côté et d'au 
+très, comme, pikonata ite. 
+
+ÂMI, [ad.) presque, kekâtch, cemo 
+se met toujours entre le pronor 
+et le verbe, et il ne s'emploie ja 
+mais seul comme kekâtch, v. g 
+n't'âmi miyik, il me le clonn 
+presque, il a été sur le point d 
+me le donner, wâbaniyik 'kit 
+âmi takusinwok, demain ils ai 
+riveront presque (probablement.) 
+
+AMISK, wok, (n. r.) castor. 
+
+« AMfôKOWIW, ok, [a. a.) il es 
+castor. 
+
+« AMISK OWAN, wa, {a. in.) c'es 
+du castor. 
+
+«AMISKWEYÂN, ak, [n. f.) pea 
+de castor, avec le poil. N. La ter 
+minaison weyân désigne une pea 
+avec son poil, et ce nom ainsi foi 
+mé a la qualité des noms animés 
+v. g., mustus weyân ak, peau. 
+de buffles avec le poil; osekamist 
+wok, castor éparé, dépecé; awe 
+tis, ak, petit castor; poyawesis 
+ak, castor d'un an ; patamisk 
+wok, castor de deux ans ; nâbe 
+misk, wok, le castor mâle; noje 
+misk, wok. la femelle. 
+
+ÂMIW, ok, {v. n.) le poisson frait 
+
+
+
+AMI 

--- a/OCR/Brown/293.txt
+++ b/OCR/Brown/293.txt
@@ -1,0 +1,121 @@
+293 ANI 
+
+
+
+du 
+
+
+
+IMIWIN, a, (n. f.) le temps 
+fraieage. 
+
+LMOW, ok, (n. r.) abeille, grosse 
+guêpe. 
+
+ANAKKÂTCH, (ad.) N. Il est très- 
+difficile de traduire ce mot, qui 
+veut dire à peu près: quelque chose 
+qu'on regrette, et qui, quoique de 
+peu de valeur, cependant a sa va- 
+leur dans la position où ça se trou- 
+ve. Des exemples feront mieux 
+comprendre. Anakkâtch ki webi- 
+naw eoko mistikus, c'est regret- 
+table que tu rejettes ce petit bois 
+(sous- entendu) quoique de peu de 
+valeur, pourtant il aurait été uti- 
+le ; anakkâtch eoko ! ça vaut 
+mieux que rien, c'est toujovrs 
+quelque chose ; o miyopimâtisiyi, 
+anakkâtch ka kikkamât, c'est 
+pourtant un bon vivant, c'est re- 
+grettable qu'il le dispute ; anak- 
+kâtch ni wanittân, je regrette de 
+lavoir perdu, quoique ce n'était 
+pas grand' chose; anakkâtch ki 
+webinaw, eyiwek ki ka ki âbat- 
+jitta ; c'est regrettable que tu le 
+rejettes, tu aurais pu t'en servir; 
+anakkâtch ni wi-miyikottày, 
+c'est regrettable que la chose soit 
+arrivée ainsi, pourtant il voulait 
+me donner tela. 
+
+ANAKATCHAY ! (ex.) admiration 
+pour quelque chose d'extraordinai- 
+re; v. g., anakatchày tâpwe mi- 
+sikitiw kit'em ! combien ton che- 
+val est gros ! 
+
+ANAKKWAY, ak, (n. r.) manche 
+dun habit; n'otanakkwân, j'ai 
+des manches; kiskanakkwày, ak, 
+manche coupée, rognée. 
+
+
+
+« ANAKWAKkawew, (v. a.) kam, 
+kâkew, tchikew, il lui fait des 
+manches. 
+
+xANÂSK, (rac.) étendre quelque 
+chose par terre, etc. 
+
+« ANÂSKEW, ok, (v. n.) il étend 
+quelque chose par terre. 
+
+« ANÂSKATtew, [v, a.) tam, si- 
+wew, tchikew, il lui étend quel- 
+que chose par terre, pour s'asseoir 
+ou se coucher. 
+
+« ANÂSKATTOWEW, twâkew, 
+idem. 
+
+« ANÂSKASUW, ok, (v. n.) il se 
+met un tapis sous lui, il étend' 
+quelque chose par terre pour 
+servir de tapis, ou de lit. 
+
+«ANÂSKATTEW, a, (a. in.) c'est 
+tapissé, la place est préparé pour 
+s'y asseoir, ou pour s'y coucher. 
+
+«ANiSKASUN, ak, (n. f.) tapis, 
+pièce pour mettre sous soi. 
+
+ANÂH, (pro.) celui là; v. g., anâh 
+ni'stes ka petchâstamuttet, celui- 
+là mon frère qui s'avance ; eoko- 
+ni ânihi ka pakamahwât, c'est ce- 
+lui-là qu'il a frappé. 
+
+« ANIKI, (pro. pi. an.) ceux-là; v. 
+g., eokonik aniki ka ki nipattâ- 
+ketjik, ce sont ceux là qui ont fait 
+un meurtre ; aniki eka ka wi- 
+ayamihâtjik, ceux qui ne veulent 
+pas prier. 
+
+ANDÊ, ou, AND A, (ad.) par là, en 
+quelque part; v. g., an de ka as- 
+tek ki mokkumân, c'est en quel- 
+que part par là qu'est ton couteau. 
+
+ANI, (ad.) (après le mot) pour donner 
+plus de force à ce que Ton dit; 
+v. g., tâpwe ani, c'est bien vrai; 
+
+
+
+ota ani, cest ici; 
+
+
+
+ni wi-ituttân 
+
+
+
+
+
+' 

--- a/OCR/Brown/294.txt
+++ b/OCR/Brown/294.txt
@@ -1,0 +1,116 @@
+294 
+
+
+
+
+am, je veux y aller assurément; 
+ki wittamâtinawaw ani, je vous 
+le dis donc. Ce mot sert à faire af- 
+firmer plus fortement ce que Von 
+avance. 
+
+ANIYE, (ad.) On emploie ce mot à 
+peu près comme ani; v. g., ot'- 
+âkkusittày aniyê, il était malade 
+en effet alors; sipwettew aniyê, 
+le voilà parti donc; takusin aniyê, 
+le voilà donc arrivé. On V entend 
+aussi dire quelquefois devant le 
+mot; v. g., aniyê ka wâbamak, 
+alors que je l'ai vu. 
+
+ANATA, (ad.) (après le mot) assuré- 
+ment, vrviment, comme kusha ; 
+v. g., wiya anata, c'est lui assu- 
+rément. 
+
+ANIHUW, ok, (v. n.) il dépérit, il 
+maigrit, par exemple un animal 
+après avoir trop travaillé. 
+
+« ANIHUhew, (v. a. ) ttaw, hiwew. 
+tchikew, il le fait dépérir. 
+
+x AN, (rac.) penser autrement, con- 
+tredire, désobéir; âniseyimew, 
+
+
+
+ttam, anisistawew, 
+désapprouve. 
+
+ÂNImew, (v. a.) TTAM, 
+
+
+
+tam, il le 
+
+
+
+miwew. 
+
+
+
+paroles, il n'approuve pas sa con 
+duite, v. g., quelqu'un qui dirait : 
+je n'approuve pas sa conduite, moi 
+je ne ferais pas ainsi. 
+
+« ÂNEYImew. {v. a.) TTAM, MIWEW, 
+tchikew, il n'approuve pas sa 
+conduite, dans sa pensée; v. g., 
+n't'âneyitten niya, eoko nama 
+ekusi ni pa to ten, je n'approuve 
+pas cela, je ne ferais pas ainsi. 
+
+«ÂNWEYImew, etc., idem. 
+
+
+
+ANI 
+
+«ANTttawew, (v.. a.) ttam, ttâ 
+kew, tchikew, il lui désobéit, i 
+n'approuve pas ses paroles; v. g, 
+awiyak ayânittawâtji ayamihe 
+wiyiniwa tâbiskotch e ânittawâ 
+Kije manitowa, celui qui déso 
+béit au prêtre, désobéit à Dieu. 
+« ÂNWEttawew, etc., idem. 
+«ANIKKEMOW, ok, (v. n.) il ré- 
+prouve, il désapprouve. 
+« ÂNWETTÂKEWIN, a, (n. f.) dé- 
+sobéissance. 
+« ÂNITTAMOWIN, a, (n, f.) idem. 
+« ANIKKEMOWIN, a, (n.f.) idem. 
+« ÂNISIhew, (v. a.) ttaw, hiwew, 
+tchikew, \l en détruit l'effet. On 
+emploie ce mot quand quelqu'un 
+par ses médecines détruit l'effet 
+d'un poison ou d'un sortilège, etc. 
+« ÂNISITCHIGAN, a, (n. f.) con- 
+tre-poison, remède contraire; v. 
+g., ^yamihewinanatâwihuwina 
+ânisitchiganiwiwa pâstâhuwin e 
+âkkusiskâkuyak, les sacrements 
+sont des contrepoisons contre le 
+péché qui nous rend malade. 
+« ÂNISIHIWEWIN, a, (n. f.) idem. 
+ANIMA, (pro. in.) celui-là; eoko 
+anima ki mokkumân, c'est ton 
+couteau celui-là. 
+ANIHI, (pro. in. pi.) ceux-là; v. g., 
+eokoni anihi ki mokkumâna, ce 
+sont vos couteaux ceux-là. 
+ANISIKIS, (ad.) c'est pourquoi, 
+donc ; comme, tasipwa, tesikote; 
+v. g. , anisikis ki miyin, donc tu 
+me le donnes; anisikis namawiya 
+ki ka sipwettân, ainsi tu ne par- 
+tiras pas; anisikis namawiya ki 
+wi-ayamihân, eka k'o pe kiski- 
+nohamâkusiyan, donc, ainsi, tu 
+
+
+
+ÂNI 

--- a/OCR/Brown/342.txt
+++ b/OCR/Brown/342.txt
@@ -1,0 +1,139 @@
+342 
+
+
+
+ISI 
+
+
+
+« ISAWÂNAKEYI M OTOtawew, 
+
+(V. a.) TAM, TÂKEW, TATCHIKEW 
+
+idem, 
+« ISAWÂNAKEYIMOW, ok, (v. 
+
+n.) il est jaloux, voy. sawânake- 
+yimow. 
+x ISA, (rac.) malgré lui, avec peine, 
+se faire violence. 
+
+(v. r.) il se modère, 
+il se retient, il se corrige, mais en 
+se faisant violence, v. g. namawi- 
+ya ki isâhuw, il ne peut se corri- 
+ger, il ne peut venir à bout de tel 
+défaut, ayis namawiya ni ki isâ- 
+hun, qiïy faire, je ne puis m'en 
+corriger, je ne puis m'en empêcher. 
+
+( ISÂHEW, [V. a ) TTAW, HIWEW, HI- 
+
+kew, il le modère, il le corrige, il 
+r empêche de faire telle chose, mais 
+ce n'est qu'en lui faisant une sorte 
+de violence. 
+« ISÂTCH, ou, IYISiTCH, malgré 
+lui, avec peine, à contre cœur, v.g. 
+iyisâtchituttew, il y va à contre 
+cœur, ekawiya iyisâtch tota, ne 
+fais pas cela à contre cœur. 
+x ISAW, {rac.) carré. 
+ISiWESIW, ok, {a. a.) il est 
+carré, ayisâwesiw. 
+ISÂWEYAW, a, {a. in.) c'est car- 
+ré, ayisâweyaw. 
+« ISÂWEK, wok, aiguille carrée, ou, 
+
+asâwek, wok. 
+« ISÂWEswew, {v. a.) sam, suwew, 
+sikew, il le taille carré avec un 
+couteau, ou, un ciseau. 
+« ISAWEnew, {v. a.) NAM, NIWEW, 
+nikew, il le tient avec la main par 
+la partie carrée, ou, coupante, 
+voy. la racine asâwe, qui est la 
+
+
+
+même que celle-ci pour la signifl 
+cation. 
+
+« ISAW E HE W, {V. a.) TTAW, HIWEW 
+
+hikew, il le fait carré. N. B. Ton 
+
+ces mots se disent plus souven 
+
+avec le redoublement, ayis, et( 
+
+C'est pour cela -probablement qu'o 
+
+dit indifféremment isâwe, ou, ay 
+
+sâwe. 
+
+xIS et IT, (rac.) ainsi, de cette wi 
+
+nière, de cette forme, de cette f 
+
+çon. 
+
+« ISI, ou, IJI, devant le verbe, aim 
+
+comme ça, v. g. ekusi iji, c'e 
+
+ainsi, eji kijewâtisit, étant ain 
+
+charitable, awâsis^ka iji-miyosi 
+
+l'enfant qui est sibeau,e\\ match 
+
+kijikâk, nama ni ka sipwettâ 
+
+vu qu'il fait ainsi mauvais terni 
+
+je ne partirai pas, eji-kâkebâ 
+
+sit ! comme il est insensé! tchis 
+
+eji-pikupayik ni mokknraâi 
+
+vois donc, comme mon couteau i 
+
+brisé! ekusi piko n't' iji-kisl 
+
+yitten, je ne le sais que de ce 
+
+manière, Jesus-Chrlst ki pe-iti 
+
+tew waskitaskamik eji-mani 
+
+wit mina eji-ayisiyiniwit, Jési 
+
+Christ est venu sur la terre com 
+
+Dieu et comme homme, eji-atcl 
+
+kowik mina ej:-owiyawik, 
+
+âme et en corps. 
+
+< IJITCHITGHEYIW, ok, (v. n. 
+
+étend la main vers. 
+« UITGHITCHEYIStawew, {v. 
+
+TAM, TÂKEW, TÂTCHIKEW, U étl 
+
+la main vers lui. 
+« IJITGHITGHEYITOtawew, 
+
+a.) etc.. idem. 
+« ISIW, ok, sorte de verbe am 
+
+aire, comme, ittiw, ayaw, il « 
+
+
+
+ISI 

--- a/OCR/Brown/362.txt
+++ b/OCR/Brown/362.txt
@@ -1,0 +1,149 @@
+362 
+
+
+
+KAK 
+
+
+
+x KAKEBATISIW, ok, (a. a.) il 
+n'a pas d'esprit, il a un caractère 
+bouché. Ce mot vient probablement 
+de la racine kepa, ou, kippaw, 
+qui veut dire bouché, fermé, avec 
+le redoublement ka. 
+
+« KAKEBATEYImew, [v. a.) ttam, 
+miwew, tchikew, Me trouve fou, 
+insensé. 
+
+« KAKEBATISIKKEW, ok, {v. n.) 
+il agit en insensé. 
+
+« KAKE BATCH LTTWAW, ok, id. 
+
+« KAKEBATISIKKEWIN, a, (n.f) 
+folie. 
+
+« KAKEBATCHITTWAWIN, a, 
+[n. f. ) idem. 
+
+« KAKEBÂTISIKKAttew, [v. a.) 
+
+
+
+TTAM, SIWEW, TCHIKEW. 
+
+
+
+il se 
+
+
+
+prend en insensé pour agir avec 
+lui, il s y prend mal pour le ga 
+gner. 
+
+« KAKEPITTEW, ok, [a. a.) il est 
+sourd, il a les oreilles bouchées. 
+
++ KAKESKImew, {v. a.) ttam, mi- 
+wew, tchikew, il le conseille, il 
+l'avise, il V avert it. 
+
+« KAKESKIMIWEW1N, a, (n. f.) 
+conseil, avis, voy. la racine kiski. 
+
+« KAKESKIMOW, ok, ou, kakes- 
+kikkeraow, ok, [v. n.) il fait des 
+instructions, il donne des avis ; 
+c'est le mot reçu pour dire : il prê- 
+che. 
+
+« KAKESK1MOWIN, a, ou, kakes- 
+kikkemowin, a, {n. f.) instruc- 
+tion, sermon. 
+
+«KAKESKWEW, ok, [v. n) com- 
+me kakeskikkemow. 
+
+« K^KESKWEWIN, a, [n. f.) com- 
+me kakeskikkemowin. 
+
+
+
+« KAKESKWEWIYINIW, ok, 
+
+f.) un prêcheur, un prédicatei 
+« KAKETTÂWEW, ok, {v. | 
+comme nittâwew, il a rasage 
+la parole, il a la parole en bouc) 
+v. g. un enfant qui a déjà bi 
+Vusage de la parole, on dirait : 1 
+kettâwew. 
+KAKETTAWEYImew, ttam, 1 
+
+trouve prudent, ingénieux. 
+KAKETTAWÂTISIW, ou. kak 
+tâweyittam, il est prudent, hom 
+de génie. 
+
+cKÂKI, (rac.) supplier, shumil 
+
+en présence de, etc., etc. 
+
+KÂKISIMOWIN, a, (n. f.) s< 
+
+plication humble. 
+
+KÂKISIMOW, ok, (v. n.) Us 
+
+plie avec larmes, avec hwrdUtè 
+
+KAKISIMOTOtawew, [v. oM 
+
+tâkew, tchikew, il le supplie 
+
+s abaissant, v. g. n'otta ki pe- 
+
+kisimototâtin kitchi kitimâke 
+
+miyan, mon père, je viens te s 
+
+plier d'avoir pitié de moi. 
+
+KÂKITOkkawew, [v. a.) M 
+
+kâkew, tchikew, il sliumilie 
+
+vaut lui, en lui faisant des l 
+
+sesses, {ce dernier mot doit s 
+
+tendre à la façon du pays,) I 
+
+e ki kisiwâhât on.âbema, et 
+
+pe-kâkitokkawew, ayant fait 
+
+cher son mari, ell vient lui f 
+
+des bassesses. 
+
+: KAK1TOKKÂSUW, ok, (v. n 
+
+fait des bassesses, il reconnai 
+
+faute. 
+
+, KAKIT OKKÂSUWIN, â ■ 
+
+bassesses, humiliation^soumiss 
+
+(KÂKITJIhew, (v. a.) ttaw, 
+
+wew, tchikew, il le console, i 
+
+
+
+KAK 

--- a/OCR/Brown/471.txt
+++ b/OCR/Brown/471.txt
@@ -1,0 +1,119 @@
+471 MUT 
+
+
+
+3SKUMEM0W, ok, (v. n.) il 
+leure de faim. 
+
+DSKUWÂtew, (v. a.) tam, si- 
+'EW, tchikew, il pleure après 
+i. 
+
+DSKWEYITTAM, wok, (v. n.) 
+t douleur éclate. , son chagrin se 
+it jour. 
+
+3SKUYÂWESIW, ok, {a. a ) 
+em. 
+
+)SKUhew, mew, (v. a.) il le 
+uche, il V affecte, il le touche jus- 
+faux larmes. 
+
+)SKITJIWAN, wa, (h. f) une 
+ntaine, une source d'eau. 
+)SKITJIWANIPEK, wa, (n.f.) 
+em. 
+
+)SK1new, (v. a.) NAM, NIWEW, 
+kew, il le découvre, il le fait 
+ir à découvert. 
+
+)SKIPItew, [v. a, ) tam, siwew, 
+ihikew, il le tire à jour. 
+)SKIW, ok, (v. n. ) il se décou- 
+•e, il se montre. 
+
+)SKINEW, ok a, (a. a. et in.) 
+est rempli jusqu'au faîte. 
+
+)SKINAHEW, {V. V.) TTAW, HI 
+
+ew, tchikew, il le remplit jus- 
+tau faîte. 
+
+ONJIhew, (v.a.) ttaw,hiwew, 
+ihikew, il le sent, il le ressent, 
+mt au physique qu'au moral.) 
+)NJIHUW, ok, (v.r.) il éprouve 
+le sensation. 
+
+)NJITTOYUW, ok.(v.r.) idem, 
+)NJITTiWIN, a, (n. f.) sensa- 
+m. 
+
+)JIHUWIN, a, (n. f) idem, 
+:>rWÂK, (ad.) pas de sitôt. Voy. 
+ayo (nama mayo) v. g. nama- 
+âtch musiwâk tchi miyoska- 
+
+
+
+mik, ce n'est pas de sitôt qu'il sera 
+
+printemps. 
++ MUSTGHI, (ad. et rac.) ou, mu- 
+
+tchi, à nu, à découvert, sans mé- 
+lange, au jour, simplement. 
+« MUSTAWÂN, c'est sans mélange • 
+« MUSTASKUSiWEW, ok, (v. n.) 
+
+il fume sans mélange, il fume le 
+
+tabac pur. 
+« MUSTAhwew, (v. a.) ham, hu- 
+
+wew, hikew, il lui touche à nu, 
+
+il le saisit à nu. 
+« MUSTInew, (v. a.) nam, niwew, 
+
+nikew, il le saisit avec la main 
+
+nue. 
+« MUSTAhyew, ( v. a.) staw, yi- 
+
+wew, tchikew, il le fait connaî- 
+tre^ il le met à nu. 
+« MUSTÂBUIY, a, (n. f.) liquide 
+
+pur, sans mélange, de V alcool. 
+« MUSTÂGAMIW, a, (a. in.) idem. 
+« MUSTÂWEYImew, (v. a.) tam, 
+
+miwew, tchikew, il le désire, il 
+
+soupire après lui. 
+« MUSTAWInawew, (v. a.) nam, 
+
+nâkew, nâtchikew, il le désire 
+
+en le voyant. 
+« MUSTAWEYITTAMÂWE W r 
+
+etc., (v. a.) il lui désire. 
+« MUSTAWINAMÂWEW, etc. il 
+
+lui envie. 
+« MUSTUTTEW, ok, (v. n. ) il mar- 
+che à pied, il va à pied. 
+« MUTCHIK, (ad.) à terre, à terre 
+
+nue. 
+« MUSTASKAMIK, (ad. ) idem. 
+« MUSTASKAMIKISIN, wok, (a. 
+
+a. ) il est étendu sur la terre nue. 
+« MUTGHITON, (ad.) de vive voix. 
+« MUTCHIMIYEW, (v. a.) il lui 

--- a/OCR/Brown/502.txt
+++ b/OCR/Brown/502.txt
@@ -1,0 +1,135 @@
+502 
+
+
+
+NIS 
+
+
+
+« NISWEYAKISIW, ok, (a. a.) il 
+est en deux façons. 
+
+« NISWEYAKIHUW, ok, (a. a.) 
+idem. 
+
+« NISWEYAKAN, wa, [a. in.) c'est 
+en deux façons. 
+
++ NISOWISIW, ok, {a. a.) il est 
+nonchalant, faible, incapable, im- 
+puissant, etc. 
+
+« NISOWISIWIN, a, (n. f) inca- 
+pacité. 
+
+« NISOWAN, _ wa, {a. in.) c'est 
+faible, sans vigueur. 
+
+« NISOWÂTISIW, ok, (a. a. ) carac- 
+tère indolent. 
+
+« NISOWATISIWIN, a, (n. f.) in- 
+dolence, incapacité morale. 
+
+« NISOWEYImew, [v. a.) ttam, 
+miwew, tchikew, il le pense in- 
+capable, il le pense sans force. 
+
+« NISOWEYIMISUW, ok, (v. r.) 
+il s'abaisse, il s'humilie. 
+
++ NISIT, (rac.) comprendre, recon- 
+naître. 
+
+« NISSITAW, {ad.) Ce mot ne pa- 
+raît s'employer qu'avec la néga- 
+tion, v. g. naraa nissitaw, ça ne 
+convient pas,nam3imssit3iW kitchi 
+pâppiyan anotch, ça ne convient 
+pas que tu ries à présent. 
+
+« NISSITAWEYImew, (va.) ttam, 
+miwew, tchikew, il le comprend, 
+il le reconnaît dans sa pensée. 
+
+« NTSSITÂWInawew, (v. a.) nâ- 
+kew, nam, nâtchikew, il le re- 
+connaît en le regardant. 
+
+« NISITOttawew, [v. a.) ttam, 
+ttâkew, ttâtchikew, il le com- 
+prend, il entend ce qu'il dit. 
+
+« NISSITOTTAM, wok, (v. n.) il 
+comprend. 
+
+
+
+« NISSITOTTAMOWIN, a, (n. 
+
+intelligence. 
+« NISSITOMATJIHUW, ok, (v. 
+
+il commît ce qu'il ressent. 
+« NISSITOMEW, etc., (v. a.) il 1 
+
+fait comprendre, ou mieux, il l 
+
+fait souvenir. Voy. M^skawâs 
+
+mew, kiskisomew. 
+« NTSSITOSIW, ok, (a. a.) il a I 
+
+dorât délicat. Cependant ce m 
+
+est reçu, pour dire : il est gras, 
+
+est en bon état, il est assez gras 
+« NISSITWAW, a, c'est assez grt 
+
+c'est d'un assez -bon goût. 
+« NISSITOSPItew, (v. a.) tam, 
+
+wew, tchikew, il en reconnaît 
+
+goût. 
+« NISSITOSPWEW, etc., (v. i 
+
+idem. 
+« NISSITOTTÂKUSIW, ok, (a. t 
+
+il est compréhensible, intelligible 
+« NISSTTOTTÂKWAN, wa, (a. 1 
+
+idem. 
+« NISSITÂWÂKÂT1SIW, ok, J 
+
+a.) avec la négation seulement, 
+
+g. nama nissitâwâkâtisiw, il t 
+
+idiot, incompréhensible. 
+« NISSITÂWEYITTÂKUSIW, o] 
+
+(a. a.) il est feconnaissable. 
+« NI8SITÂWEYITTÂKWAN, w, 
+
+(a. in.) idem. 
+«NISSITOTTAMOhew, (v. a 
+
+TTAW, HIWEW, TCHIKEW, U II 
+
+fait -comprendre. 
+
++ NISTA, (ad. ) aussi, de même, pi 
+reillement, v. g. nista matchip 
+mâtisiw, lui aussi vit mal, nistc 
+ki ka nipin, toi aussi tu mow 
+ras. 
+
++ NISTA, (pron. ) moi aussi, kistc 
+toi aussi, wista, lui aussi. 
+
+
+
+NIS 

--- a/OCR/Brown/514.txt
+++ b/OCR/Brown/514.txt
@@ -1,0 +1,158 @@
+514 
+
+
+
+OSI 
+
+
+
+« OSÂWÂBÏSKISIW, ok, (a. a.) il 
+est jaune, du fer. 
+
+« OSÂWÂBISKAW, wa, (a. in.) 
+idem. 
+
+« OSÂWABÂN, ak, (n. f.) bile. 
+
+« OSÂWÂBEW, ok, [a. a.) il a de 
+
+labile, il est bilieux. 
+« OSÂWÂBUIY, a, (n. f.) liquide 
+jaune. 
+
+« OSÂWEGIN, wa, [n. f) étoffe jau- 
+ne, indienne jaune. 
+
+« OSÂWEKAN, wa, (a. in.) il est 
+jaune, en parlant d'étoffe, d'indi- 
+enne. 
+
+« OSAWISKUSIW, ok, (a. a.) il 
+luit, il brille par le jaune. 
+
+« OSÂWJSKWAN, wa, (a. in.) id. 
+
+« OSÂWISKWAW, {v. im.) soufre 
+en pierre. 
+
+« OSÂWAKKESIW, ok, (n. f.) re- 
+nard jaune. 
+
+« OSAWAKKWANEW, (v. im.) 
+flamme jaune. 
+
+« OSÂWASK, wok, [n.f.) ours jau- 
+ne. 
+
+xOSEYAW, a, {a. in.) c'est en 
+coteau, c'est une hauteur. 
+
+« OSESIW, ok, (a. a.) il est en for- 
+me de dos, de coteau. 
+
+« OSESKAMIKAW,(t\tro.) terrain 
+élevé. 
+
+«OSETCHAW, (v. im.) terre en 
+forme de coteau. 
+
+« OSETINAW, [v. im, ) colline, cô 
+teau. 
+
+« OSEYÂBISKAW, (v. im.) rocher 
+en forme de coteau. 
+
+« OSETTUY, a, {n. r.) la queue de 
+la raquette. 
+
+« OSI, pi. osa,(n.r.) canot ; mistikosi, 
+canot de bois; waskwày osi, ca- 
+
+
+
+qui nage i 
+rac. ) faire, c 
+
+
+
+not d'écorce de bouleau; n 
+
+mon canot ; ot'os, son canot , 
+
+sottakaw, grand canot. 
+xOSAhwew, [u. a.) HAM, huv 
+
+hikew, il le lève, il le fait fui 
+« OSISkawew, (v. a.) idem. 
+« OSAHIKEW, ok, (v. ind.) \ 
+
+fuir, v. g., quelqu'un qui va 
+
+chasse, et qui, en faisant du b 
+
+fait fuir l'animal qu'il appn 
+
+qu'il guette. 
+OSIPIW, ok, {v. n.) il remue l 
+
+v. g., un castoi 
+
+deux eaux. 
++ OSI, et, OJI, 
+
+manufacturer. 
+« OJIhew, (v. a.) TTAW, HIV 
+
+TGHiKEw, il le fait, il le crée. 
+« OJIHUMAGAN, {v. r. in.) ç 
+
+forme. 
+« OSITGHIKEW, ok, {v. ind 
+
+crée, il opère. 
+« OSITCHIKEWIN, a, (n. f.) i 
+
+tion, opération. 
+« OS1TGHIGAN, ak, a, [n. f.) 
+
+ture. 
+« OT OJIHIWEW, ok, {n.f) le 
+
+ateur. 
+« OSITTOWEW, (v. a.) il le lui 
+« OSITTAMAwew, {v. a.) il le 
+
+à sa place. 
+« 0SJKKIP1MIW, ok, {v. n.) 
+
+un clou, enflure, un furoncle. 
++ OSIKAMISK, wok, (n. /?) cai 
+
+éparè et séché. De la racine c 
+
+qui se rétrécit, v. g., quelque 
+
+se, qui, en séchant, devient m 
+
+are. 
+
+
+
+OSIKÂKATOSUW, ok 
+
+
+
+(a. a 
+
+
+
+se rétrécit en séchant. 
+OSIKlKATOTEW, a, (a. in.) 
+
+
+
+"~r 
+
+
+
+NIP 

--- a/OCR/Brown/576.txt
+++ b/OCR/Brown/576.txt
@@ -1,0 +1,126 @@
+576 
+
+
+
+POS 
+
+
+
+« PONI-AYAMIHAW, ok, (v. n.) il 
+finit de prier. 
+
+« POMI-AYAW, ok, (v. n.) il cesse 
+
+d'être, d'exister. 
+« PONIYÂWESIW, ok, (a. a.) il 
+
+cesse d'être fâché. 
+
+« PONINOKUSIW, ok, (a. a.) il 
+disparaît. 
+
+<i PONINOKWAN, wa, (a. in.) id. 
+« PONINONIW, ok, {v. n ) il cesse 
+de téter. 
+
+« PONINOYEW, etc., («. a.) elle le 
+
+sévre. 
+« PONI-PIMÂTISIW, ok, [a. a.) il 
+
+cesse de vivre. 
+
+« PONTPAYIW, ok, a, (a. a. et in.) 
+ça cesse, ça finit d'agir. 
+
+«PONIWITJEWEW, etc., (v. a.) 
+il se sépare de lui. 
+
+« PONIYOTIN, [v. im ) lèvent s'ap- 
+paise. 
+
+« POYUW, ok. (v. n.) il cesse d'a- 
+gir, il se désiste. 
+
+«POYUW1N, a, {n. f) cessation, 
+désistement. 
+
+x PONEW, {V. a. ) NAM NIWEW NI- 
+
+kew, il alimente le feu avec lui, 
+il s'en sert comme de bois v. g., 
+matchi-manito ponew owebi- 
+nikowisiwa, le démon alimente 
+le feu avec les damnés, [ou, les y 
+jettent). 
+
+« PONAM, wok, (v. n.) il alimente 
+le feu, il met du bois dans le feu. 
+
+a PONIKÂTEW, a, (a. in.) le feu 
+est préparé, fait. 
+
+POUS, ak, chat. 
+
+POSÂKKWÂMIW, ok, (a. a) il 
+dort profondément. 
+
+xPOSIW, ok, {v. n.) il embarguel 
+
+
+
+dans un canot, barge, navire, et il 
+monte, dans une voilure sur terre. 
+«POSIWIN, a, [n. f.) embarque- 
+ment. 
+
+« POSIhew, [v. a.) ttaw, hiwew, 
+tchikew, il l'embarque, il le fait 
+embarquer, il le fait monter en 
+voiture. 
+
+« POSIPAYIW, ok, a, (a. a. et in.) 
+ça entre dedans, ça embarque, v 
+g. posipayiw nipïy, l'eau embar- 
+que, entre dedans. 
+
+«POSITTÂSUW, ok, («.«.') il 
+charge, v. g. un navire. ' 
+
+« POSITTÂSUWIN, a, (n.f.) char- 
+ge d'un canot, ou, action de le 
+charger. 
+
+« POSIWEBInew, («. a.) nam, ni- 
+wew, nikew, il l'embarque en le 
+jetant dedans. 
+
+« POSIWEPAhwew, («. a.) ham, 
+huwew, hikew, il V embarque en 
+lui donnant une secousse. 
+
+« POSISKISIW, ok, (a. a.) il est 
+concave. 
+
+« POSISKAW, a, {a. in.) idem. 
+
+« POSISKIHEW, etc, («. a.) il le- 
+fait concave. 
+
+POSKU, {préfixe,) dans le même 
+temps, dans le même espace, v. g. 
+posku kijik, le même jour, posku 
+pipon, dans le cours du même hi- 
+ver, posku tibisk, dans Vinterval 
+de la nuit, posku wâskâhigan, 
+dans l'étendue de la maison, pos 
+ku sâkahigan, dans l'espace du 
+lac, posku kijik takusin, il ar- 
+rive le même jour (qu'il est parti). 
+
+x POSK, (rac. ) crever, éclater, faire 
+explosion. 
+
+
+
+POS

--- a/OCR/Brown/581.txt
+++ b/OCR/Brown/581.txt
@@ -1,0 +1,146 @@
+581 
+
+
+
+SAK 
+
+
+
+« SÂKIHAGAN, ak, {n. f.) amant, 
+favori. 
+
+« SÂHIhew, (v. a.) TTAW, HIWEW, 
+tchikew, il r aime j il y est atta- 
+ché, il ne veut pas s'en détacher. 
+
+«SÂKIHIWEW, ok, (v. ind) il 
+aime. 
+
+« SÂKIH1WEWIN, a, (n.f.) amour 
+pour, affection pour, etc. 
+
+« SÂKIHIWEWINIWIW, ok a, 
+(a. a. et in.) il est amour, c'est 
+amour. 
+
+« SÂKIHIWEWISIW, ok, [a. a.) 
+
+il est amoureux. 
+
+« SÂKIHITUWOK, [v. m.) ils s'en- 
+tr'aiment. 
+
+« SiKIHITUWIN, a, (h. f.) amour 
+mutuel. 
+
+« SiKIHIKUSIW, ok, {a. a.) il est 
+aimable. 
+
+«SÂKIHIKWAN, wa, (a. in.) idem. 
+
+«SÂKIHIKUSIWIN, a, (n. f.) 
+amabilité., 
+
+« SÂK1HIKOWIN, a, [n. f.) action 
+d'être aimé. 
+
+« SÂKIHIKOWISIW, il est aimé 
+par Dieu. 
+
+« SÂKIHIKOWISIWIN, a, (n. f.) 
+action d'être aimé par Dieu. 
+
+« SiKIHISUW, ok, {v. r.)il s'aime. 
+
+a SÂKIHISUWIN, a, [n. f.) amour- 
+propre. 
+
+« SÂKISIW, ok, (a. a. ) il est avare, 
+il aime son bien. N. B. Ce mot et 
+le suivant, se disent toujours avec 
+le redoublement , ainsi, sâsâkisiw. 
+
+« SÂKISIWIN, a, (n. f.) (sâsâkisi- 
+win, a,) avarice, amour de son 
+bien. 
+
+SÂKITTIW, ok, [a. a.) (sâsâkittiw) 
+
+
+
+il a les pieds nus. Voy. la racine 
+
+plus loin. 
+x SAKK, (rac. Rattacher à, agraffer, 
+
+accrocher, embarrasser dans, etc. 
+« SAKKAPPItew, (v. a.) tam, si- 
+
+wew, tchikew, il l'attache, v. g. 
+
+à un poteau. 
+« SAKKAPPISUW, ok, '(a. a.) il 
+
+est attaché à, etc. 
+« SAKKAPPITEW, a, (a. in.) idem. 
+« SAKKÂBÂtew, {v. a.) tam, si- 
+
+wew, tchikew, il l'y attache, il le 
+
+coud à. 
+« SAKKIPÂTEW, etc., (v. a.) idem, 
+
+il le boutonne. 
+
+< SAKKIPÂSUW, ok, {v.n.) il se 
+
+boutonne, il agraffe ses ho bits. 
+
+< SAKKIPÂSUN, a, (n. f.) bouton, 
+
+agraffe. Voy. Aniskamân. 
+«SAKKÂSKWAhwew, {v. a.) 
+ham, huwew, hikew, il I' agraffe, 
+il le boutonne, il l'attache, il l'en- 
+lace. 
+
+< SAKKÂSKUHEW, etc.., [v. a.) 
+idem, il V agraffe, etc. 
+
+« SAKKÂSKWAHUN, a, (n, f.) 
+
+bouton, agraffe. 
+« SAKKAmew, (v. a.) ttam, miwew, 
+ç tchikew, il le tient serré^ entre 
+
+ses dents. 
+« SAKKAhwew, {v. a.) ham, hu- 
+wew, hikew, il le cloue. 
+« SAKKAHIGAN, a, [n. f.) clou, 
+
+cheville. 
+« SAKKAHIGANIS, a, (n. f) petit 
+
+clou, pointe. 
+.< SAKKAMOW, ok, a, {a. a. et in.) 
+
+il y est cloué, attaché. 
+:< SAKKAMOhew, (v. a. ) ttaw, hi- 
+
+wew, tchikew, il l'y attache, en 
+
+le clouant. 
+
+
+
+
+
+I, I 1 
+
+
+
+.til 
+
+
+
+SAK 

--- a/OCR/Brown/616.txt
+++ b/OCR/Brown/616.txt
@@ -1,0 +1,128 @@
+616 
+
+
+
+TET 
+
+
+
+« TEPISIWIN, a, [n. f.) contente- 
+ment, satisfaction. 
+« TEPIYÂWESIWIN, a, (n. f.) id. 
+« TEPIKKWÂMIW, ok, [a. a.) il a 
+
+assez dormi. 
+« TEPImew, etc., (v. a ) il lui parle 
+suffisamment, ou, il le contente par 
+ses paroles. 
+« TEPIMÂKUSIW,ok, (a.a.) il rem 
+
+plit la place de son odeur. 
+
+.« TEPIMÂKWAN, wa, {a, in.) id. 
+
+« TEPInew, [v. a.) NAM, NIWEW, NI- 
+
+kew, il peut y atteindre arec sa 
+
+main. 
+
+« TEPINAMÂwew, etc., [v. a.) il 
+
+lui en fournit assez. 
+« TEPISkawew, {v. a.) kam, kâkew 
+kâtchikew, il lui va bien, v. g., 
+ni tipiskawâwok ni wikwepâ- 
+nak, mes pantalons me vont bien, 
+tepiskam omaskisina, ses souliers 
+lui font bien. 
+« TEPISUW, ok, [a. a.) il a assez 
+
+fumé. 
+« TEPIPEW, ok, {a.a.) il a assez 
+
+bu. 
+« TEPIPUW, ok, {a, a.) il a assez 
+
+mangé. 
+« TEPISKITEHEW, ok, [à. a.) il a 
+
+le cœur fatigué, accablé. 
+« TEPIPAYIHIKUW, ok, [v.pass.) 
+
+il en a assez, ça lui suffit. 
+« TEPITTÂKUSIW, ok, (a. cl) il 
+
+est bien entendu. 
+« TEPLTTÂKWAN, wa, [a. in.) ici. 
+« TEPIttawew, (v. a.) ttam, ttâ- 
+tchikew, il l'entend bien, il saisit 
+assez sa voix, il l'entend suffisam- 
+ment. 
+« TEPISTN, wok, {a. a.) il est con- 
+venable, il s'ajuste, il est juste. 
+
+
+
+(TEPITTIN, wa, [a. in.) ici. 
+
+:< TEPIsimew, (v. a.) ttitaw, simi- 
+wew, tchikew, il Vajuste, il le 
+fais joindre. 
+
+xTEPIYÂK, {ad.) {saltern,) au 
+moins, du moins, v. g., tepiyâk 
+ekawiya ekusi to ta, au moins ne 
+fais pas cela, 
+
+xTEPWEW, ok, {v. a.) il crie, il 
+appelle. 
+
+« TEPWE WIN, a, {n. f. ) cri. 
+
+« TEPWÂtew, {v. a.) TAM, SIWEW, 
+tchikew, il l'appelle, il lui crie, 
+aussi : il est publié dans l'église, etc. 
+
+« TEPWESKITTEW, ok, {v. n.) les 
+oreilles lui tintent. 
+
+x TET, (rac.) être dessus, etc. 
+
+« TETTAhyew, {v. a.) staw, yiwew, 
+tchikew, il le met dessus. 
+
+« TETTAPIW, qk, (a. a.) il est as- 
+sis dessus, c'est-à-dire, il est à 
+cheval, v. g., quelqu'un qui est à 
+cheval. » 
+
+TETTÂPÂTEW, ok, il est à cheval 
+sur lui. 
+
+« TETTAPIWIN, ak, (n. f.) ce sur 
+quoi on va à cheval, le cheval. 
+
+((TETTAPIWIN, a, [n. f.) siège, 
+chaise, banc. 
+
+« TETTAPIhew, etc., [v. a.) il l'as- 
+sied dessus. 
+
+« TETGHIKWASKUTTIW, ok,(v. 
+n.) il saute dessus. 
+
+« TETGHIPAYIW, ok, a. {a. a. et 
+in.) il monte sur, etc. 
+
+« TETGHIPAYIHUW, ok, (v. r.) 
+. il s'élance dessus, il monte dessus. 
+
+a TETGHIPAYIHUStawew, etc., 
+(v. a.) il monte sur quelqu'un, 
+etc. N. B. Ordinairement c'est em- 
+ployé dans le sens impudique. 
+
+
+
+TET 

--- a/OCR/Brown/636.txt
+++ b/OCR/Brown/636.txt
@@ -1,0 +1,158 @@
+G3G 
+
+
+
+WÂS 
+
+
+
+WAPISKEYÂPEGAN, wa, (a. 
+in.) idem, (une corde.) 
+
+WÂPISKAYOWINISSEW, ok, 
+
+(a. a.) il a des habits blancs. 
+WÂPISKIKÂTEW, ok, (a. a.) il 
+a les jambes blanches. 
+
+
+
+WAPISKIhew, 
+
+
+
+(V. a.) TTAW, HI 
+
+
+
+wew, tchikew, il le blanchit, il le 
+
+rend blanc. 
+« WÂPISKIHUW, ok, (v. r.) il est 
+
+habillé en blanc. 
+« WÂPISKIPEhwew, (v. a.) ham, 
+
+huwew, hikew, il le peinture en 
+
+blanc. 
+
+« WÂPISKWAKUP, a, (n. f,) cou- 
+verture blanche. 
+
+« WÂPEKINIGAN, a, (n.f.) c'est le 
+tabac que s'envoient les sauvages. 
+gui est enveloppé dans une peau 
+blanche, ou, un morceau de coton. 
+Cet objet a ccompagnetoujours les 
+ambassades et il est fumé en con- 
+seil ou rejeté, selon qu'on accepte 
+la paix, ou quon rejette ce qui est 
+proposé. 
+
+« WAPISKOWEW, ok, (a. a.) il est 
+cendré, blafard. 
+
+« WÂPISKOWES, ak, (n. f.) cen- 
+dré, il a le poil blafard. 
+
+« WÂPISKASÀKAY, a, (n. f.) ca- 
+pot blanc, habit blanc 
+
+«WÂPISTÂN, ak, (n. f.) martre. 
+N. D. On se sert presque toujours 
+du diminutif, wâpislânis, ak. 
+
+
+
+WAP1STXKWAN, 
+
+
+
+a, (n. f.)' tête 
+
+
+
+blanche. 
+« WÂPISTIKWÂNEW, ok, (a. a.) 
+
+il a la tête blanche. 
+•« WÂPITEW, ok, (a. a.) fané, pâle, 
+
+brun, de couleur sale. 
+
+
+
+« WÂPITEYAW, ok, a, (a.a.et in.) 
+idem. 
+
+« WAPITTAKAHIGAN, a, (n. f) 
+craie, ou, wâpigao, a. 
+
+« WlPUS, wok, (n.f.) lapin, lièvre, 
+mistâpus, gros lièvre de prairie. 
+
+« WÂPUSWEYÂN, ak, (n.f) peau 
+de lièvre avec le poil. 
+
+«WÂPOWEYÂN, a, (n, f.) cou- 
+verture blanche. 
+
+«WÂPÂWAKKAW, (v. im.)boue 
+blanche, sable blanc. 
+
+« WAPATÂWÛKKAW, (v. im.) 
+
+idem. 
+x WÂS, (rac.) en forme de baie, une 
+
+anse dans un lac. 
+« WÂSAKÂM. (adv. ) autour de Veau 
+
+du lac 
+« WÂSAKÂMEW, ok, (v. n.) il va 
+
+autour du lac, de Veau. 
+« WÂSAKÂMEWIN, a, (n. f.) action 
+
+trailer autour de Veau. 
+
+WÂSAKÂMUTTEW, ok, (v.n.) il 
+
+marche autour de Veau. 
+« "WÂs wew, (va) SAM, SUWEW, SI- 
+
+kew. il le coupe à Vent our. 
+«WASÂPEW, ok, (v. n.) il taille 
+
+autour, v. g., tailler des cordes , 
+
+autour d'une peau. 
+« WÂSÂHIGAMAW, (v. im.) il y a 
+
+une baie (dans un lac.) 
+xWÂSK, (même racine) autour, à 
+
+Ventour, en cercle. 
+« WÂSKÂPAYIW, ok, a, (a. a, et 
+
+in.) il tourne en cercle, en rond. 
+« WÂSKÂPAYIHUW, ok, (v. r.) il 
+
+tourne en rond, en "faisant des 
+
+mouvements. 
+« WÂSKÂPAWIWOK, (a. a.] ils 
+
+sont debout en rond. 
+
+
+
+V 
+
+
+
+
+
+
+WAS 

--- a/OCR/Brown/660.txt
+++ b/OCR/Brown/660.txt
@@ -1,0 +1,126 @@
+660 
+
+
+
+YAW 
+
+
+
+v. g., yâkki ot ayâttay peyak ayi- 
+siyiniw, jadis il y avait un hom- 
+me, ekusi otiji liikâsuttay yâkki, 
+(vide lur sic nominatum esse.) 
+
++ YÂKWÂMEYImew, (v.a.).TTAM, 
+miwew, tchikew, il est attentif 
+auprès de lui, prévenant, il s'en 
+occupe beaucoup, il lui fait la cour, 
+
+' il est persévérant auprès de lui. 
+N. B. Pour cette rac. et ses déri 
+vés, c'est la même chose, que ayâk- 
+wâmeyimew. 
+
+« YÂKWÂMEYIMOW, ok, (v. n.) 
+il est persévérant, il donne ses 
+soins de plus en plus. 
+
+« YÂKWÂMEYIMOWIN, a, [n, f.) 
+persévérance, attention. 
+
+« YÂKWÂMImew, etc., (v. a.) il 
+V encourage, il est sans cesse à lui 
+parler de cela. 
+
+« YÂKWÂMISIW, ok, (a. a.) il est 
+sur ses gardes, précautionné, cir- 
+conspect, (caulus, providus), per- 
+sévérant. 
+
+« YÂKWÂMÏSIWIN, a, (n. f-) per- 
+sévérance, prévoyance, précaution.. 
+
+x YÂS, (rac.) descendre, s'abaisser. 
+
+« YÂSAPEKfNEw, (v a.) nam, ni- 
+wew, nikew, il le descend, il Va- 
+baisse au moyen d'une corde, v.g.,. 
+abaisser un pavillon, une voile, 
+etc. 
+
+« YÂSInew, (v. a) il le descend avec 
+la main. 
+
+« YÂSIPAYIHUW,ok, (v.r.) il s'a 
+baisse, il se glisse en bas. 
+
+« YÂSIPAYIW, ok, a, (a. a. et in.) 
+il descend, il va en bas. 
+
+« YASIPAYIhew, (v. a.) ttaw, hi- 
+v 
+fait s'abaisser. 
+
+
+
+« YASITINEW, etc. , [v. a. ) il l'en- 
+voie au bas, il le descend à terre. 
+
+« YÂSITISAHAMÂWEW, etc., [v. 
+a.) il le lui descend à terre. 
+
+«YÂSISTAWEW, etc., {v. a.) il 
+descend vers lui, v. g., Jésus - 
+Christ ki ki pe-yâsi-tâkonow,. 
+Jésus-Christ a descendu vers nous. 
+
+« YÂSETOTAWE.W, etc., (v. a.) 
+idem, 
+
+« YÂSIW, ok, (v. n ) il descend, il 
+s'abaisse vers la terre. 
+
+« YÂSIWIN, a, (n. f. ) descente, ac- 
+tion de descendre sur la terre. 
+
+« YÂS ASKEW, ok, (v. n. ) il des- 
+cend sur la terre. 
+x YÂTTOKAMIK, (ad.) Voy.Ay&t- 
+tokamik, dans une autre maison, 
+dans une 'autre loge.. 
+
+x YÂW, (rac.) indique qu'il n'y a 
+pas assez, insuffisant, être prêt 
+de manquer avant d'atteindre, 
+au dessous. 
+
+«YÂWÂPAmew, (v. a.) TTAM, 
+kkew, etc., il ne peut le voir par- 
+ce qu'il est trop loin, sa vue n'est 
+pas assez longue pour le voir. 
+
+a YÂWInawew, (v. a ) nam, nX- 
+kew, nâtchikew, idem. N. B. 
+Toute cette racine renferme l'idée 
+de nottow. K Voy. plus haut. 
+
+« YÂWINÂKUSIW, ok, (a. a.) il 
+est hors de vue, il est impercep- 
+tible. 
+
+« YÂWINÂKWAN, wa, (a. in.) id. 
+
+« YÂWInew, (v. a.) nam, niwew, 
+nikew, il ne peut le saisir avec la 
+main,il ne peut l'atteindre. 
+
+« YÂWÂSIttawevv, {v. a.) ttam, 
+ttâkew, ttâtchikew, il ne peut 
+saisir sa voix, il ne peut le com- 
+
+
+
+
+
+
+YAW 

--- a/OCR/LOC/289.txt
+++ b/OCR/LOC/289.txt
@@ -1,0 +1,132 @@
+289 
+
+
+
+AKW 
+
+
+
+AKWEKISFW ok, (a. a,: 
+
+
+
+est 
+
+
+
+durci, il est amoindri par la sé- 
+cheresse. 
+
+«ÂKWEKAN, wa, (a. in.) idem. 
+
+« AKOTEWISIW, ok, {a. a.) il est 
+cruel, rude, dur. 
+
+«ÂKOTEWAN, wa, (a. in.) idem. 
+
+AKWÂWÂN, a, (n. r.) grille, écha- 
+faudage pour faire sécher la vian- 
+de. 
+
+x ÂKWÂ (rac.) profondément, en- 
+foncé bien avant, loin. 
+
+«ÂKWÂTCH, (ad.) profondément, 
+loin, en avant ; v. g., âkwâtchis- 
+payiw, ça s'enfonce bin avant ; 
+on dirait aussi: sâsay osâm âk- 
+wâtchispayiw, V affaire, est déjà 
+trop avancé ; âkwâtch ni pimiti- 
+sahwaw, je le poursuis loin; âk- 
+wâtch payipaham, il le perce bien 
+avant ; âkwâkijikaw, jour avan- 
+cé; âkwâtibiskaw, nuit avancé; 
+il signifie aussi: avec peine, com- 
+me akâwâtch ; v. g.,- âkwâtch 
+pimâ'isiw, il vit à peine, ou, sa 
+vie vient de loin, par ex. quelqu'un 
+qui s'échappe avec peine d'un dan- 
+ger ; sâsay âkwâtch kiskeyittam, 
+il sait déjà beaucoup; âkwâtch 
+kinakatchihitin, je suis beaucoup 
+accoutumé à ta façon. 
+
+«ÂKWÂSIN, wok, (a. a.) il est 
+beaucoup enfoncé, il est beaucoup 
+arrivé loin. 
+
+« AKWÂTTIN, wa, [a. in.) idem. 
+
+« ÂKWÂSImew, (v. a.) c'est avee 
+peine qu'il le fait vivre. 
+
+« ÂKWÂSK, (ad.) au devant, par 
+devant. 
+
+« ÂKWÂSkawew, (v. a.) kam, kâ- 
+kew, tchikew. il lui coupe le che- 
+
+
+
+min pour passer devant lui; v. g., 
+kakwe âkwâskaw mayowes wâ- 
+yo e ayât, tâche de lui couper 
+chemin avant qu'il soit loin. 
+
+«ÂKWÂSK AM, (ad.) davantage, 
+plus; v. g., âkwâskam musta- 
+winam, il en désire davantage. 
+
+« ÂKWASKISPAYIW, ok, a, (a. 
+v. an. et in.) il, ou, ça agit comme 
+voulant couper chemin, voulant 
+passer par devant. 
+
+«. ÂKWÂSK Inew, (v. a.) nam, ni- 
+wew, nikew, il le lient dans ses 
+bras, il le tient à brassées; v. g., 
+âbittasiyaw âkwaskinaw, il est- 
+tenu par le milieu du corps. 
+
+« ÂKWASKITInew, (v. a.) nam, ni- 
+wew, nikew, idem. 
+
+« ÂKWASKISkawew, (v. a.) kam, 
+
+KÂKEW, TCHIKEW, U llli COUpe le 
+
+chemin en passant devant lui, en 
+
+faisant un détour. 
+x AKWAN, (rac.) couvrir, abriter, 
+
+mettre un couvercle. 
+« AKWANÂhwew, (v, a.) ham, hu- 
+
+wew, hikew, il le couvre, recou- 
+vre. 
+« AKWANInew, (v. a.) nam, ni- 
+
+wew, nikew, idem. 
+« AKWANÂsimew, (v. a.) ttitaw, 
+
+simiwew, sitchikew, idem. 
+« AKWANÂHUW, ok, (v. r.) il se 
+
+couvre. 
+« AKWANÂHUWIN, a, (n, f.) cou- 
+verture, chale, couverte. 
+« AKWANÂhyew, (v. a.) staw, 
+
+yiwew, tchikew, il le place en le 
+
+couvrant. 
+« AKWANÂBOhwew, (v. a.) ham, 
+
+huwew, hikew, il le couvre, v. g., 
+
+un vase. 
+
+
+
+AKW 

--- a/OCR/LOC/290.txt
+++ b/OCR/LOC/290.txt
@@ -1,0 +1,131 @@
+290 
+
+
+
+AKW 
+
+
+
+« AKWANiBOHIGAN, a, (n. f.) 
+
+couvercle d'un vase, a" une chau 
+
+diere, etc. 
+«AK WAN ABO WE SIN, wok, 
+
+(a. a.) il est couvert. 
+« AKWANÂBOWETTIN, wa, (a. 
+
+in. ) idem, 
+« 4KWANÂKKWEW, ok, (v. n.) 
+
+il se couvre le visage. 
+« AKWANÂKKWEhwew, ham, 
+
+huwew, hikew, ou, akokkweh- 
+
+wew, ou, akokkwepitew, il lui 
+
+couvre le visage. 
+«AKWANÂKKWEPItew, (v. a.) 
+
+TAM, SIWEW, TGHIKEW,, U lui 
+
+bande le visage. 
+«AKWANAKKWEPISUWIN, a, 
+
+(n. f.) couverture du visage. 
+
+«AKAWÂYIK, (ad.) à l'abri, à 
+couvert, v. g. akawâyik pimut- 
+tew, il marche à Vabri, akawâtik, 
+à Vabri du bois, de la forêt, aka- 
+wâmatin, à Vabri de la montagne, 
+akawâtin, à Vabri de la colline. 
+
+« AKAWÂBIKKWEW, ok, (a. v.) 
+il a les yeux couverts. 
+
+« AKAWÂBIKKWEhwew, (v. a.) 
+
+HAM, HUWEW, HIKEW, U lui COUVre 
+
+la vue. 
+« AKAWÂKKWEPItew, (*. a.) 
+
+tam, siwew, tchikew, il lui bande 
+
+les yeux. 
+« AKAWÂWESIMOW, ok, (a. v.) 
+
+il se meta Vabri de quelque chose. 
+« AK AWÂWEsimew, [v. a. ) tti- 
+
+TAW, MIWEW, TCHIKEW, U le place 
+
+à Vabri. 
+«AKOSIMOW, ok, (a, v.) comme, 
+
+akawâwesimow. 
+« AKOSkawew, [v. a.) kam.kâkew, 
+
+tchikew, il le couvre complète 
+
+
+
+ment, v. g. mustuswok misiwe 
+akoskamok askïy, les buffles 
+couvrent la terre. 
+
+x AKWEB, (rac.) embarrassant, 
+qui prend beaucoup de place, 
+beaucoup, en grande quantité. 
+
+« AKWEBÉS,(ad.)quandona beau- 
+coup de choses, jusqu'à en être 
+embarrassé, v. g. akwébés n't'a- 
+yâwâwok kinusewok, fai des 
+poissons en abondance. 
+
+a AKWEBISIW, ok, [a. a.) il est 
+embarrassant, et,il est embarrassé, 
+il a beaucoup de choses qui V em- 
+barrassent, v. g. awiyak weyo- 
+sitji mistahi akwebisiw mâna, 
+celui qui est riche a beaucoup de 
+choses a son usage. 
+
+«AKWEBAN, wa, [a. in.) c'est 
+embarrassant. 
+
+« AKWEBEYImew, [v, a.) ttam, 
+miwew, tchikew' il le trouve em- 
+barrassant. 
+
+« AKWEPAPIW, ok, [a. v.) il est 
+embarrassant, v. g. quelqu'un qui 
+occupe trop de place. 
+
+« AKWEPASTEW, a, [a. v. in.) 
+c'est embarrassant par le volume, 
+etc. 
+
+« AKWEPInew, [v. a.) nam, ni- 
+wew, nikew, il ne sait trop com- 
+ment le placer à cause de l'em- 
+barras. 
+
+x AKW AN, (rac.) la même que celle 
+ci-dessus, à couvert, etc. 
+
+« AKWANOKIJOWEW, ok, (v.n.) 
+il parle à mots couverts, il parle 
+en paraboles. 
+
+« AKWANOKIJ vVÂtew, (v. a.) 
+tam, siwew, tchikew, il lui parle 
+à mots couverts, en paraboles. 
+
+
+
+AKW 

--- a/OCR/LOC/291.txt
+++ b/OCR/LOC/291.txt
@@ -1,0 +1,134 @@
+291 
+
+
+
+AMA 
+
+
+
+« AKWANOKIJOWEWIN, a, (*. 
+
+f.) parole à couvert, parabole. 
+xÂKWETTAW, (rac.) doubler, 
+
+mettre l'un sur Vautre, 
+«lKWETTÂWAHYEW,(u.a.) staw, 
+
+yiwew, tchikew, il les met l'un 
+
+sur Vautre, 
+« ÂKWETTÂWIKWÂtew, {v. a.) 
+
+TAM, SIWEW, TCHIKEW, U \leS COUCl 
+
+l'un sur Vautre, il le double. 
+
+«ÂKWETTiWESKISINEW, ok, 
+{v. n.) il met double paire de sou- 
+liers, ou, ayâkwettâweskisinew, 
+{Red.) 
+
+« ÂKWETTÂWESÂKEW, ok, (v. 
+n.) il met double habit, capot. 
+
+« ÂKWETTÂWEWEYONISEW, 
+
+ok, (y. n.) il revet double habille- 
+
+ment. 
+« ÂKWETTÂWAPIW, ok, (a. r.) 
+
+v. g. mustusweyânak âkwetta- 
+
+wapiwok, les robes de buffles sont 
+
+en tas les unes sur les autres. 
+«AKWETTÂWaSTEW, a, (a. in.) 
+
+c'est doublé, c'est l'un sur Vautre. 
+x AKUST, {rac.) tremper dans Veau, 
+
+mouiller. 
+« ÂKUSTImew, (v. a.JTAW, miwew, 
+
+tghikew, il le met dans Veau. 
+« ÂKUSTABÂWAyew, {v. a.) tàw, 
+
+yiwew, tghikew, idem. 
+« AKUSTIMOW, ok, (n. a.) il est 
+
+mouillé. 
+«ÂKUSTIN, wa, {a. in.) c'est 
+
+mouillé. 
+xÂJIW, {rac.) incapable, qui ne 
+
+réussit pas. 
+« ÂJIWISIW, ok, {a. a.) Une reus- 
+
+sit pas, (synonimes) nayoyuw, 
+
+akawisiw. 
+
+
+
+« ÂJIWAN, wa, (a. in.) ça n'arrive 
+pas, ça ne réussit pas, nama aji- 
+waa, ça arrive toujours, sans 
+faute, v. g. ekayikok mâaanama 
+âjiwaii eka kitchi mispuk, c'est 
+le temps qu'il neige sans faute. 
+
+«AJIWEYImew, {v. a.) ttam, mi- 
+wew, tghikew, il le pense inca- 
+pable de faire telle chose, de réus- 
+sir, etc., nama kekway n't'âjiwe- 
+yimaw Kijemanito, je pense 
+Dieu capable de réussir en toutes 
+choses. 
+
+« ÂMAK, wok, (n. r.) aiguille pour 
+lacer les raquettes. 
+
+x AM, {rac.) faire fuir, faire peur. 
+
+« AMÂmew, {v. a.) tam, miwew, 
+tghikew, il le fait fuir, v. g. quel- 
+qu'un qui veut approcher un ani- 
+mal sauvage, et en faisant quel- 
+que bruit, il le fait fuir, il l'épou- 
+vante. 
+
+«AMÂhew, {v. a.) ttaw, hiwew, 
+tchikew, idem. 
+
+« AMAHAMAwew, {v. a.) tam, 
+
+KEW, TGHIKEW, U lui fait fuil\ U 
+
+est la cause que l'animal d'un 
+
+autre fuit. 
+« AMAWEHAMAwew, {v. a.) tam, 
+
+kew, tchikew, idem. 
+« AMÂTAMAWEW, (v. a.) idem. 
+« AMÂWEKAHIKEW, ok, {v. ind.) 
+
+il le fait fuir, eu frappant avee 
+
+une hache. 
+« AMAWEswew, {v. a) sam, siwew, 
+
+sikew, il le fait fuir en tirant du 
+
+fusil. 
+« AMATISUW, ok, {v. n.) il est aux 
+
+aguets, il craint quelque surprise, 
+
+il est sur ses gardes. 
+
+
+
+AMA 

--- a/OCR/LOC/292.txt
+++ b/OCR/LOC/292.txt
@@ -1,0 +1,117 @@
+292 
+
+
+
+AMI 
+
+
+
+« AMATISUWIN, a, (o. f.) crainte 
+d'être surpris. 
+
+« AMATISUStawew, {v. a.) tam, 
+tâkew, tchikew, il craint quel- 
+que surprise de sa part, il se 
+garde contre lui. 
+
+« AMATISUSTAMÂwew, [v. a.) 
+
+TAM, KEW, [ TCHIKEW, il est aUX 
+
+aguets sur son compte, v. g. eoko 
+iskwew amatisustamâwew oko 
+sissa, cette femme craint pour son 
+fils. Note. Toute cette racine in- 
+dique qu'on est effrayé, qu'on est 
+aux aguets parce qu'on a vu, ou 
+qu'on croit avoir vu quelque 
+chose; ce qui est bien différent 
+d'un autre mot, astâsiw, qui pa- 
+rait signifier la même chose, et 
+qui cependant est bien différent. 
+
+x AMAT, (rac.) monter une côte, 
+une élévation, hauteur. 
+
+« ÂMATGHIWEW, ok, (v. n.) il 
+monte une côte, une colline. Note. 
+La terminaison tchiwew, indique 
+une colline, montagne, v. g. nit 
+tatchiwew,î7 descend une colline. 
+
+ÂMATGHIWEYAW, (a. in.) c'est 
+en montant, c'est une hauteur. 
+
+« ÂMATCHIWETGHAW, (a. in.) 
+c'est une hauteur de terre, qui va 
+en montant. 
+
+« ÂMATGHIWEhew, [v. a.) ttaw, 
+hiwew, hikew, il le monte. 
+
+« ÂMATGHIWEPItew, {v. ût.)tam, 
+siwew, tchikew, il le monte en 
+le tirant à lui. 
+
+« ÂMATGHIWETISAhwew, (v. a.) 
+
+HAM, HUWEW, HIKEW, il le fait 
+
+monter promptement. 
+« ÂMATCI-HWEWIN, a, {n, f.) une 
+montée. 
+
+
+
+« ÂMATGHIWESKANAW, a, (n. 
+f.) chemin pour monter. 
+
+«AMATIN, terminaison qui désigne 
+une montagne, butte, colline, v. g. 
+takkutchâmatin, sur la monta- 
+gne, awapâmatin, de l'autre côté 
+de la butte, astamâmatin, de ce 
+côté de la colline; alors ces mots 
+sont des adverbes, et ne se décli- 
+nent pas. 
+
+AMATITTE, {ad.) de côté et d'au- 
+tres, comme, pikonata ite. 
+
+AMI, (ad.)' presque, kekâtch, ce mot 
+se met toujours entre le pronom 
+et le verbe, et il ne s'emploie ja- 
+mais seul comme kekâtch, v. g. 
+n't'âmi miyik, il me le donne 
+presque, il a été sur le point de 
+me le donner, wâbaniyik kita 
+âmi takusinwok, demain ils ar- 
+riveront presque [probablement.) 
+
+AMISK, wok, (n. r.) castor. 
+
+« AMISKOWIW, ok, (a. a.) il est 
+castor. 
+
+« AMISK WAN, wa, (a. in.) c'est 
+du castor. 
+
+« AMISKWEYÂN, ak, {n. f.) peau 
+de castor, avec le poil. N. La ter- 
+minaison weyân désigne une peau 
+avec s on poil, et ce nom ainsi for- 
+mé a la> qualité des noms animés; 
+v. g., mustus weyân ak, peaux- 
+de buffles avec le poil; osekamisk, 
+wok, castor éparé, dépecé; awe- 
+tis, ak, petit castor; poyawesis, 
+ak, castor d'un an ; patamisk, 
+wok, castor de deux ans ; nâbe- 
+misk, wok', le castor mâle; noje- 
+misk, wok. la femelle. 
+
+ÂMIW, ok, (v. 7i.) le poisson fraie. 
+
+
+
+AMI 

--- a/OCR/LOC/293.txt
+++ b/OCR/LOC/293.txt
@@ -1,0 +1,112 @@
+293 
+
+
+
+ANI 
+
+
+
+ÂMIWIN, a, (n. f) le temps du 
+fraieage. 
+
+ÂMOW, ok, (n. r.) abeille, grosse 
+guêpe. • 
+
+ANAKKÂTCH, (ad.) N. Il est très- 
+difficile de traduire ce mot, qui 
+veut dire à peu près: quelque chose 
+qu'on regrette, et qui, quoique de 
+peu de valeur, cependant a sa va- 
+leur dans la position oïl ça se trou- 
+ve. Des exemples feront mieux 
+comprendre. Anakkâtch ki webi- 
+naw eoko mistikus, c'est regret- 
+table que tu rejettes ce petit bois 
+(sous- entendu) quoique de peu de 
+valeur, pourtant il aurait été uti- 
+le ; anakkâtch eoko ! ça vaut 
+mieux que rien, c'est toujovrs 
+quelque chose; o miyopimâtisiyi, 
+anakkâtch ka kikkamât, c'est 
+pourtant un bon vivant, c'est re- 
+grettable qu'il le dispute ; anak- 
+kâtch ni wanittân, je regrette de 
+
+I l'avoir perdu, quoique ce n'était 
+pas grand' chose; anakkâtch ki 
+webinaw, eyiwek ki ka ki âbat- 
+jitta ; c'est regrettable que tu le 
+rejettes, tu aurais pu t'en servir; 
+anakkâtch ni wi-miyikottây, 
+c'est regrettable que la chose soit 
+arrivée ainsi, pourtant il voulait 
+me donner tela. 
+
+ANAKATGHAY ! '{ex.) admiration 
+pour quelque chose d'extraordinai- 
+re; v. g., anakatchây tâpwe mi- 
+sikitiw kit'em ! combien ton che- 
+val est gros ! 
+
+ANAKKWAY, ak, (n. r.) manche 
+d'un habit; n'otanakkwân, j'ai 
+des manches; kiskanakkwây, ak, 
+manche coupée, rognée. 
+
+
+
+« ANAKWÂKkawew, (v. a.) kam 7 
+kâkew, tchikew, il lui fait des 
+manches. 
+x ANÂSK, (rat.) étendre quelque 
+chose par terre, etc. 
+
+«ANÂSKEW, ok, (v. n.) il étend 
+quelque chose par terre. 
+
+« ANÂSKATtew, (v. a.) tam, si- 
+wew, tchikew, il lui étend quel- 
+que chose par terre, pour s'asseoir 
+ou se coucher. 
+
+« ANÂSKATTOWEW, twâkew, 
+idem. 
+
+« ANÂSKASUW, ok, (v. n.) il se 
+met un tapis sous lui, il étend 
+quelque chose par terre pour 
+servir de tapis, ou de lit. 
+
+«ANÂSKATTEW, a, (a. in.) c'est 
+tapissé, la place est préparé pour 
+s'y asseoir, ou pour s'y coucher. 
+
+«ANÂSKASUN, ak, (n. f.) tapis, 
+pièce pour mettre sous soi. 
+
+ANÂH, (pro.) celui là; v. g., anâh 
+ni'stes ka petchâstamuttet, celui- 
+là mon frère qui s avance ; eoko- 
+ni ânihi ka pakamahwât, c'est ce- 
+lui-là qu'il a frappé. 
+
+« ANIKI, (pro. pi. an.) ceux-là ; v. 
+g., eokonik aniki ka ki nipattâ- 
+ketjik, ce sont ceux là qui ont fait 
+un meurtre ; aniki eka ka wi- 
+ayamihâtjik, ceux qui ne veulent 
+pas prier. 
+
+ANDÊ, ou, ANDA, (ad.) par là, en 
+quelque part; v. g., andô ka as- 
+tek ki mokkumân, c'est en quel- 
+que part par là qu'est ton couteau. 
+
+ANI, (ad.) (après le mot) pour donner 
+plus de force à ce que l'on dit; 
+v. g., tâpwe ani, c'est bien vrai; 
+ota ani, c'est ici; ni wi-ituttân 
+
+
+
+ANI 

--- a/OCR/LOC/294.txt
+++ b/OCR/LOC/294.txt
@@ -1,0 +1,116 @@
+294 
+
+
+
+ANI 
+
+
+
+ani. je veux y aller assurément; 
+ki wittamâtinawaw ani, je vous 
+le dis donc. Ce mot sert à faire af- 
+firme? plus fortement ce que Ton 
+avance. 
+
+ANIYE, (ad.) On emploie ce mot à 
+peu près comme ani; v. g., oV- 
+âkkusittày aniyê, il était malade 
+en effet alors; sipwettew aniyê, 
+le voilà parti donc; takusin aniyê, 
+le voilà donc arrivé. On ï entend 
+aussi dire quelquefois devant le 
+mot; v. g., aniyê ka wâbamak, 
+alors que je l'ai vu. 
+
+ANATA, (ad.) (après le mot) assuré- 
+ment, vraiment, comme kusha ; 
+v. g., wiya anata, c'est lui assu- 
+rément. 
+
+ÂNIHUW, ok, (v. n.) il dépérit, il 
+maigrit, par exemple un animal 
+après avoir trop travaillé. 
+
+« ÂNIHUhew, (v. a.) ttaw, hiwew. 
+tchikew, il le fait dépérir. 
+
+x AN, (rac.) penser autrement, con- 
+tredire, désobéir; âniseyimew, 
+ttam, ânisistawew, tam, il le 
+désapprouve. 
+
+« ÂNImEW, (V. a.) TTAM, MIWEW, 
+
+tchikew, il le réprouve par ses 
+paroles, il n'approuve pas sa con- 
+duite, v. g., quelqu'un qui dirait : 
+je n'approuve pas sa conduite, moi 
+je ne ferais pas ainsi. 
+
+« ÂNEYImew. (v. a.) TTAM, MIWEW, 
+tchikew, il n'approuve pas sa 
+conduite, dans sa pensée; v. g., 
+n't'âneyitten niya, eoko naraa 
+ekusi ni pa toten, je n'approuve 
+pas cela, je ne ferais pas ainsi. 
+
+« ÂNWEYImew, etc., idem. 
+
+
+
+« ÂNIttawew, (v. a.) ttam, ttâ- 
+kew, tchikew, il lui désobéit, il 
+n'approuve pas ses paroles; v. g,, 
+awiyak ayânittawâtji ayamihe- 
+wiyiniwa tâbiskotch e ânittawât 
+Kije manitowa, celui qui déso- 
+béit au prêtre, désobéit à Dieu. 
+
+« ÂNWEttawew, etc., idem. 
+
+«ÂNIKKEMOW, ok, (v. n.) il ré- 
+prouve, il désapprouve. 
+
+« ÂNWETTÂKEWIN, a, (n. f.) dé- 
+sobéissance. 
+
+« ÂNITTAMOWIN, a, (n, f.) idem. 
+
+« ÂNIKKEMOWIN, a, (n.f.) idem, 
+
+« ÂNISIhew, (v. a.) ttaw, hiwew, 
+tchikew, il en détruit l'effet. On 
+emploie ce mot quand quelqu'un 
+par ses médecines détruit l'effet 
+d'un poison ou d'un sortilège, etc. 
+
+« ÂNISITCHIGAN, a, (n. f.) con- 
+tre-poison, remède contraire; v. 
+g., ayamihewinanatâwihuwina 
+ânisitchiganiwiwa pâstâhuwin e 
+âkkusiskâkuyak, les sacrements 
+sont des contrepoisons contre le 
+péché qui nous rend malade. 
+
+« ÂNISIHIWEWIN, a, (n. f.)idem. 
+
+ANIMA, (pro. in.) celui-là; eoko 
+anima ki mokkumân, c'est ton 
+couteau celui-là. 
+
+ANIH1, (pro. in. pi.) ceux-là; v. g., 
+eokoni anihi ki mokknmâna, ce 
+sont vos couteaux ceux-là. 
+
+ANISIKIS, (ad.) c'est pourquoi, 
+donc ; comme, tasipwa, tesikote; 
+v. g., anisikis ki miyin, donc tu 
+me le donnes; anisikis namawiya 
+ki ka sipwettân, ainsi ta ne par- 
+tiras pas; anisikis namawiya ki 
+wi-ayamihân, eka k'o pe kiski- 
+nohamâkusiyan, donc, ainsi, tu 
+
+
+
+ÂNI 

--- a/OCR/LOC/342.txt
+++ b/OCR/LOC/342.txt
@@ -1,0 +1,117 @@
+342 
+
+
+
+ISI 
+
+
+
+« ISAWÂNAKEYI M OTOtawew, 
+
+(V. a.) TAM, TÂKEW, TATCHIKEW, 
+
+idem. 
+«ISAWÂNAKEYIMOW, ok, {v. 
+
+n.) il est jaloux , voij. sawânake- 
+yimow. 
+
+x ISA, [roc.) malgré lui, avec peine, 
+se faire violence. 
+
+« ISÂHUW, ok, (v. r.) il se modère, 
+il se retient, il se corrige, mais en 
+se faisant violence, v. g. namawi- 
+ya ki isâhuw, il ne peut se corri- 
+ger, il ne peut venir à bout de tel 
+défaut, avis namawiya ni ki isâ- 
+hun, qu'y faire, je ne puis m'en 
+corriger, je ne puis m'en empêcher. 
+
+« ISÂHEW, [V. a ) TÏAW, HIWEW, HI- 
+
+kew, il le modère, il le corrige, il 
+V empêche de faire telle chose, mais 
+ce n'est qu'en lui faisant une sorte 
+de violence. 
+
+« ISÂTCH, ou, IYISÂTCH, malgré 
+lui, avec peine, à contre cœur, v.g. 
+iyisâtchituttew, il y va à contre 
+cœur, ekawiya iyisâtch tota, ne 
+fais pas cela à contre cœur. 
+
+x ISÂW, frac.) carré. 
+
+«ISÂWESIW, ok, (a. a.) il est 
+carré, ayisâwesiw. 
+
+« ISÂWEYAW, a, {a. in.) c'est car- 
+ré, ayisâweyaw. 
+
+« ISÂWEK, wok, aiguille carrée, ou, 
+asâwek, wok. 
+
+« ISÂWEswew, [v. a.) SAM, SUWEW, 
+sikew, il le taille carré avec un 
+couteau, ou, un ciseau. 
+
+u ISÂWEnew, (v. a.) NAM, NIWEW, 
+nikew, U le tient avec la main par 
+la partie cnrrée, ou, coupante, 
+voy. la racine asâwe, qui est la 
+
+
+
+même que celle-ci pour la signifi- 
+cation. 
+
+« ISÂWEhew, (v. a.) ttaw, hiwew, 
+hikew, il le fait carré. N. B. Tous 
+ces mots se disent plus souvent 
+avec le redoublement, ayis, etc. 
+C'est pour cela probablement qu'on 
+dit indifféremment isâwe, ou, avi- 
+sa we. 
+
+x IS et IT, frac.) ainsi, de cette ma- 
+nière, de cette forme, de cette fa- 
+çon. 
+
+« ISI, ou, IJI, devant le verbe, ainsi, 
+comme ça, v. g. ekusi iji, c'est 
+ainsi, eji kijewâtisit, étant ainsi 
+charitable, aw r âsis°ka iji-miyosit, 
+l'enfant qui est sibeau,eji matchi- 
+kijikâk, nam a ni ka sipwettân, 
+vu qu'il fait ainsi mauvais temps, 
+je ne partirai pas, eji-kâkebâti- 
+sit ! comme il est insensé! tchist ! 
+eji-pikupayik ni mokkumân î 
+vois donc, comme mon couteau est 
+brisé! ekusi piko n't' iji-kiske- 
+yitten, je ne le sais que de cette 
+manière, Jesus-Chrlst ki pe-itut- 
+tew w T askitaskamik eji-manito- 
+wit mina eji-ayisiyiniw r it, Jésus - 
+Christ est venu sur la terre comme 
+Dieu et comme homme, eji-atchâ- 
+kow T ik mina eji-owiyawik, en 
+âme et en corps. 
+
+h IJITGHITGHEYIW, ok, {v. n.) il 
+étend la main vers. 
+
+« IJITGHITGHEYIStawew, [v. a) 
+tam, tâkew, tâtchikew, il étend 
+la main vers lui. 
+
+« IJITGHITGHEYITOtawew, (t\ 
+a.) etc.. idem, 
+
+« ISIW, ok, sorte de verbe auxili- 
+aire, comme, ittiw, ayaw, il est. 
+
+
+
+ISI 

--- a/OCR/LOC/362.txt
+++ b/OCR/LOC/362.txt
@@ -1,0 +1,126 @@
+362 
+
+
+
+KAK 
+
+
+
+x KAKEBATISIW, ok, (a. a.) il 
+n'a pas d'esprit, il a un caractère 
+bouché. Ce mot vient probablement 
+de la racine kepa, ou, kippa w, 
+qui veut dire bouché, fermé, avec 
+le redoublement ka. 
+
+« KAKEBÂTEYImew, (n. a.) ttam, 
+miwew, tchikew, il le trouve fou, 
+insensé. 
+
+« KAKEBÂTISIKKEW, ok, (v. n.) 
+il agit en insensé. 
+
+a KAKE BATCH LTTWAW, ok, id. 
+
+« KAKEBÂTISIKKEWIN, a, (n.f.) 
+folie. 
+
+« KAKEBATCHITTWÂWIN, a, 
+
+(n. f.) idem. 
+
+« KAKEBÂTISIKKAttew, (v. a.) 
+
+TTAM, SIWEW, TCHIKEW, U S6 
+
+prend en insensé pour agir avec 
+lui, il s'y prend mal pour le ga- 
+gner. 
+
+« KAKEPITTEW, ok, (a. a.) il est 
+sourd, il a les oreilles bouchées. 
+
++ KAKESKImew, [v. a.) ttam, mi 
+wew, tchikew, il le conseille, il 
+Favise, il V avertit. 
+
+« KAKESKIMIWEW1N, a, (n. f.) 
+
+conseil, avis, voy. la racine kiski. 
+
+« KAK ESKIMO W, ok, ou, kakes- 
+kikkemow, ok, (v. n.) il fait des 
+instructions, il donne des avis; 
+c'est le mot reçu pour dire : il prê- 
+che. 
+
+« KAKESK1MOWIN, a, ou, kakes 
+kikkemowin, a, (n. f.) instruc- 
+tion, sermon. 
+
+«KAKESKWEW, ok, [v. n.) com- 
+me kakeskikkemow. 
+
+« K.\KESKWEWIN, a, (n. f.) com- 
+me kakeskikkemowin. 
+
+
+
+« KAKESKWEWIYINIW, ok, (n. 
+
+f.) un prêcheur, un prédicateur. 
+«KAKETTÂWEW, ok, (v. n.) 
+comme nittâwew, il a Vusage de 
+la parole, il a la parole en bouche, 
+v. g. un enfant qui a déjà bien 
+Vusage de la parole, on dirait : ka- 
+kettâwew. 
+KAKETTAWEYImew, ttam, il le 
+
+trouve prudent, ingénieux. 
+KAKETTÂWÂTISIW, ou, kaket- 
+tâweyittam, il est prudent, homme 
+de génie. 
+xKÂKI, [rac.) supplier, s'humilier 
+
+en présence de, etc., etc. 
+* KÂKISIMOWIN, a, (n. f.) sup- 
+plication humble. 
+« KÂKISIMOW, ok, ( v. n.) il sup- 
+plie avec larmes, avec humilité. 
+« KAKISIMOTOtawew, (v. %).tam, 
+tàkew, tchikew, il le supplie en 
+s abaissant, v. g. n'otta ki pe-kâ- 
+kisimototâtin kitchi kitimâkeyi- 
+miyan, mon père, je viens te sup- 
+plier d'avoir pitié de moi. 
+« KÂKITOkkawew, (v. a.) kkam, 
+kâkew, tchikew, il s'humilie de- 
+vant lui, en lui faisant des bas- 
+sesses, (ce dernier mot doit s'en- 
+tendre à la façon du pays,) v. g. 
+e ki kisiwâhât onâbema, ekwa 
+pe-kâkitokkawew, ayant fait fâ- 
+cher son mari, ell vient lui faire 
+des bassesses. 
+« KÂKITOKKÂSUW, ok, (v. n.) il 
+fait des bassesses, il reconnaît sa 
+faute. 
+« KAKITOKKÂSUWJN, â, (n. f) 
+bassesses, humil iation, soumission- 
+
+
+
+« KAKITJIhew, i 
+
+WEW, TCHIKEW, 
+
+
+
+V. a.) TTAW, HI- 
+
+il le console* il le 
+
+
+
+KAK 

--- a/OCR/LOC/471.txt
+++ b/OCR/LOC/471.txt
@@ -1,0 +1,140 @@
+471 
+
+
+
+MUT 
+
+
+
+«MOSKUMEMOW, ok, [v. ri.) il 
+pleure de faim. 
+
+« MOSKUWAtew, (v. a.) tam, si- 
+wew, tchikew, il pleure après 
+lui. 
+
+«~MOSKWEYITTAM,wok, (v. n.) 
+sa douleur éclate. , son chagrin se 
+fait jour. 
+
+« MOSKUYÂWESIW, ok, (a. a ) 
+idem. 
+
+« MOSKUhew, mew, (v. a.) il le 
+touche, il V affecte, il le touche jus- 
+qu'aux larmes. 
+
+« MOSKITJIWAN, wa, \n. f.) une 
+fontaine, une source d'eau. 
+
+« MOSKITJIWANIPEK, wa, (n.f,) 
+idem. 
+
+« MOSKInew, (v. a.) nam, ni wew, 
+nikew, il le découvre, il le fail 
+coir à découvert. 
+
+« MOSKIPItew, i v. a. ) tam, siwew, 
+tchikew, il le tire à jour. 
+
+« MOSKIW, ok, (v. n.) il se décou- 
+vre, il se montre. 
+
+« MOSKINEW, ok a, [a. a, et in.) 
+il est rempli jusqu'au faîte. 
+
+« MOSKINAhew, (v. v.) ttaw, hi 
+wew. tchikew, il le remplit jus- 
+qu'au faite. 
+
+x MONJIhew, (v.a.) ttaw,hiwew, 
+tchikew, il le sent, il le ressent., 
+(tant au physique qu'au moral.) 
+
+« MONJIHUW, ok, {v.r.) il éprouve 
+une sensation. 
+
+« MONJITTOYUW, ok.{v.r.) idem. 
+
+« MONJITTÂWIN, a, [n. f.) sensa- 
+tion. 
+
+'(MOJIHUWIN, a, (i?. f.) idem, 
+
+MUSIWÂK, (ad.) pas de sitôt. Voy. 
+
+I Mayo (nama mayo) v. g. nama- 
+wâtch musiwâk te hi miyoska- 
+
+
+
+mik, ce n'est pas de sitôt qu'il sera 
+
+printemps. 
++ MUSTGHI, (ad. et rac.) ou, mu- 
+
+tchi, à nu, à découvert, sans mé- 
+lange, au jour, simplement. 
+« MUSTAWÂN, c'est sans mélange* 
+« MUSTASKUSÂWEW, ok, (v. n.) 
+
+il fume sans mélange, il fume le 
+
+tabac pur. 
+« MUST A h wew, (v. a.) ham, hu- 
+
+wew, hikew. il lui touche à nu, 
+
+il le saisit à nu. 
+« MUSTInew, (v. a.) nam, niwew, 
+
+nikew, il le saisit avec la main 
+
+nue. 
+
+« MUSTAhyew, ( v. a. ) staw, yi- 
+wew, tchikew, il le fait connaî- 
+tre, il le met à nil. 
+
+« MUSTÂBUIY, a, (n. f.) liquide 
+pur, sans mélange, de l'alcool. 
+
+« MUSTAGAMIW, a, (a. in.) idem. 
+
+a. ) TAM, 
+
+
+
+« MUSTAWEYImew, 
+
+
+
+miwew, tchikew, il le désire, il 
+
+soupire après lui. 
+« MUSTAAVInawew, (v. a.) nam, 
+
+nâkew, nâtchikew, il le désire 
+
+en le voyant. 
+« MUST A WE YI TT A MA W E W, 
+
+etc., (v. a. ) il lui désire. 
+« MUSTAWINAMÂWEW, etc. il 
+
+lui envie. 
+« MUSTUTTEW, ok, [v. n.) il mar- 
+^che à pied, il va à pied. 
+« MUTGHIK, (ad. ) à terre, à terre 
+
+nue. 
+« MUSTASKAMTK, (ad.) idem. 
+«MUSTASKAMIKISIN, wok, (a.. 
+
+a. ) il est étendu sur la terre nue. 
+« MUTGHITON, (ad.) de vive voix. 
+« MUTGHIMIYEW, (v. a.) il lui 
+
+
+
+MUS 

--- a/OCR/LOC/502.txt
+++ b/OCR/LOC/502.txt
@@ -1,0 +1,143 @@
+502 
+
+
+
+NIS 
+
+
+
+« NISWEYAKISIW, ok, (a. a.) il 
+
+est en deux façons. 
+« NISWEYAKIHUW, ok, (a. a.) 
+
+idem. 
+
+« NISWEYAKAN, wa, (a. in. ) c'est 
+en deux façons. 
+
++ NISOWISIW, ok, {a. a.) il est 
+nonchalant, faible, incapable, im- 
+puissant, etc. 
+
+« NISOWISIWIN, a, {n. f) inca- 
+pacité. 
+
+«NISOWAN, wa, (a. in.) c'est 
+faible, sans vigueur. 
+
+« NISOWÂTISIW, ok, {a. a.) carac- 
+tère indolent. 
+
+« NISOWÂTISIWIN, a, (n. f.) in- 
+dolence, incapacité morale. 
+
+« NISOWEYImew, (v. a.) ttam, 
+miwew, tchikew, il le pense in- 
+capable, il le pense sans force. 
+
+« NISOWEYIMISUW, ok, (v. r.) 
+
+il s'abaisse, il s'humilie. 
++ NISIT, (rac.) comprendre, recon- 
+naître. 
+
+«NISSITAW, (ad.) Ce mot ne pa- 
+raît s'employer qu'avec la néga- 
+tion, v. g. naraa nissitaw, ça ne 
+convient pas,ri8imdLmssitdL\v kitchi 
+pâppiyan anotch, ça ne convient 
+pas que tu ries à présent. 
+
+« NISSITAWEYImew, (v a*) ttam, 
+miwew, tchikew, il le comprend, 
+il le reconnaît dans sa pensée. 
+
+« NISSITÂWInawew, (v. a.) nâ- 
+kew, nam, nâtchikew, il le re- 
+connaît en le regardant. 
+
+« NISITOttawew, (v. a. ) ttam, 
+ttâkew, ttâtchikew, il le com- 
+prend, il entend ce qu'il dit. 
+
+« NISSITOTTAM, wok, [v. n.) il 
+comprend. 
+
+
+
+« NISSITOTTAMOWIN, a, (n. f. ) 
+
+intelligence. 
+« NISSITOMATJIHUW, ok, (v. r.) 
+
+il connaît ce qu'il ressent. 
+« NISSITOMEW, etc., {v. a.) il lui 
+
+fait comprendre, ou mieux, il lui 
+
+fait souvenir. Voy. Miskawâso- 
+
+mew, kiskisomew. 
+« NrSSITOSIW, ok, [a. a.) il a l'o- 
+dorat délicat. Cependant ce mot 
+
+est reçu pour dire : il est gras, il 
+
+est en bon état, il est assez gras. 
+« NISSITWAW, a, c'est assez gras, 
+
+c'est d'un assez bon goût. 
+« NISSITOSPItew, (v. a.) tam, si- 
+
+wew, tchikew, il en reconnaît le 
+
+goût. 
+« NISSITOSPWEW, etc., (v. a.) 
+
+idem. 
+« NISSITOTTÂKUSIW, ok, (a. a.) 
+
+il est compréhensible, intelligible. 
+« NISSTTOTTÂKWAN, wa, (a. in.) 
+
+idem. 
+« NISSITÂWÂKÂT1SIW, ok, (a. 
+
+a.) avec la négation seulement, v. 
+
+g. nama nissitâwâkâtisiw, il est 
+
+idiot, incompréhensible. 
+« NISSITÂWEYITTÂKUSIW, ok, 
+
+(a. a.) il est reconnaissable. 
+« NISSITÂWEYITTÂKWAN, wa, 
+
+(a. in.) idem. 
+«NISSITOTTAMOhew, (v. a.) 
+
+
+
+TTAW, HIWEW, TCHIKEW, 
+
+
+
+il lui 
+
+
+
+fait comprendre. 
+
++ NISTA, (ad.) aussi, de même, pa 
+reillement, v. g. nista matchipi- 
+mâtisiw, lui aussi vit mal, nista, 
+ki ka nipin, loi aussi tu mour- 
+ras. 
+
++ NISTA, (pron.) moi aussi, kista, 
+toi aussi, wista, lui aussi. 
+
+
+
+NIS 

--- a/OCR/LOC/514.txt
+++ b/OCR/LOC/514.txt
@@ -1,0 +1,134 @@
+514 
+
+
+
+OSI 
+
+
+
+« OSAWÂBISKISIW, ok, (a. a.) il 
+est jaune, du fer. 
+
+« OSAWÂBISKAW, wa, (a. in.) 
+idem. 
+
+« OSAWABÂN, ak, (n. f.) bile. 
+
+« OSÂWÂBEW, ok, [a. a.) il a de 
+la bile, il est bilieux. 
+
+« OSÂWÂBUIY, a, (n. f,) liquide 
+jaune. 
+
+« OSÂWEGIN, wa, (n. f.) étoffe jau- 
+ne, indienne jaune. 
+
+« OSÂWEKAN, wa, {a. in.) il est 
+jaune, en parlant d'étoffe, d'indi- 
+enne. 
+
+« OSÂWISKUSIW, ok, {a. a.) il 
+luit, il brille par le jaune. 
+
+« OSÂWISKWAN, wa, {a. in.) id. 
+
+« OSÂWISKWAW, (v. im.) soufre 
+en pierre. 
+
+« OSÂWAKKESIW, ok, (n. f.) re- 
+nard jaune. 
+
+« OSÂWAKKWANEW, {v. im.) 
+flamme jaune. 
+
+« OSÂWASK, wok, (n.f.) ours jau- 
+ne. 
+
+x OSEYAW, a, (a. in.) c'est en 
+coteau, c'est une hauteur. 
+
+« OSESIW, ok, {a. a.) il est en for- 
+me de dos, de coteau. 
+
+« OSESKAMIKAW,(u.im.) terrain 
+élevé. 
+
+«OSETCHAW, (v. im.) terre en 
+forme de coteau. 
+
+« OSETINAW, {v. im.) colline, cô 
+teau. 
+
+« OSEYÂB1SKAW, {v. im.) rocher 
+en forme de coteau. 
+
+« OSETTUY, a, {n. r.) la queue de 
+la raquette. 
+
+t OSI, pi. osa,(n.r.) canot ; misiikosï, 
+canot de bois; waskwây osi, ca- 
+
+
+
+not d'écorce de bouleau; n't'os, 
+mon canot ; ot'os, son canot ; mi- 
+sottakaw, grand canot. 
+
+xOSAhwew, (v. a.) HAM, huwew, 
+hikew, il le lève, il le fait fuir. 
+
+« OSISkawew, (v. a.) idem. 
+
+« OSAHIKEW, ôk, {v. ind.) il fait 
+fuir, v. g., quelqu'un qui va à la 
+chasse, et qui, en faisant du bruit, 
+fait fuir l'animal quil approche, 
+qu'il guette. 
+
+OSIPIW, ok, (v. n.) il remue l'eau, 
+v. g., un castor qui nage entre 
+deux eaux. 
+
++ OSI, et, OJI, (rac.) faire, créer, 
+manufacturer. 
+
+« OJIhew, (v. a.) TTAW, hiwew, 
+TGHiKEW, il le fait, il le crée. 
+
+« OJIHUMAGAN, {v. r. in.) ça se 
+forme. 
+
+« OSITGHIKEW, ok, (v. ind.) il 
+crée, il opère. 
+
+« OSITCHIKEWIN, a, (n. f.) créa- 
+tion, opération. 
+
+« OS1TCHIGAN, ak, a, {n. f.) créa- 
+ture. 
+
+« OT OJIHIWEW, ok, (n. f.) le cré- 
+ateur. 
+
+« OSITTOWEW, (v. a.) il le lui fait. 
+
+a OSITTAMAwew, {v. a.) il le fait 
+à sa place. 
+
+« OSIKKIP1MIW, ok, {v. n.) il a 
+un clou, enflure, un furoncle. 
+
++ OSIKAMISK, wok, (n. f.) castor, 
+éparé et séché. De la racine osik, 
+qui se rétrécit, v. g. , quelque cho- 
+se, qui, en séchant, devient moin- 
+dre. 
+
+« OSIKÂKATOSUW,. ok, (a. a.) il 
+se rétrécit en séchant. 
+
+« OSIKÂKATOTEW, a, (a. in.) id. 
+
+
+
+NIP 

--- a/OCR/LOC/576.txt
+++ b/OCR/LOC/576.txt
@@ -1,0 +1,125 @@
+576 
+
+
+
+POS 
+
+
+
+« PONI-AYAMIHAW, ok, (v. n.) il 
+
+finit de prier. 
+« PONI-AYAW, ok, [v. n.) il cesse 
+
+d'être, d'exister. 
+« PONIYÂWESIW, ok, (a. a.) il 
+
+cesse d'être fâché. 
+<< PONINOKUSIW, ok, (a. cl) il 
+
+disparait. 
+
+a PONINOKWAN, wa, (a. in.) id. 
+« PONINONIW, ok, (t). n.) il cesse 
+
+de téter. 
+« PONINQYEW, etc., [v. a.) elle le 
+
+sevré. 
+« PONI-PIMATISIW, ok, (a. a.) il 
+
+cesse de vivre. 
+« PONTPAYIW, ok, a, {a. a. et in.) 
+
+ca cesse, ca finit d'agir. 
+«POXIWITJEWEW, etc., (v. a.) 
+
+il se sépare de lui. 
+a PONIYOTIN, (v. im.) lèvent s'ap- 
+
+paise. 
+« POYUW, ok. {v. n.) il cesse d'a- 
+gir, il se désiste. 
+« POYUWINT, a, (n. f) cessation, 
+
+désistement. 
+
+xPOnEW, (V. CI.) NAM NIWEW NI- 
+
+kew, il alimente le feu avec lui, 
+il s'en sert comme de bois v. g., 
+matchi-mauito ponew owebi- 
+nikowisiwa, le démon alimente 
+le feu avec les damnés, (ou, les y 
+jettent). 
+
+« PONAM, wok, [v. n.) il alimente 
+le feu, il met du bois dans le feu. 
+
+« PONIKÂTEW, a, [a. in.) le feu 
+est préparé, fait. 
+
+POUS, ak, chat. 
+
+POSAKKWÂMLW, ok, (a. a) il 
+
+dort profondément. 
+xPOSIW, ok, [v. n.) il embarque 
+
+
+
+dans un canot, barge, navire, et il 
+monte, dans une voilure sur terre. 
+
+«POSIWIN, a,- (n. f) embarque- 
+ment. 
+
+« POSIhew, [v. a.) TTAW, HIWEW, 
+tchikew, il l'embarque, il le fait 
+embarquer, il le fait monter en 
+voiture. 
+
+« POSIPAYIW, ok, a, (a. a. et in.) 
+ça entre dedans, ça embarque, v 
+g. posipayiw nipïy, l'eau embar- 
+que, entre dedans. 
+
+«POSITTASUW, ok, (v.n.)il 
+charge, v. g. un navire. 
+
+« POSITTASUWIN, a, (n. f.) char- 
+ge d'un canot, ou, action de le 
+charger. 
+
+« POSIWEBInew, (v. a.) nam, ni- 
+wêw, nikew, il l'embarque en le 
+jetant dedans. 
+
+« POSIWEPAhwew, [v. a.) ham, 
+huwew, hikew, il V embarque en 
+lui donnant une secousse. 
+
+« POSISKISIW, ok, (a, a.) il est 
+concave. 
+
+« POSISKAW, a, [a. in.) idem. 
+
+« POSISKIHEW, etc, [v. a.) il le 
+fait concave. 
+
+POSKU, {préfixe,) dans le même 
+temps, dans le même espace, v. g. 
+posku kijik, le même jour, posku 
+pipon, dans le cours du même hi- 
+ver, posku tibisk, dans Vinterval 
+de la nuit, posku wâskâhigan, 
+dans rétendue de la maison, pos- 
+ku sâkahigau, dans l'espace du 
+lac, posku kijik takusin, il ar- 
+rive le même jour {qu'il est parti). 
+x POSK, {rac.) crever, éclater, faire 
+explosion. 
+
+
+
+POS 

--- a/OCR/LOC/581.txt
+++ b/OCR/LOC/581.txt
@@ -1,0 +1,135 @@
+581 
+
+
+
+SAK 
+
+
+
+« SÂKIHAGAN, ak, (n. /*.) amant, 
+favori. 
+
+« SÂHIhew, [v. a.) TTAW, HIWEW, 
+tchikew, il Vaime, il y est atta- 
+ché, il ne veut pas s' en détacher. 
+
+«SÂKIHIWEW, ok, (v. ind) il 
+aime. 
+
+« SÂKIHIWEWIN, a, (n.f.) amour 
+pour, affection pour, etc. 
+
+« SÂKIHIWEWINIWIW, ok a, 
+
+(a. a. et in.) il est amour, c'est 
+
+amour. 
+« SAKIHIWEWISIW, ok, (a. a.) 
+
+il est amoureux. 
+« SAKIHITUWOK, (v. m. ) ils Cen- 
+trai ment. 
+« SÂKIHITUWIN, a, (n. f.) amour 
+
+mutuel. 
+« SÂKIHIKUSIW, ok, {a. a.) il est 
+
+aimable. 
+«SÂKIHIKWAN, wa, (a. in.) idem. 
+« SÂKIHIKUSIWIN, a, (n, f.) 
+
+amabilité. 
+« SÂK1HIKOWIN, a, [n. f.) action 
+
+d'être aimé. 
+« SAKIHIKOWISIW, il est aimé 
+
+par Dieu. 
+« SÀKIHIKOWISIWIN, a, [n. f.) 
+
+action d'être aimé par Dieu. 
+« SÂKIHISUW, ok, {v. r.)il s'aime. 
+« SÂKIHISUWIN, a, (n. f.) amour 
+
+propre. 
+«-SÂKISIW, ok, (a. a.) il est avare, 
+
+il aime son bien. N. B. Ce mot et 
+
+le suivant, se disent toujours avec 
+
+le redoublement, ainsi, sâsâkisiw. 
+« SÂKISIWIN, a, (ri. f.) (sâsâkisi- 
+
+win, a,) avarice, amour de son 
+
+bien. 
+SÂKITTIW, ok, (a. a.) (sâsâkittiw) 
+
+
+
+il a les pieds nus. Voy. la racine 
+
+plus loin. 
+x SAKK, (rac. Rattacher à, agraffer, 
+
+accrocher, embarrasser dans, etc. 
+« SAKKAPPItew, {v. a.) tam, si- 
+
+wew, tchikew, il Vattache, v. g. 
+
+à un poteau. 
+« SAKKAPPISUW, ok, [(a. a.) il 
+
+est attaché à, etc. 
+« SAKKAPPITEW, a, [a. in.) idem. 
+« SAKKÂBÂtew, {v. a.) tam, si- 
+
+wew, tchikew, il Vy attachent le 
+
+coud à. 
+« SAKKIPÂTEW, etc., {v. a.) idem, 
+
+il le boutonne. 
+« SAKKIPÂSUW, ok, (v.n.) il se 
+
+boutonne, il agraffe ses habits. 
+« SAKKIPÂSUN, a, [n. f.) bouton, 
+
+agraffe. Voy. Aniskamân. 
+«SAKKÂSKWAhwew, [v. a.) 
+
+ham, huwew, hikew, il V agraffe, 
+
+il le boutonne, il l'attache, il V en- 
+lace. 
+« SAKKÂSKUHEW, etc.-, (v. a.) 
+
+idem, il V agraffe, etc. 
+« SAKKÂSKWAHUN, a, [n. f.) 
+
+bouton, agraffe. 
+« SAKKAmew, [v. a.) ttam, miwew, 
+^ tchikew, il le tient serré*, entre 
+
+ses dents. 
+« SAKKAhwew, (v. a.) ham, hu- 
+wew, hikew, il le cloue. 
+« SAKKAHIGAN, a, [n. f.) clou, 
+
+cheville. 
+« SAKKAHIGANIS, a, [n. f.) petit 
+
+clou, pointe. 
+;< SAKKAMOW, ok, a, [a. a. et in.) 
+
+il y est cloué, attaché. 
+« SAKKAMOhew, [v. a.) ttaw, hi- 
+
+wew, tchikew, il Vy attache, en 
+
+le clouant. 
+
+
+
+SAK 

--- a/OCR/LOC/616.txt
+++ b/OCR/LOC/616.txt
@@ -1,0 +1,132 @@
+616 
+
+
+
+TET 
+
+
+
+« TEPISIWIN, a, (ft. f.) contente- 
+ment, satisfaction. 
+
+« TEPIYÂWESI.WIN, a, (ft. f.) id. 
+
+« TEPIKKWÂMIW, ok, {a. a.) il a 
+assez dormi. 
+
+« TEPImew, etc., (v. a.) il lui parle 
+suffisamment, ou, il le contente par 
+ses paroles. 
+
+« TEPIMÂKUSIW,ok,(a.a.) il rem 
+plit la place de son odeur. 
+
+« TEPIMiKWAN, wa, {a. in.) id. 
+
+« TEPInew, (v. a.) NAM, NIWEW, NI- 
+kew, il peut y atteindre avec sa 
+main. 
+
+« TEPINAMÂwew, etc., (v, a.) il 
+lui en fournit assez. 
+
+« TEPISkawew, {v. a.) kam, kâkew 
+katchikew, il lui va bien, v. g., 
+ni tipiskawâwok ni wikwepâ- 
+nak, mes pantalons me vont bien, 
+tepiskam omaskisina, ses souliers 
+lui font bien. 
+
+« TEPISUW, ok, (a. a.) il a assez 
+famé. 
+
+« TEPIPEW, ok, {a. a.) il a assez 
+bu 
+
+« TEPIPUW, ok, {a, a.) il a assez 
+mangé. 
+
+« TEPISKITEHEW, ok, (a. a.) il a 
+le cœur fatigué, accablé. 
+
+« TEPIPAYIHIKUW, ok, (v.pass.) 
+il en a assez, ça lui suffit. 
+
+« TEPITTÂKUSIW, ok, (a. a.) il 
+est bien entendu. 
+
+« TEPiTTÂKWAN, wa, (a. in.) id. 
+
+« TEPIttawew, (v. a.) ttam, ttâ 
+tchikew, il V entend bien, il saisit 
+assez sa voix, il V entend suffisam- 
+ment. 
+
+« TEPISTN, wok, {a. a.) il est con- 
+venable, il s'ajuste, il est juste. 
+
+
+
+« TEPITTIN, wa, {a. in.) id. 
+
+« TEPISIMEW, (V. a.) TTITAW, SIMI- 
+
+wew, tchikew, il fajuste, il le 
+fais joindre. 
+
+xTEPIYÂK, {ad.) {saltern,) ' au 
+moins, du moins, v. g., tepiyâk 
+ekawiya ekusi tota, au moins ne 
+fais pas cela, 
+
+xTEPWEW, ok, {v. a.) il crie, il 
+appelle. 
+
+« TEP WE WIN, a, {n. f.) cri. 
+
+« TEPWÂtew, {v. a.) TAM, SIWEW, 
+tchikew, il l'appelle, il lui crie, 
+aussi : il est publié dans l'église,etc. 
+
+« TEPWESKITTEW,ok, {v. n.) les 
+oreilles lui tintent. 
+
+x TET, {rac.) être dessus, etc. 
+
+« TETTAhyew, {v. a.) staw, yiwew, 
+tchikew, il le met dessus. 
+
+« TETTAPIW, ok, {a. a.) il est as- 
+sis dessus, cest-à-dire, il est à 
+cheval, v. g., quelqu'un qui est à 
+cheval. 
+
+TETTÂPÂTEW, ok, il est à cheval 
+sur lui. 
+
+« TETTAPIWIN, ak, (n. f.) ce sur 
+quoi on va à cheval, le cheval. 
+
+« TETTAPIWIN, a, (ft. -f.) siège, 
+chaise, banc. 
+
+« TETTAPIhew, etc., {v. a.) il l'as- 
+sied dessus. 
+
+a TETGHIKWÂSKUTTIW, ok,(v. 
+ft.) il saute dessus. 
+
+« TETGHIPAYIW, ok, a. {a. a. et 
+in.) il monte sur, etc. 
+
+« TETCHIPAYIHUW, ok, (v. r.) 
+il s'élance dessus, il monte dessus. 
+
+« TETGHIPAYIHUStawew, etc., 
+{v. a.) il monte sur quelqu'un, 
+etc. N. B. Ordinairement c'est em- 
+ployé dans le sens impudique. 
+
+
+
+TET 

--- a/OCR/LOC/636.txt
+++ b/OCR/LOC/636.txt
@@ -1,0 +1,132 @@
+636 
+
+
+
+WAS 
+
+
+
+« WÂPISKEYÂPEGAN, wa, (a. 
+
+in.) idem, {une corde.) 
+« WÂPISKAYOWINISSEW, ok, 
+
+(a. a.) il a des habits blancs. 
+« WÂPISKIKÂTEW 7 , ok, [a. a.) il 
+
+a les jambes blanches. 
+
+« WÂPISKIhew, (v. a.) ttaw, hi- 
+wew, tchikew, il le blanchit, il le 
+rend blanc. 
+
+« WÂPISKIRUW, ok, (v. r.) il est 
+habillé en blanc. 
+
+« WÂPISKIPEhwew, (v. a.) ham, 
+huwew, hikew, il le peinture en 
+blanc. 
+
+« WÂPISKWAKUP, a, [n. f.) cou- 
+verture blanche. 
+
+« WAPEKINIGAN, a, {n.f.) c est le 
+tabac que s'envoient les sauvages, 
+qui est enveloppé dans une peau 
+blanche, ou, un morceau de coton. 
+Cet objet a ccompagnetoujours les 
+ambassades et il est fumé en con- 
+seil ou rejeté, selon qu'on accepte 
+la paix, ou quon rejette ce qui est 
+proposé. 
+
+« WÂPISKOWEW, ok, {a. a.) il est 
+cendré, blafard. 
+
+« WÂPISKOWES, ak, (n. f.) cen- 
+dré, il a le poil blafard. 
+
+« WÂPISKASÂKAY, a. (n. f.) ca- 
+pot blanc, habit blanc 
+
+« WÂPISTÂN,. ak. (n. f.) martre. 
+N. B. On se sert presque toujours 
+du diminutif, wâpistânis, ak. 
+
+« WAP1STIKWÂN, a, (n. f.) tête 
+blanche. 
+
+« WÂPISTIKWÂNEW, ok, [a. a.) 
+il a la tête blanche. 
+
+a WÂPITEW, ok, (a. a.) fané. pale, 
+brun, de couleur sale. 
+
+
+
+« WÂPITEYAW, ok, a, (a.a.et in.) 
+idem. 
+
+« WÂPITTAKAHIGAN, a, [n, f.) 
+craie, ou, wâpigan, a. 
+
+« WÂPUS, wok, {n.f.) lapin, lièvre, 
+mistâpus, gros lièvre de prairie. 
+
+« WÂPUS WE YÂN, ak, [n.f) peau 
+de lièvre avec le poil. 
+
+«WÂPOWEYÂN, a, (n. f.) cou- 
+verture blanche. 
+
+« WÂPÂWAKKAW, (v. im.) boue 
+blanche, sable blanc. 
+
+« WÂPATÂWOKKAW, (v. im.) 
+
+idem. . . ' 
+x WÂS, (rac.) en forme de baie, une 
+
+anse dans un lac. 
+« WÂSAKÂM. {adv. ) autour de Veau 
+
+du lac. 
+« WÂSAKAMEW, ok, (y. n.) il va 
+
+autour du lac, de Veau. 
+« WÂSAKÂMEWIN, a, [ri. f.) action 
+
+cV aller autour de Veau. 
+
+« WASAKAMUTTEW, ok, [v.n.) il 
+
+marche autour de Veau, 
+« WÂswew, {v a) SAM, suwew, si- 
+
+kew, il le coupe à Ventour. . 
+« WÂSiPEW, ok, [v. n.) il taille 
+
+autour, v. g., tailler des cordes 
+
+autour d'une peau. 
+« WÂSlHIGAMAW, {v. im.) il y a 
+
+une baie (dans un lac.) . 
+xW ÂSK, (même racine) autour, à 
+
+Ventour, en cercle. 
+« WÂSKÂPAYIW, ok, a, [a. a. et 
+
+in.) il tourne en cercle, en rond. 
+« WÂSKÂPAYIHUW, ok, (v. r.) il 
+
+tourne en rond, en 'faisant des 
+
+mouvements. 
+« WÂSKAPÂWIWOK, (a. a.] ils 
+
+sont debout en rond. 
+
+
+
+WÂS 

--- a/OCR/LOC/660.txt
+++ b/OCR/LOC/660.txt
@@ -1,0 +1,123 @@
+660 
+
+
+
+YAW 
+
+
+
+V. g., yâkki ot ayâttay peyak ayi- 
+siyiniw, jadis il y avait un hom- 
+me, eknsi otiji hikâsuttay yâkki, 
+(vide lur sic nominatum esse.) 
+
++ YÂKWÂMEYImew, (v. a. ) ttam, 
+miwew, tchikew, il est attentif 
+auprès de lui, prévenant, il s'en 
+occupe beaucoup, il lui fait la cour, 
+il est persévérant auprès de lui. 
+N. B. Pour cette rac. et ses déri 
+vés, c'est la même chose, que ayâk- 
+wâmeyimew. 
+
+« YlKWÂMEYIMOW, ok, (v. n.) 
+il est persévérant, il donne ses 
+soins de plus en plus. 
+
+« YÂKWÂMEYIMOWIN, a, (n, f) 
+persévérance, attention. 
+
+«YÂKWÂMImew, etc., [v. a.) il 
+Vencourage, il est sans cesse à lui 
+parler de cela. 
+
+« YÂKWÂMISIW, ok, [a. a.) il est 
+sur ses gardes, précautionné, cir- 
+conspect, (cautus, providus), per- 
+sévérant. 
+■.« YAKWÂMISIWIN, a, (n. f-Y per- 
+sévérance, prévoyance, précaution.. 
+
+x YÂS, (rac.) descendre, s'abaisser. 
+
+« YÂSÂPEKTnew, (v. a.) nam,, ni- 
+wew, nikew, il le descend, il l'a- 
+baisse au moyen d'une corde, v.g., 
+abaisser un pavillon, une voile, 
+etc. 
+
+« YÂSInew, (v. a) il le descend avec 
+la main. 
+
+« YÂSIPAYIHUW,ok, (v.r.) il s'a 
+baisse, il se glisse en bas. 
+
+« YASIPAYIW, ok, a, (a. a. et in.) 
+il descend, il va en bas. 
+
+« YÂSIPAYIhew, (v. a.) ttaw, hi- 
+wew, tchikew, il le descend, il le 
+fait s'abaisser. 
+
+
+
+« YASITINEW, etc., (v. a.) il l'en- 
+voie au bas, il le descend à terre. 
+
+« YÀSITISAHAMAWEW, etc., (v. 
+a.) il le lui descend à terre. 
+
+« YÂSISTAWEW, etc., (v. a.) il 
+descend vers lui, v. g., Jésus- 
+Christ ki ki pe-yâsi.4âkonow, 
+Jésus-Christ a descendu vers nous. 
+
+« YÂSITOTAWEW, etc., (v. a.) 
+idem. 
+
+« YÂSIW, ok, (v. n-) il descend, il 
+s'abaisse vers la terre. 
+
+« YÂSIWIN, a, (n. f.) descente, ac- 
+tion de descendre sur la terre. 
+
+« YÂSASKE W, ok, [v. n. ) il des- 
+cend sur la terre. 
+x YÂTTOKAMIK, [ad.) Foy.Ayât- 
+tokamik, dans une autre maison, 
+dans une autre loge. 
+
+x YÂW, (rac.) indique qu'il n'y a 
+pas assez, insuffisant, être prêt 
+de manquer avant d'atteindre, 
+au dessous. 
+
+« YÂ WAP Ame w, (v. a.) ttam, 
+kkew, etc., il ne peut le voir par- 
+cequ'il est trop loin, sa vue n'est 
+pas assez longue pour le voir. 
+
+« YÂWInawew, (v. a ) nam, nâ- 
+kew, nâtchikew, idem. N. B. 
+Toute cette racine renferme l'idée 
+de nottow. Voy. plus haut. 
+
+« YÂWINÂKUSIW, ok, (a. a.) il 
+est hors de vue, il est impercep- 
+tible. 
+
+« YÂWINÂKWAN, wa, (a. in.) id. 
+
+« YÂWInew, (v. a. ) nam, niwew, 
+nikew, il ne peut le saisir avec la 
+main,il ne peut l'atteindre. 
+
+« YÂWÂSIttawew, (v. a.) ttam, 
+
+TTÂKEW, TTÂTCHIKEW, U ne peut 
+
+saisir sa voix, il ne peut le corn- 
+
+
+
+YAW

--- a/OCR/Peel/289.txt
+++ b/OCR/Peel/289.txt
@@ -1,0 +1,83 @@
+289 
+
+
+~ åkwåtch | 
+
+
+AKW 
+
+min pour passer devant lui; v. g., 
+
+kakwe åâkwåskaw mayowes wå- 
+
+yo e ayât, tåche de lui couper 
+
+, Chein avant qu'il soit loin. 
+
+« ÂKWÂSKAM, ({ad.) davantage, 
+. plus; v., g., äkwäskam musta- 
+winam, d en désire davantage. 
+
+«ÂAKWASKISPAYIW, ok, a, (a. 
+van. etin.}il, ou, ca agit comme 
+voulant couper chemin, voulant 
+passer par devant. 
+
+« ÂK WASKINEw, (v. a.) NAM, NI- 
+WEW, NIKEW, îl le lient dans ses 
+bras, A le tient à brassées; v, g., 
+âbittasiyaw äkwaskinaw, il est 
+tenu par le milieu du corps. 
+
+«AK WASKITINEw, (0. a.) NAM, Ni- 
+WEW, NIREW, idem. 
+
+e ÂKWASKISKAWEW, ` {v. a) KAM, 
+
+KÂKEW, TOHIKEW, d lui coupe le 
+
+
+chemin en passant devant lui, en 
+
+
+` ¡faisant un détour: ~: 
+
+“x AK WAN, frac.) couvrir, abriter, 
+“mettre un couvercle. kb 
+
+«u AKRWANÂHWEW, Io, a.) HAM, RO- 
+WEW, HIKEW, i le couvre, recou- 
+
+me oet 
+
+t : AKWANINEw, (o. a. a) NAM, NI- 
+NEW; NIKEW, idem." 
+
+D AKWANÂSMEW, (0. a.) TTITAW, 
+SIMTWEW, SITCHIREW,, idem. 
+
+` AKWANÂHUVW, ok, (v. r.) i se 
+couvre. 
+
+
+« AKWANÂHUWIN, a, (n. f. cou- 
+‘| verture, chale, couverte. 
+
+
+« AKWANÂnYEw, (D. a.) .STAW, 
+` YIWEW,, TCHIEEW, i- le plače en le 
+“couvrant. 
+
+
+Je ARWANAEOHwEr, (v. a.) BAM, 
+t ÂKWåSra wiw: (oi a.) SA ål 
+
+
+'HUWEW, HIKEW; $ g le couvre, E 
+un vase. 
+
+
+H 
+
+
+en, 

--- a/OCR/Peel/290.txt
+++ b/OCR/Peel/290.txt
@@ -1,0 +1,75 @@
+AKW 290 > AKW 
+
+u AKWANÂBOHIGAN, a, (n: f.) 
+couvercle d'un vase, d'une chau 
+dière, ete. ` 
+
+«AKWA NÂBOW ESIN, Gil 
+(a. a,).il est couvert. 
+
+« AKWANABOWETTIN, a, la. 
+in.) idem. . - 
+
+D AR WANAKEWEW, DN D n.) 
+il se couvre le visage. >, 
+
+
+ment, v. g. Mustuswok misiwe 
+akoskamok - askiy, Les bufles 
+
+. Couvrent la terre. e, 
+
+x AKWEB, qrac.) émbarrassant, 
+“qui prend beaucoup: di place, 
+beaucoup, en grande quantité. 
+
+` AKWEBÉS (ad.)quand ong be. 
+` coup de: choses, jusqu'à! eñ, étre 
+embarrassé; v.g: akwébés oa. 
+
+& AKWANÂKKWEswWEw, HAM,| yåwâwok kinusewok, We der 
+BUWEW, HIKEW, OU, akokkweh- j... poissons bn'abandance.: 
+wew, OU, akokkwepitew, d. lui l'e AKWEBISIW, ok, (a; aji est 
+couvre le visage. . rembarrassänt, etjil est embarrassé, 
+
+€ AKWANÂRK WEPTrew, ra a.)| ila beaucoup de choses qui Tem- 
+TAM, SIWEW, TCHIKEW, À lui] , barrassent; .0..g:awiyak/weyo- 
+bande le visage. sit, mistahi. akwebisiw måna, 
+
+« AKWANÂKKWEPISUWIN, a, | . celui. qui est gichg,a -bequeoup, de 
+(n. f.) couverture du visage. — "1 choses.à soh wan, u, 
+
+« AKAWÂYIK, (ad.) à l'abri, Al ARWEBAN, wa, (a. Zei gest 
+couvert, v. g. akawäyik pimut| embarrassant. pi 
+tew, 2 marche à l'abri, akawâtik, “ ARWEBEYINEW, In. a) vru 
+à l'abri du bois, de la forêt, ika | ` MIWEW, TOHIREW. ù ki trouve em- 
+
+: wâmalin, à labri dela montagne, barrassant. ` 
+` akawätin, à l'abri de la colline- | « AKWEPAPIW, ak, (a. EI d'est 
+
+d AKAWÂBIKKWEW.: ok, la: 2) | embarrassant, D: A quélguun qui 
+
+ü a les yeux couverts. : occupe trop de place. ` : 
+
+« AKAWÂBIKKWEnwew; (D. a. TAKWEPASTEW, a Ca (ER 
+HAM, HUWEW, RIREW, il lui couvre. c'est embarrassant pari le volume, 
+la vue. c'en r 
+
+« AKAWÂKKWEPImEw, bo. "ail ARWEPIKEW,. (g: EN KAM UNI 
+` TAM, SIWEW, TORRENT, il luibande| ra, MIKEW, Ü n sait trop tom- 
+
+les yeuz, > -° Hi | ment le “plâcer' à cause Ka Tem- 
+
+« ARAWAWESIMOW, okla. Al barras, "7 "Ji 
+
+. U semetà labri de quelque chose | x AKWAN, (rac.) la méme queiele 
+« AKAWÂWEsmew, (0. a.) dn" ci-dessus, à egent, ar ai 
+
+TAW, MIWEW, "reen il le place! b AKWANOKNOWEW; oki (vin) 
+à l'abri. il parle à mots couverts, Ù purk | 
+« AKOSIMOW, ok, (a. vj comme, en paraboles. ` 
+
+f akawäwesimow. i H AKWANOKIJ eise," (0 a) 
+
+« AKOSKA WEW, (v. a.) an. sirge |- - TAM, SIWEW, "TCHIKËW, Ù lui parle 
+TCHIKEW, Ù le couvre complète- à mots couverts, en paraboles. 

--- a/OCR/Peel/291.txt
+++ b/OCR/Peel/291.txt
@@ -1,0 +1,163 @@
+DES Tan, 
+
+
+et 
+x 
+
+
+AKW 
+
+
+-1 AKWANOKDOWEWIN, a, {n. 
+£) parole à cotivert, parabole. 
+
+xAKWETTAW, (rac.j. doubler, 
+mettre Pun sur Vautrei ‘ {7 47. 
+
+ÅKWETTÂWAuTEW,{0. 0.) STAW, 
+YIWEW,”TCHIKEW, Ù les met Fun 
+sur autre, vu LOS a? 
+
+ÂKWETTÀWIK Wåtew, W: a.) 
+TAM; STOEN, TCHIKEW, di Bez coud 
+Tun sur. l'autre, il le double: 
+
+1ÂKWETTA WESKISINEW,. ok, 
+-(v. n} u met double‘vaire de sau- |- 
+liers bity “ayilovettämreskisinonr, 
+(ed) 
+
+à ÂEWETTAWESAKEW, ok, (v. 
+
+YU mei doublé habit, capot. 
+
+b AK WETTAWEWEYONISEW, |: 
+ok, (v. n.) il ane ‘double. habille. 
+ament WA A PARENT =: 
+
+4 ARWETTA WAPLW, i ok, { (a. r.) 
+KI nustusweyänak äkweita. 
+wapiwok, les robes dë bufles sont 
+
+| En las les unes sur les, dures. 
+
+
+ei sh N°? 
+
+
+ARWETTAWASTÉW. : a, Je. CAM 
+
+
+c'est doublé, DN "est. Lun. Sur. ll autre. 
+*AKUST, (rac.) tremper dans Peau, 
+mouille, a in 
+« ÀKUSTI EW, Wa a. one, MEN, 
+Zen i le met dans l'eau. 
+` AKUSTABA een, D ai: TAW, 
+TIVEW, ICHIREW,, idem... ' 
+«ÅKUSTIMOW, ok, { n: a.) 
+
+
+mouillé., Ké ` 
+
+
+Lie PU Lit. 
+
+(ARD IN was 
+mourié.: POLE Qui ACTA 2 je 
+
+*ÂJIW, {rac}. incapable, 
+réussit pas. ` - y 
+
+« AJTWISIW ok Ae, aY D ne e réus- 
+st pas, : {synonëmes). nayoyuw, 
+akawisiw. - j 
+
+
+`o 
+Wi 
+
+
+10 est 
+KÉ 
+
+
+Ms, 
+oi ne 
+
+
+D 
+
+
+29t 
+
+
+{ax in), C'est 
+
+
+N D 
+
+
+AMA 
+
+
+« ÂJIWAN, wa, (a: in. ) £a n'arrive 
+Das, £a ne réussit pas, nama aji- 
+wan, ça arrive toujours, sans 
+` faute, vg. ekuyikok aåninama 
+Awam eka kitchi mispuk, c'est 
+letemps qu'il neige sans faute. 
+
+« ÂTIWEY new; (D. a.) Tran, MÉ 
+
+` WEW; TOHIREW, il le pense inca- 
+pable de faire telle chose, de réus. 
+sir, ele, nama'kekway m lâjiwe- 
+yidaw Kijemanito, je pense 
+` Dieu capablé de réussir en toutes 
+
+- choses. 
+
+D ÂMAK, wok, (n: r.) aiguille pour 
+lacer les raquettes. ` 
+
+x AM, {rac. faire fuir, faire peur, 
+
+` AMBew, Io, a } TAM,. MIWEW, 
+TOBIREW, À le fait fuir, v. g. quel- 
+
+. o un gui veut ahprocher un ani- 
+“mal, sauvage, et en faisant quel. ` 
+. que bruit, ille fail fur, il lipou- 
+
+
+DÉI vanie. a 
+
+
+t AMåaew, Im. oi TUAW, HIWEW, 
+: TCHIKEW, idem. Lu 
+
+` AMÂHAMÂwEw, w., a.). TAM, 
+-REW, TOHIREW, A lui fait. fuir, d 
+est la cause que, l'animal, dur 
+autre fuit. 
+
+
+D AMÂWEHAMÂvwew, (v. a. ` TAM, 
+
+
+EE, TCHIREW, idem... 
+
+D AMÂTAMÂAWEW, {v. 2.) idem. ? 
+
+«AMÂWEKAHIKEW, ok „Ww. ind.) . 
+ou le fait. fuir, en frappant « avee ` 
+` une hache.. `, 
+
+« AMÂWEswew, In. a ju, SIWEW, 
+SIKEW, À le fait fuir en tirant du 
+usil. 
+
+« ‘AMATISUW, ok, d vi d eslaus 
+aguéts, il craint quelque surprise, : 
+il est sur ses gardes. 

--- a/OCR/Peel/292.txt
+++ b/OCR/Peel/292.txt
@@ -1,0 +1,158 @@
+` AMA 
+
+
+« AMATISUWIN, a, (0. 
+d'étre surpris. di 
+
+« AMATIBUSTAwWEw, (v. oi TAM, 
+TÂREW, TCHIKEW, craint quel- 
+que surprise de sa part, il se 
+
+. garde contre lui. WW 
+n AMATISUSTAMÂwEw, Ai 
+TAM, KEW, x 
+aguëts. sur son compte, V. g. éoko 
+
+| iskvéw amatisustamâwew oko 
+ sissa, cette femme craint Aer? son 
+fils. Note. Toute cette racine: DS 
+dique qu'on est effrayé, qu'on est 
+
+. aux aguels parce qu'on À TU, Où 
+gwon croit avoir vu quelque 
+chose; ce qui est bien différent 
+d'un autre mot, astäsiw, qui pa- 
+
+
+rait signifier la même chose. et) 
+
+
+qui cependant est bien différent. 
+
+XxÂMAT, (rac.) monter une cóte, 
+une élévation, hauteur. 
+
+« ÂMATCHIWEW, ok, (w. n.) d 
+monte une côte, üne colline. Note. 
+La terminaison tchiwew, indique 
+une colline, montagne, ‘v. d. nit 
+tatchiwew, A descend une colline. 
+
+ÂAMATCHIWEYAW, (a. in.) test 
+en montant, c'est une hauteur. 
+
+« AMATCHIWETCHAW, Ia. in.) 
+c'est une hauteur de terré, qui! va 
+
+` en montant. 
+
+« ÂMATCHIWEHEW, (2. u:) TTAW, 
+HIWEW, HIREW, Ù le monte. 
+
+ÂMATCHIWEPITEw, (v. a.) TAM, 
+
+SIWEW, TCHIKEW, il le monte en 
+le tirani à lui. 
+
+e AMATCHIWETISAHwEw, In a. . 
+HAM, HUWEW, HIKEW, A Je fait 
+monter promplement. 
+
+« ÂMATCHIWE WIN, a, (n. f.) une 
+
+
+montée. 
+
+
+292 
+f.) crainte |« MATGHTWESKANAW, a, (n. 
+
+
+
+
+
+o, 
+TCHIKEW, À cst. ‘aux ` 
+
+
+
+
+
+AMISK, wok, In. 
+« AMISKOWEWS "hie" KE 
+
+
+ÂMI 
+
+
+fà chemin pour monter." à 
+
+
+« ÂMATIN, terminaison wi désigne ~ 
+
+
+une montagne, butte, colline, v. 9 
+takkuichâmatin, sur la monja- 
+gne, awasâmalin, "de Tautre côté 
+de la butte, aslamämiatin, de ce 
+côté de la colliné; ; alors ces mots. 
+-sont des advérbes, et në se didi- 
+nent, pas. 
+
+
+AMATITTE, | ad.) (ée DH el d'au- 
+
+
+res, comme, pikonatä ite. 
+
+
+ÂMI, od) presque, ‘kekâtch, sa 
+
+
+RE 
+
+
+mais seul comme keki, DN 
+
+n Yami miyik, il me le dimme 
+presque,. il a été sur le “point de 
+me le donner, “ébaniyik "a 
+
+
+.âmi takusiniwok, démain ils; ar- 
+
+
+riveront presque (probablement ) 
+r:\castor. 
+
+
+castor... 
+
+
+aboa 
+
+
+D AMIS OWAN, CH e in) at 
+
+
+du castor, e 
+
+
+D AMISEWEYAN: ak, d f.) peau 
+
+
+de castor; ‘avec le poil N. Leier, 
+minaison weyän désigne une peat 
+avec son poil, Ai cenom ainsi for. 
+mé a la qualité des noms animés, 
+v. g., mustus weyän' ak; dE 
+de bufles avec le poil; osekamisk, 
+wok, castor’ éparé; dépécé; awe- 
+tis, ak, -petit “castor; poyawésls, 
+ak, castor d'un an; patamisk, 
+wok; eier de deux ‘ans’? nàbe- 
+misk, wok, le castor mâle; ‘noje- 
+
+
+` misk, wok. la femelle. À S 
+ÂMIW, ok, (w. n.) le poisson froi- ~ 

--- a/OCR/Peel/293.txt
+++ b/OCR/Peel/293.txt
@@ -1,0 +1,141 @@
+ÂMI . 293 
+
+
+ANI 
+
+
+ÂMIWIN, g (e | LL ‘temps du|« ANAEWÄES Aerm, (v. a.) KaM, 
+
+
+ON 
+
+ÂAMOW, ok, (n. D A abeille, grosse 
+quépe. > 
+
+ANAKKÂTCH, lad.) | N. D est très- 
+dificile de traduire ce ‘mot, qui 
+veul dire à peu. près: quelque chose 
+qu'on regrette, et. qui, “quoique de 
+peu de valeur, cependant a sa va- 
+leur dans la position où ça se trou. 
+ve Des exemples feroni, mee) 
+comprendre. Anakkäich ki webi- 
+naw eoko mistiküs, cest regret- 
+table que tù rejellès” cê petit "bois 
+(sous-entendu) quoique de peu de 
+"be, pourtant il aurai} été uli. 
+le; anakkatch èokól ça vaut 
+
+
+x ANÂSK, 
+
+
+i ANÂSK ATTOWEW, 
+. idem... ~- 
+H ANÂSKASUW, ok, (v. n.) 
+
+
+KÂKEW, TCHIKEW, d lui fait des 
+manches. ` - 
+{(rac.) étendre quelque 
+chose par terre, ete. 
+
+
+«ANÂSKEW, ok, (v. n.) i étend 
+
+
+quelque chose par terre. 
+
+
+« ANÂSKATrEw, (v. æ) TAM, SI- 
+. WEW, TOHIKEW, d lui étend guel- 
+
+
+que chose par terre, pour s'asseoir 
+ou se coucher. - 
+TWÂREW, 
+
+
+met, un tapis sous wi il ¿lend ` 
+quelque chose par terre pour > 
+servir de tapis, ou de lit, 
+
+
+dee ` 
+
+
+mieux que. rien, c'est toujours «ANÂSKATTEW, a, (a. in.) c'est 
+quelque chose ; 0 miyopimälisiyi, tapissé, la place est. préparé pour 
+anakkáich ` “ka “kikkami, Cest| sy asseoir, ou pour s'y coucher. 
+pourtant uin bon vivant, d'est re-|« ANÂSKASUN, ak, (n. f.) tapis, 
+gretlable guii D dispte ; anak- pièce- pour mettre sous soi. ` 
+kâtch ni wanittân, Ze régrette del ANÂH, (pro.) celui là; pg., ànâh 
+
+
+lavoir perdu, .quoique Jee ‘n'était |. 
+
+
+pas grand'chose; anakkåtch ki 
+webinaw, épiwek Er ka ki åbät- 
+jita; c'est regrettable que: tù le 
+rjeltes, tu aurais pu Pen servir; 
+anakkâtch: ni, wi-miyikottäy, 
+cest regrettable .que.la-chase soit 
+arrivée : ainsi, pourtant il voulait 
+me donner elo, 
+
+ANAKATCHAY 7 Leo? admiration 
+pour quelque chose d'ectraordinai. 
+ré; V. g., anakatchäy. tâpwe mi- 
+sikitiw kit em! combien ton che. 
+val est gros! :- i 
+
+ANAKKWAY, ak, in. Dt manche 
+d'un habit: n'otanakkwän, j'ai 
+des manches ; Kiskanakkwäy, ak, 
+"anche coupée, rognée. 
+
+
+nË’stes ka petchâstamuttet, celui- 
+
+
+là mon.frère qui s'avance ; eoko- 
+ni Abt ka pakamahwät, c’est ce- 
+lui-là qu'il a frappé. 
+
+
+« ANIKI, (pro. pl. an. l'ceux-là ; D. 
+
+
+ER eokonik aniki ka ki nipaité- 
+ketjik; ce sont ceux là ‘qui ont fait 
+un meurtres aniki eka ka ot 
+ayamihätjik, ceux qui ne veulent 
+
+
+' pas prier. - 
+ANDÉ, 
+
+
+ou, ANDA, (ad.) par là, en 
+quelque part; v, g., andè ka as- ` 
+tek ki mokkumån, gest en quel- 
+que`part par. là qu'est ton couteau. 
+
+
+AN I, (ad. } (aprèš'le mot} pour donner 
+plus de force à ce que Ton dit; 
+
+
+v. g., lâpwe.ani, c’est bien vrai; : 
+ota ani, cest ici; ni wi-ituttän 
+
+
+ANI 294 . ANI 
+
+
+ani, je veux y aller assurément, | « ÂNITTawew, (v. oi TTAM, TTÅ- 
+
+
+ki wittamärinawaw ani, je vous 
+le dis done. Ce mot sert à faire

--- a/OCR/Peel/294.txt
+++ b/OCR/Peel/294.txt
@@ -1,0 +1,113 @@
+af- 
+firmer plus fortement ce que l'on 
+avance. . 
+
+ANIYÉ, lad.) oh emploie. ce -mot à 
+peu près comme ani; v. g., ot- 
+&kkusittäy aniyé, d était malade 
+en effet alors; sipwettew aniyé, 
+le voilà partidonc; takusin ani yë, 
+le voilà donc arrivé. On Fentend 
+aussi dire quelquefois devant le 
+mot; v. g. , aniy ka "och 
+alors que jelai vw’: 
+
+ANATA, (ad.) (après le mot) assuré- 
+ment, 'oroiment, comme kusha; 
+v. g., wiya anata, c'est Jui assu- 
+rément. ' d 
+
+ÂNIHUW, ok, (v. n.) à dépérit, il 
+maigrit, par esemple- un- animal 
+
+` après avoir trop travaillé. 
+
+4 ÂN IHUREw, (v. a.) TTAW, lge 
+` TCHIKEW, A le fait dépérir. : | 
+
+x ÂN, (rac.) penser autrement, con- 
+tredire, désobéir ; äniseyimew, 
+ttam, Anisistawew, tam, il le 
+désapprouve. | 
+
+
+A ÂNIxEw, (D. ol TTAM, wen, 
+
+
+TCHIKEW, Ù le réprouve, par sel 
+
+
+paroles, il n'approuve pas sa con- 
+quite, V. ga quelqu’ un qui dirait : 
+je n'approuve pas sa conduite, moi 
+je ne ferais pas. ainsi. 
+
+
+(ÂNEYInEw. jo. a.) TTAM, MIWEW, 
+TCHIKEW, Ù mapprouve pas sa 
+conduite, dans sa pensée; v. g., 
+n'täneyitten niya, eoko nama 
+ekusi ni pa toten, Je n'approuve 
+` pas cela, je ne ferais pas ainsi. 
+
+
+CÂNWEYImEw, etc., idem. 
+
+
+KEW, TCHIREW, : (d lui désobéit, d 
+n'approuve pas ses paroles; 3. g, 
+awiyak ayânittawâtji ayamihe. 
+wiyiniwa tâbiskotch e Anittawät 
+-Kije manitowa, celui qui dén, 
+béit du.préire, désobéit à Dien, 
+« ÂNWETrawew, etc., idem. 
+« ÂNIKKEMOW, ok, te. n.) il ré 
+prouve, 1} désapprouve. 
+ÂNWETTAKEWIN, a,H{rf.) dé 
+sobéissance. Sa 
+ÂNITTAMOWIN, A. Jm idem. 
+ÂNIKKEMOWIN, a, Io, fı} iden. 
+« ÂNISInEw, (V. a.) TTAW, HIWE, 
+TCHIKEW, 1 en détruit l'efet. On 
+emploie. ce mol:quand quelqu'un 
+par ses médecines: détruit Tefa 
+d'un poison.pu d'op Sortie, et 
+ÂNISITCHIGAN, a, (nf) con- 
+tre-poison, remèderebhtraire; v 
+` o, ayamihewinanatäwihuwin 
+nisitchiganiwiwa pâstähuwine 
+Akkusiskäkuyak, Les, sacrement 
+- sont. des contrepoisons contre le 
+péché qui nous, rend malade. 
+« ÂNISIHIW EWIN „a, (n f) idem. 
+ANIMA, (pro. in), celui-là: eoko 
+anima, ki mokkumän,, cat ton 
+couteau celui-là. E. 
+ANIHI, (pro. in. pl) ceur-làre. UD 
+eokani anihi ki mokkumána, a | 
+
+
+z 
+
+
+{ 
+
+
+ii 
+
+
+H 
+
+
+{ 
+
+
+ANISIKIS, (ad. 1 £ “est, | pourquéi, 
+donc ; comme, tasipwa,. tesikole; | 
+v. g., anisikis ki miyin, dons fu 
+me le donnes: anisikis. namawiya 
+kika, sipwettån, ginsi. fu.ne par, 
+
+-tiras pas; anisikis pamawiya ki 
+wi- äyamihäo, 'eka ko pe kiski 
+` nohamäkusiyan, done, ainsi, H 

--- a/OCR/Peel/342.txt
+++ b/OCR/Peel/342.txt
@@ -1,0 +1,183 @@
+ISA. i 
+
+
+« ISAWÂNAKEYI M OTOrawEw, 
+(V. 0.) TAM, TÂKEW, TÂTCHIKEW, 
+idem. 
+
+o ISAWÂNAKEYIMOW, ok, (v. 
+n.) i est jaloux, voy. sawânake- 
+yimow. 
+
+x ISÂ, (rac) malgré lui, avec peine, 
+se faire violence. 
+
+« ISÂHUW, ok, (v. r.) d se modère, 
+‘il se retient, il se corrige, mais en 
+
+
+D 
+
+
+" se faisant violence, v. g. namawi-|. 
+` ya ki isâhuw, t ne peut se-corri. 
+
+
+ger, il ne peut venir à bout de tel 
+
+
+défaut, ayis namawiya ni ki is4- | 
+
+
+hun, qu'y faire, je ne puis m'en 
+` corriger, je ne puis m'en empécher. 
+
+
+. MISÂHEW, (v. a) TTAwW, RIWEW, HI- f, 
+KEW, Ñ le modère, ù le corrige, il |: 
+Teimpêche de faire telle chose, maïs |, 
+
+
+ce west qu'en lui faisant une sorte |: 
+de violence. 
+
+
+H 
+
+
+
+
+
+xISÂW, (ras) carré. 
+
+
+«ISÂ WESIW, ok, ES zl 
+
+
+carré, ayisiwesiw. 
+
+
+&. «ISÂWEYAW, CHE? in.) ce c'est car- |; 
+
+
+ré, ayisäweyaw: ` >, : 
+
+«ISÂWEK, wok aiguille carrée, ow, 
+asåwek, wok. 
+
+K ISÂWEswzW, {v. a) SAM; steen, 
+
+
+` SIKEW, Tl Je taille carré. ouer: un |: 
+
+
+— Couteau, EI? ciseau.. EE 
+g ISÂWEnEw, (v. ai NAM, | NIWEW, | 
+
+
+NEW, ile lientavec la. main:par |: 
+
+
+la. partie, carrée; ou, coupante, | 
+
+
+pop la racine asåwe; ‘qui est. al 
+
+
+
+
+
+342. 
+
+
+` sit:lrcomme il est insensé! ichish! à 
+
+
+i 
+
+
+VU la main vers lui.» 
+
+
+ISI 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+méme que celle-ci pour la. signif- 
+cation. 
+
+« ISÅWEnEw, (v. a.) rraw, HIWEW, 
+HIKEEW, d le fait carré, N.B, Tous 
+ces mots se disent plus souvent 
+avec le redoublement, ayis, et. | 
+C'est. pour cela probablement qu'on 
+dit indifféremment isåwe, ou, ayi- 
+såwe. 
+
+x IS et IT, (rac.) ainsi, decetie me À 
+nière, de celle for me, de cetle fa- 
+con. 2 
+
+« ISI; ou, UE devant le verbe, ainsi, 
+` comme ep, v.g ekusi iji, cet À 
+
+‘ainsi,ej: kijewätisit, étant ainsi À 
+charitable, awåsis ka iji-miycsit, $ 
+l'enfant qui est sibeau eji matchi- 
+kukäk, nama ni ka sipwettån, 
+vú qu'il fait ainsi mauvais temps, 8 
+` Ze ne partirai pas, eji-kàkebåti - 
+
+
+en 
+
+
+' : > eji-pikupayik „ni. mokkumän ! 
+vois donc, comme:mon couteau est, 
+brisé! ekusi piko n'v- iji-kiske- H 
+-yitten,, jene le sais que. de celle 
+. manière, Jesus-Ghrist. ki pe-ilut 
+„tew waskjtaskamik: eji-manito 8 
+-wit mina eji-ayisiyiniwit, Jésus. Wi 
+Christ. est venu surla. terre comme EE 
+Dieu et commehomme, eji-atché $ | 
+kowik, mina. eji owiyawik,. W 
+mee en corps: : Ea 
+kb «HITCHITCHEYIW, ok, w AN ` 
+
+étend:la: main vers. = i 
+D 0 IFC HITCH EN Trape ip. a 2 
+GO TÂREW, TÂTORIKEW; AM Se 
+
+
+4 LITGHTORE VITOm vew t F 
+a.) -eté ‘idem: ` D? zi 
+
+LU ISTW, ok, sorte. de. verbe: wf Si 
+.aire, comme; Dé ayaw, dot, z 

--- a/OCR/Peel/362.txt
+++ b/OCR/Peel/362.txt
@@ -1,0 +1,139 @@
+KAK 362 " KÂK 
+
+
+` x KAKEBÂTISIW, ok, (a. a.) Ale KAKESKWEWIYINIW, ok, [n 
+n'a pas d'esprit, il a un caractère| f.) un précheur, un prédicateur, 
+bouché. Ce motvient probablement|« KAKETTÂWEW, ok, (v. n) 
+de la racine kepa, ou, kippaw,} comme nittâwew, € a Tusage de 
+qui veut dire bouché, fermé, avec| la parole, il a la parole en bouche, 
+le redoublement ka. > >. v. g. un enfant qui a déjà bien 
+
+« KAKEBÂTEYIxEw, (v. a) TTam,} Tusage de la parole, on dirail : ka- | 
+MIWEW, TCHIKEW, le trouwe fou, kettåwew. 
+
+
+insensé. KAKETTÂWEVInEw, TTAN, dk 
+« KAKEBÂTISIKKEW, ok, (v. n.) | . trouve prudent, ingénieur. 
+il agiten insensé. . KAKETTÂWÁÂTISIW, ou, kakel- 
+
+
+e KAKEBÂTCHITTWAW, ok, id. | tâweyittam, dest prudent, homme 
+« KAKEBÂTISIKKE WIN, a, (n.f)| de génie. 
+
+
+D 
+
+
+x folie. x KÂKI, (rac.) supplier, s'humilier 
+“eu KAKEBÂTOHITTWA WIN, a, en présence de, cte., ete. 
+(n. f.) idem. . « KAKISIMOWIN, a, (n. f.) sup- 
+
+
+plication humble. ` 
+
+« KÂKISIMOW, ok, (v. n.) isup- 
+plie avec larmes, avec humiliti. 
+
+« KÂKISIMOTOTAWEW, (v. ayran | 
+
+
+« KAKEBÂTISIKKATTEW, (v. a.) 
+TTAM, SIWEW, TCHIKEW, fl se 
+prend en insensé pour agir avec 
+lui, il s'y prend mal pour le ga 
+gner yP PO e g - TÂREW, TCHIKEW, à le supplie en 
+
+i | . s'abaissant, v. g. notta ki pekt 
+nu KAKEPITTEW, ok, (a. a.) i est kisimototâtin kitchi kitimäkeyi- 
+
+
+urd, il a les oreille es." 
+sourd, il a l s bouchées miyan, mon père, je viens te sup- 
+
+
++ KAKESKImEW, (V. a.) TTAM, MI plier d'avoir pitié de moi. 
+WEW, TCHIKEW, Ù le conseille, OI, KÂKITOrKAwEw, (0. a.) EKAN, 
+l'avise, il l'avertit. o KÂKEW, TCHIREW, Ù s'humilie de 
+
+« KAKESKIMIWE WAN, a, (n. EI vant lui, en lui faisant des bas- 
+conseil, avis, voy. la racine kiski. sesses, (ce dernier, mot. doit s'en- 
+
+«KAKESKIMOW, ok, ou, kakes.| tendre à la façon du pays) 5. 
+kikkemow, ok, (v. n.) à fait des| ek kisiwähât onäbema, ekwa 
+instructions, il donne des avis;|  pe-käkitokkawew, ayani fait H 
+c'est le mot reçu pour dire: il pré-| cher son mari, ell- vient lui fare 
+che. des bassesses. `, 
+
+` KAKESKIMOWIN, a, ou, kakes- |‘ KÂKITOKKÂSUW, ok, Im. mi 
+kikkemowin, a, (n. D instruc-| fait des bassesses, À reconnait st 
+
+
+lion, sermon. faute. ' 
+« KAKESKWEW, ok, (v. n} com-|« KÂKITOKKASUWIN, à, (n. f 
+me kakeskikkemow. bassesses, humiliation, soumission | 
+
+
+« KAKESKWEWIN, a, (n. f.) com-] « KÂKITITuew, jn. o) TTAW, ` 
+me kakeskikkemowin. ` WEW, TCHIKEW, il le console, P . 
+
+
+supplie de se consoler. 
+fois on emploie aussi ce mot, en 
+religion pour dire, il l'apaise, v. g. 
+Kijemanitowokosissân ki kâkit- 
+jihew ottäwiya, le fils de Dieu a 
+apaisé son père, kåkitjih kisimis 
+ka mâtut, console ton petit frère 
+qui pleure. 
+
+RRUTITHTWE WIN, ‘a, (i f. ) 
+action de consoler quelqu un qui 
+pleure, 
+
+1 KÂKITJIHISUW, ok, (v. n) il se 
+console, il cesse de pleurer. -~ 
+
+(KÂKITJIHISUWIN, a; (n. f) ac- 
+tion de se consoler dans les pleurs. 
+
+KÂKITJINEW, (0. a.) TTAM, Mi- 
+
+
+WEW, TCHIKEW, il lui parle en le: 
+
+
+consolant; (peu usilé). 
+
+KÂKITISIW, ok, (a. a.) il est sen- 
+sible v. g. quelqu'un qui a du mal, 
+qui, st on le touche un peu, pous- 
+sera un eri. 
+
+« KÅKITISIWTIN, a, (n. Gi sensibt- 
+lité, Voy. la racine kit. 
+
+1 KÂKITJIMOW, ok, (v. n.) il ne 
+fait que parler dé son mal: {il vou- 
+drait le faire ressentir à tout le 
+monde.) 
+
+*KAKISTIW, ok, (a. a) d est 
+d'roud, impudent, grossier, pour 
+empoigner tout ce qui lui tombe 
+sous la main. - 
+
+t KAKISTIWIN, a, (n. f) effronte- 
+rie, impudence: - o’ 
+
+KAKISTWEW, ok, (w. n} u 
+parle avec efronterie, 
+
+(KAKISTWEWIN, a, (n. f. 
+role d'éfronterie. Yoy. 
+kist. , 
+x KAKI, oc) avec orgueil, vanie- 
+rie, Le 
+
+
+} pa 
+la es 

--- a/OCR/Peel/471.txt
+++ b/OCR/Peel/471.txt
@@ -1,0 +1,115 @@
+MOS —~ =A MUT 
+
+
+, MOSKUMEMOW, ok, (v n) d 
+plure de faim. ` 
+:MOSRUWÂTEw, (v. al TAM, SI- 
+WEW, TCHIKEW, il pleure après 
+lui. i 
+
+CMOSKWEYITTAM, wok, In. n.) 
+sa douleur éclate., son chagrin se 
+fait jour. 
+‘MOSKUYÂWESTW, ok, (a. a) 
+idem. A 
+
+
+TT, 
+mik, ce n'est pas de sitôt gui il sera 
+printemps. : 
+
++ MUSTCHI, (ad. et rac.) ou, mu- 
+tchi, à nu, à découvert, sans mé- 
+lange, ag jour, simplement. 
+
+« MÜSTAWÂN, c'est sans mélange- 
+
+H MUSTASKUSAWEW, ok, (v. n.) 
+il fume sans: mélange, il fume le 
+tabac pur. 
+
+«. MUSTAzwEw; (v. d.) HAM, ĦU- 
+
+` WEW, HIKEW, À lui touche à nù, 
+il le saisit à nu: - 
+
+D MUSTINEw, (In. ol NAM, NIWEW, 
+NIKEW, d le saisit avec la main 
+nué. Ai 
+
+« MUSTARYEW, A D” a. } STAW, Tt 
+WEW, TCHIREW, d le fait connai- 
+tre, d le met à nu. , 
+
+« MUSTÂBUIY, a, (n. f.) liquide 
+pur, sans mélange, de l'alcool. 
+
+« MUSTÂGAMIW, a, (a. in.) idem. 
+
+«MUSTÂWEYImEw, (V. a.) TAM, 
+MIWEW, TCHIKEW, d le désire, il 
+soupire après lui. 
+
+« MUSTAWINawE y, (V. a.). NAM, 
+NÂKEW, NÂTCHIREW, il le désire, 
+en le voyant.r 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+louche, i il l'affecte, il le touche Jus- 
+qu'aux larmes. 
+
+tMOSKITIIWAN, wa, (n. f.) uñe 
+fontaine, une source d’eau. ! 
+
+:MOSKITJIWANIPEK, wa, (n.f.) 
+idem, 
+
+MOSKINEw, (e, a) NAM, NIWEW, 
+"era, il le découvre, il le fai 
+voir à découvert. . 
+
+:MOSKTPTrew, (V. a.) TAM, SIWEW, 
+
+
+MOSKIW, ok, (v. n.) à se décou- 
+vre, ilse montre.  ‘ 
+MOSKINEW, ok a, (a. a. et in.) 
+
+
+MOSKINAHEw, (v. 0.) TTAW, HI 
+NEW, TCHIKEW, À le remplit jus- - ` 
+qu'au faite. « MUSTAWEYITTAMAWE W, 
+
+AMONJIHEw, al Traw miwew, |. … CbC., (V. a.) il lui désire. 
+
+TCHIKEW, dl le sent, d le. ressent; | « MUSTAWINAMÂWEW, etc. i 
+(lant au physique qu'au moral) |` luienvie 
+
+*MONSIHUW, CHE éprouve « MUSTUTTEW, ok, (v. n.) il mar- 
+“ne sensation * * che à pied, il va à pied. | 
+
+MONJITTOYU W, ok.{v.r. ) idem, | « MUTCHIK, (ad. } à terre, à terre 
+
+NONJTTTAWIN, a; (n. f } šensa-| nue. i 
+tom « MUSTASKAMIK, (ad.) idem. 
+
+'MOJIHUWIN, a, Ur. y idem, i MUSTASKAMIKISIN, wok, IER 
+
+MUSEWÂK, (ad. ) pas de sitôt. Voy.| a.) il est étendu sur la terre nue. 
+
+t Mayo (nama mayo) v.: g. nama-|« MUTCHITON, (@d.) de vive: vois. 
+Wich musiwâk tchì 'mıyoska- « : MUTCHMIYEW, (v. a.) il lu

--- a/OCR/Peel/502.txt
+++ b/OCR/Peel/502.txt
@@ -1,0 +1,128 @@
+NIS 
+
+
+a NISWEYAKISTW, ok, (a. a.) ù 
+‘est en deux facons. 
+.(NISWEYAKIHUW, ok, {a a.) 
+idem. 
+« NISWEYAKAN, wa, (a. in.) c'est 
+en deux facons. . : 
++NISOWISIW, ok, (a. a.) il est 
+nonchalant, faible, incapable, im- 
+puissant, ele. 
+“ NISOWISIWIN, à, (n. f) inca- 
+pacité. 
+
+
+«NISOWAN, wa, (a. in.) cest 
+faible, sans vigueur. 
+«NISOWÂTISIW, ok, (o, a.) caràc- 
+
+
+tère indolent. 
+« NISOWÂTISIWIN, a, Ia, D ) în- 
+"  dolence, incapacité morale. 
+
+« NISOWEYInew, (v. ol Tram, 
+MIWEW,.TCHIKEW, à le pense in- 
+capable; il le pense sans foree. ` 
+
+« NISOWEYIMISỌW, ok, (v. r.) 
+
+© U s'abaisse, il s'humilie. 
+
++ NISIT, (rac.) comprendre, recon- 
+naitre, | 
+
+« NISSITAW, (ad.) Ce mot ne pa- 
+rait s'employer qu'avec la néga- 
+
+` dion, v. g. nama nissitaw, ca ne 
+convient pas nama nissitaw kitchi 
+påppiyan anotch, ça ne convient 
+pas que tu ries à présent. 
+
+« NISSITAWEYluew, (0 a.) rram, 
+MIWEW, TCHIREW, d le comprend, 
+il le reconnaît dans sa pensée. 
+
+H NISSITA WInawsw, (v. a.) Nå- 
+KEW, NAM, NÂTCHIKEW, il le re- 
+connait en le regardant. : 
+
+« NISITOTTAWEW, (v. 
+'TTÅKEW, TTÂTCHIKÈW, Ù le com- 
+prend, il entend ce qu'il dit. 
+
+« NISSITOTTAM, wok, (o al d 
+comprend, 
+
+
+502 
+
+
+a.) TTAM, | 
+
+
+NIS 
+
+
+«a NIESITOTTAMOWIN, a, (nf) 
+intelligence. 
+
+« NISSITOMATJIHUW, ok, (v. r) 
+il connaît ce qu’il ressent, 
+
+« NISSITOMEW, etc., (v. a.) ù lui 
+fait comprendre, ou mieux, il lui 
+fait souvenir. Voy. Miskawäso- 
+mew, kiskisomew. 
+
+« NISSITOSIW, ok, {a. a.) ila lo- 
+dorat délicat, Cependant ce mot 
+
+_est reçu pour dire: il est gras, il 
+est en bon état, il est.assez gras. 
+
+« NISSITWAW, a, c'est assez gras, 
+c'est d'un assez bon goût. . 
+
+« NISSITOS Diego, (v. a.) TAM, St 
+WEW, TCHIKEW, Ùl en reconnait le 
+goùt. 
+
+D NISSITOSPWEW, ete., Ip. a) 
+idem. 
+
+« NISSITOTTÂKUSIW, ok, (a): 
+
+` iest compréhensible, intelligible. 
+
+« NISSITOTTÂKWAN, wa, feat) 
+idem. à 
+
+H NISSITAWARÂTISIW dk (a. 
+a.) avec la négation seulemént, v. 
+o. nama nissitâäwäkätisiw, d est 
+idiot, incompréhensible: 
+
+` NISSITA WE YITTAKUSIW, ok, 
+
+. (a. a.) il est reconnaissable. 
+
+« NISSITÂ WE YITTÂKWAN, wa, 
+(a. in.) idem. | 
+
+« NISSITOTTA M One, (t. a) 
+TTAW, CHIWEW, TOHIREW, Ù lu 
+fait comprendre. ` 
+
++ NISTA, (ad.) aussi, de méme, pa; 
+reillement, v. g. nista matehipi: 
+måtisiw, lui aussi vit mal, pistas 
+ki ka nipin, toi aussi tu mr. 
+TaS. >, 
+
++ NISTA, (pron. } moi aussi, kista, 
+toù aussi, wista, lui aussi. , 
+

--- a/OCR/Peel/514.txt
+++ b/OCR/Peel/514.txt
@@ -1,0 +1,150 @@
+OSÂ 
+« OSÂ WÂBISKISIW, ok, (a. a.) d 
+
+
+est jaune, du fer. 
+
+« OSÂWÂBISKAW, wa, 
+idem. 
+
+« OSÂWAÂBAÂN, ak, (n. f.) bite. 
+
+v OSÂWÂBEW, ok, (a. a.) il a de 
+la bile, il est bilicux. 
+
+- «a OSÈWAÂBUIY, a, (n. f.) liquide 
+jaune. 
+
+« OSÂWEGIN, wa, In. f) étoffe jau- 
+ne, indienne jaune. 
+
+v OSÂWEKAN, wa, (a. in.) il est 
+jaune, en parlant d'étoffe, d'indi- 
+enne. ` 
+
+H OSÂWISKUSIW, oh, (o, ol A 
+luit, il brille par le jaune. 
+
+` OSÂWISEWAN, wa, (a. in.) id. 
+
+« OSÂWISK WA W, (v. im.} soufre 
+
+. En pierre. 
+
+"uv OSÂWAKKESIW, ok, Un. re 
+nard jaune. 
+
+« OSÂWAKKWANEW, 
+flamme jaune. 
+
+a OSÂWASK, wok, (n. EN ours jau- 
+ne ` 
+
+XOSEYAW, a, (a. in) c'est en 
+côteau, c'est une hauteur. 
+
+« OSESIW, ok; (a. a.) il est en for- 
+me de dos, de côteau. 
+
+———QSESKAMIKAW, (v. Zo.) terrain 
+élevé. 
+
+v OSETCHAW, (v. im.) terre en 
+
+orme de côteau. . 
+
+« GSETINAW, fo, im.) colline, có 
+teau. 
+
+« OSEYÂBISKAW, (v. im.) rocher 
+en forme de côteau. ` 
+
+« OSETTUY, a, (n: r.) la queue de 
+la raquette, 
+
+« OSI, pl. osa, (nr) canot ; mistikosi, 
+canot de bois; waskwäy osi, ca- 
+
+
+(a. 
+
+
+in.) 
+
+
+(v. im) 
+
+
+614 
+
+
+OSI 
+
+
+not d'écorce de bouleau: nos, 
+mon canot; otos, son.kanol : mi- 
+soltakaw, grand canot, 
+
+x OSARWEW, (V. A.) HAM, HUWEW, 
+HIKEW, à le lève, il le fait fuir 
+
+« OSISKAWEW, (v. a.) idem. 
+
+« OSAHIKEW, ok, (v. ind.) d fai 
+fuir, v. g, quelqu'un qui va à la 
+chasse, et qui, en faisant du bruit, 
+fait fuir Panimal qu'il approche, 
+
+, qu'il guette. 
+
+OSIPIW, ok, (v. u.) il remue l'eau, 
+
+V. g, Un caslior qui nage -enire 
+deug eaux. ` 
+
++ OST, et, OJI, {rac.} faire, créer, 
+manufaclurer. 
+
+« OJTHEw, (v. ol TTAW, HIWEW, 
+
+\TCHIEEW, À le fait, il le crée. 
+
+« OJIHUMAGAN, (v. r. in) ça sè 
+forme. 
+
+« OSITCHIKEW, ok, OI 
+crée, il opère. 
+
+
+id) îl 
+
+
+Fa OSITGHIKEWIN, a, (n. f.) cria- 
+
+
+tion, opération. 
+
+« OSITCHIGAN. rak, a, (n. f.) créa- 
+ture. 
+
+« OT OJIBIWEW, ok, (nf) } de eré- 
+ateur, 
+
+« OSITTOWE W, (v: a.) il le lui fait. 
+
+« OSITTAMÂwew, (0. a) il le fait 
+-à sa place. - b 
+
+«OSIKKIPIMIW, ok, (v. n) à a 
+un clou, enflure, un furoncle. 
+
++OSIKAMISK, wok, (n. f.) castor, 
+éparé et séché. De la racine osik, 
+qui se.rétrécit, ©. g., quelque cho- 
+se; qui; en:séchant, devient moin- 
+dre. 
+
+& OSIKÂKATOSUW, ok, (a. a)i 
+se rétrécit en séchant. E 
+
+« OSIKÂKATOTEW, a; (a. in.) id-

--- a/OCR/Peel/576.txt
+++ b/OCR/Peel/576.txt
@@ -1,0 +1,137 @@
+PON 
+
+
+« PONI-AYAMIHAW, ok, (vzn) d 
+finit de prier. 
+
+u PONI-AYAW, ok, (v. n.) tl cesse 
+d'étre, d'exister. ` , 
+
+« PONIVÂWESIW, ok, (a. a.) il 
+cesse d'étre fåché. 
+
+« PONINOKUSIW, ok, (a. a.) i 
+disparait. 
+
+« PONINOKWAN, wa, (a. in.) id. 
+
+« PONINONIVW, ok, (v. n.) à cesse 
+de téter. >. NEE 
+
+« PONINOYEW, Sie, (0. a.) elle le 
+
+
+sévre. 
+
+
+` a PONI-PIMÂTISIW, ok, (a. a) d 
+
+
+cesse de vivre. . 
+« PONIPAYIW, ok, a, (a. a. et in.) 
+ca cesse, ça finit d'agir. ` 
+
+
+. a PONIWITJEWEW, etc., (v. a.) 
+
+
+_ Ù se sépare de lui. o 
+« PONIYOTIN, (v. im.) le vent s'ap- 
+
+
+|, paise, 
+
+
+« POYUW, ok. (v. n.) il cesse da- 
+gir, il se désiste. 
+
+
+` POYUWIN, a; (n. f) cessation, 
+
+
+désistement, 
+
+x PONEW, (b. a.) NAM NIWEW NI- 
+KEW, îl alimente le feu avec lui, 
+‘il s'en sert commè de bois v. g. 
+matchi-manito ponew owebi- 
+
+
+` nikowisiwa, le démon alimente 
+
+
+le feu avec les damnés, (ou, les y 
+jettent). , 
+« PONAM, wok, (v. n.) A alimente 
+le feu, il met du bois dans le feu. 
+« PONIKÂTEW, a, (a. in) le feu 
+est préparé, fait.” 9 
+POUS, ak, chat. | . 
+POSÂKKWÂMIW, ok," (a. a) d 
+dort profondimenta `- 
+x POSIW, ok, (v. n.) il embarque 
+
+
+576 
+
+
+POS ` 
+done un canot, barge, navire, et il 
+monte, dans unevailure sur terre. 
+« POSITWIN, a,.{n. f) embarque. 
+
+
+ment. 
+
+
+« POSIHEW, (o. a.) TTAW, HIWEW, 
+TCHIKEW, d l'embarque, lil le fait 
+embarquer, il le fait monter en 
+voiture. 
+
+« POSIPA YIW, ok, a. (a. a. et in.) 
+ca entre dedans, ca embarque, v 
+g. posipayiw nipiv, d'eau embar- 
+que, entre dedans. 
+
+« POSITT À SU W, ok, (v. n) à 
+charge, v. g. un navire. ` 
+
+« POSITTÂSUWIN, a, {n:f.) char- - 
+ge d'un canot, ou, action de le> 
+
+. charger. | 
+
+« POSIWEBINEw, (V. a.) NAM, St 
+WEW, NIKEW, d l'embarque en le 
+jetant dedans. E 
+
+« POSIWEPARWEw, (V. a.) HAM, 
+HUWEW, HIKEW, i} d'embarque en 
+„lui doùnant une secousse. ` 
+
+« POSISKISIW, ok, (a. a) ú est 
+
+7 concave. - 
+
+« POSISKAW, a, {a. in.) idem. 
+
+« POSISKIHE W, etc, (v: a) à le 
+
+| fait concave.. 
+
+POSKU, (préfize,) dans le méme 
+temps, dans le méme espace, v. 8. 
+posku kijik, le méme jour, posku 
+pipon, dans le cours du même hi- 
+ver, posku tibisk, dans l'interval 
+de la nuit, posku wäskähigan, 
+dans l'étendue de la maison, DS 
+
+` ku säkahigan, dans Pespacé du 
+ée, posku kijik takusin, il ar- 
+rive le méme jour (qu'il est parti). 
+
+x POSK; trac.) crever, éclater, foire 
+
+. explosion. ` 

--- a/OCR/Peel/581.txt
+++ b/OCR/Peel/581.txt
@@ -1,0 +1,128 @@
+SÂK 581 SAK 
+
+
+i SÂKIHÂGAN, ak, (n. n. f) amant, 
+
+, favori. ` 
+
+ı BÅHIusW, (V. ol TTAW, HIWEW, 
+TCHIKEW, d Faime, il y est atta- 
+ché, il ne veut pas s'en détacher. 
+
+SÂKIHTWEW, ok, (v. ind) ü 
+dime. 
+
+s SÂKIHIWEWIN, a, (n.f.) amour 
+pour, affection 3 pour, etc. 
+
+` SÂKIHIWEWINIWIW, ok a, 
+(a. a. et in), u est amour, c'est 
+amour. 
+
+ISÂKIHIWE WISIW, ok, le d 
+Ù est'amoureuzr. ` 
+
+1 SÂKIHITUWOK, ek m. D s'en- 
+tr'aiment. 
+
+"SÂKIHITU WIN, a, (a. f:) amour 
+mutuel, ' 
+
+«SÂKTAIKUSIW, ok, {a aji est 
+aimable.. `. 
+
+SÅKIHIKWAN, wa, (a. in.) idem. 
+
+‘SÂRIHIKUSTWEN, a, Ia f) 
+amabilité. 
+
+b SAKIBIKOWIN, a, in, f re action 
+d'être aimé. - ` 
+
+«SIRIHIKO WISTW, il est aimé 
+par Dieu, ` 
+
+«SRTHIKOWISTWIN, a, (n. El 
+action d'être aimé par Dieu. 
+
+‘SÂKIHISUW, ok, (0. rd s'aime. 
+
+í SÂKIHISUWIN, a, We E) amour 
+Propre — 
+
+ISÂKISTW, ok, (å: a. Y il est avare, 
+il aime son bien. N.-B. Ce mot et 
+le suivant, se disent toujours avec 
+le redoublement, ainsi, säsäkisiw. 
+
+« SÅKISIWIN, a, (7. Di (sâsäkisi- 
+win, a,) avarice; amour de son 
+bien. ` 8. 
+
+SÂKITTIW, ok, (a. a. A ite 
+
+
+H 
+ss, 
+
+
+d'a Les pieds nus. Voy. la racine 
+plus loin. 
+
+x SAKK, (rac. attacher à, agraffer, 
+accrocher, embarrasser dans, etc. 
+
+« SAKKAPPIrrw, (V. a.) Tax, SI- 
+WEW, TCHIREW, d l'altache, v. g. 
+à un poteau, 
+
+« SAKKAPPISUW, ok, ta. a) il 
+` est attaché à, etc. , 
+
+« SAKKAPPITEW, a, (a. in.) idem. 
+
+«SAKKÂBÂTEW, (v, a) TaM, st ` 
+WEW, TCHIKEW, A l'y attache, il le 
+coud à. 
+
+« SAKKIPÂTEW, etc., (v. a) idem, 
+il le boutonne. . 
+
+« SAKKIPÂSUW, ok, (u.n.) i se 
+bouionne, il agraffe ses hibits. 
+
+« SAKKIPÂSUN, a, (n. f.) bouton, 
+agraffe. Voy. Aniskamän. ` `. 
+
+«SAKKÂSK WA HWwEw, (v. a.) 
+HAM, HUWEW, HIKEW, A lagraffe, 
+4 le. boutonne, ü l'attache, il l'en- 
+laçe. 
+
+« SAKKÂSKUHEW, etc. (v a) 
+idem, il l'agraffe, etc. ` 
+
+« SAKKÂSKWAHUN, a, (n. f) 
+bouton, agraffe. ` 
+
+« SAKKAMEW, (V. a.) TTAM, MIWEW, 
+
+C remxew, Ù le tient serré! entre ` 
+ses dents. ` 
+
+cSAKKAnwEWw, (v. ol HAM, HU- 
+WEW, HIKEW, il le cloue. 
+
+1 BAKKAHIGAN, a, (n. f.) clou, 
+. cheville. 
+
+« SAKKAHIGANIS, a, (n. f) petit 
+clou, pointe. . 
+
+1 SAKKAMOW, ok, a, (a. a. et in.) 
+il y'est cloué, attaché. 
+
+« SAKKAMOnEW, (. a.) TTAW, HI- 
+
+` WEW, TCHIKEW, Ù l'y attache, en 
+le clouant. ) 

--- a/OCR/Peel/616.txt
+++ b/OCR/Peel/616.txt
@@ -1,0 +1,149 @@
+616 
+
+
+TET 
+
+
+«a TEPISIWIN, a, (n. f.) contente- |a TEPITTIN, wa, (a. dn. Vd 
+
+
+ment, satisfaction. 
+« TEPIYÂ WESI WIN, a, (n. CH. dd. 
+« TEPIKKWÂMIW, ok, (a. a) ila 
+assez dormi. 
+
+
+« TEPImEw, eie, (v. ol i lui parle |. 
+
+
+suffisamment, ou, il le contente par 
+Ses paroles. 
+
+« TEPIMÂKUSIW, ok, (a.a.) à rem 
+plit la place de son odeur. ` 
+
+
+.« TEPIMÂK WAN, wa; (a. in.) id.. 
+. #TEPINEw, (0. a.) NAM, NIWEW, NI 
+
+
+KEW, ù peut y atteindre. avec sa 
+main. . 
+
+` TEPINAMÂwEw, Si: t. aj à 
+lui en fourņit-assez. - 
+
+
+« TEPISxAWEW, (D. a.) EAM, KÂKEW: 
+
+
+, KÂTCHIKEW, il lui. va bien, v, g., | 
+ni tipiskawåwok ni wikwepå- 
+"pak, mes pantalons me vont bien, 
+
+tepiskàm omaskisina, ses souliers 
+lui font bien. 
+
+« TEPISUW, ok, (a. 
+fumé. 
+
+« TEPIPEW, ok, (a. 
+bu. 
+
+
+a.) À a assez 
+
+
+D TEPIPUW, ok, (a. a. U d a assez . 
+
+
+mangé. 
+
+« TEPISKITEHEW, ok, {a. aji a 
+le cœur fatigué, accablé. 
+
+A TEPIPAYIHIKUW, ok, (o pass.) 
+` ilen a assez, ça lui suffit, ` 
+
+` TEPITTAKUSIW, ok, (a. zi E 
+
+est bien enlendu., ~. 
+
+«TEPITTÂKWAN, wa, (a. în.) Vid. 
+
+UTEPITTAwWEwW, (V. a.) TTAM, Tri 
+
+
+. TCHIKEW, d l'entend bien, il saisit | 
+
+
+“assez Se voir, il l'entend sufisam- 
+ment. 
+
+
+« TEPISIN, wok,. (a. a). il est con- 
+venable; il s'ajuste, îl est juste. 
+
+
+a) il a assez |. 
+
+
+a TEPIsmEw, (V. a.) TTITAW, si. 
+WEW, TCHIKEW, il ajuste, die 
+fais joindre., 
+
+xTEPIYÂK, (ad) (saltem, au 
+‘moins, du "moins, v. g, tepiydk 
+ekawiya ekusi tota, au moins ne 
+fais pas cela, 
+
+x TEPWEW, ok, (v. a.) d crie, à 
+
+- appelle, 
+
+t TEPWE WIN, a, (n f) cri. 
+
+« TEPWÂrTEW, (v. a) TAM, SIWEW, 
+_TCHIKEW, il l'appelle, il lai crie, 
+aussi : dert guff danstèglise eie 
+
+« TEPWESKITTEW, ok, {v. n. } ls 
+oreilles" lui Maien) A © 
+
+«x TET, (rac).être. dessus ec. F. 
+
+H TETTARYEW, (0. a.) STAY, FIVE, 
+TOHIKEW, die met dessus, \' 
+
+« TETTAPIW, ok, (a. u.) Ù est as- 
+sis dessus, c'es dire, il est d 
+cheval, v. o. quelqu'un : qui. cs à 
+cheval. ` 
+
+TETTÂÅPÅTEW, ok, d est à cha 
+sur lui, =" 
+
+« TETTAPIWIN, ak, (n. f) ce sur 
+quoi on va à cheval, le cheval. ' 
+
+« TETTAPIWIN, a, (n H siège, 
+chaïse, banc. 
+
+« TETTAPIHEw, etc., (v. lf 
+. sied dessus. 
+
+« TETCHIKWASKUTTIW, dun 
+
+n.) i saute dessus. 
+
+|u FETCMIPAYIW, ok, a. H o 
+
+in.) A mônle sur, ett- 
+
+D TETCHIPÀYIHUW, ok, pr 
+-ü s'élance desus, il monte'dessus. 
+
+« TETCHIPAYIHUSTAWEM), ete, 
+w a.) à fonte. Sur quelqu'un, 
+- ete. N. B. Òrdinairement c'est em- 
+. ployé dans le sens impudique. 

--- a/OCR/Peel/636.txt
+++ b/OCR/Peel/636.txt
@@ -1,0 +1,43 @@
+WA 636 Wis 
+
+
+v WÂPISKEYÂPEGAN, wa, (a. 1 WÂPITEYAW, ok, a, (a.0.et in.) 
+in.) idem, (une corde.) idem. 
+« WÂPISKAYOWINISSEW, ok, |ı WÂPITTAKAHIGAN, à, (n. f) 
+(a. a.) il a des habits blancs. ` vi craie, ou, wâpigan, a. 
+` « WÂPISKIKÂTEW, ok, {a. a.) div WÂPUS, wok, (n. f.) lapin, lièvre, 
+a les jambes blanches. , miståpus, gros lièvre de prairie, 
+« WÂPISKIMEw, (v. a.) Traw, mr-|( WÂPUSWÉYAN, ak, (n.f) peau 
+WEW, TCHIKEW, il le anchis, ille] de lièvre avec le poil. 
+rend blanc. [a WÂPOWEYAN, a, (n. f} cou 
+x WÂPISKIAUW, ok, (v. r.) West] verture blanche. 
+habillé en blane. « WÂPÂWAKKAW, (v. im) boue 
+« WÂPISKIPEn wew, (0. a.) gan, blanche, sable blanc. , 
+HUWEW, HIKEW, il le peinture en «t WÂPATÂWOKKAW, (v. im.) 
+‘blanc. f : idem. , 
+u WÂPISKWAKUP, a, (n. f.) cou- |°% WÂS, {rac.) en forme de baie, une 
+verture blanche, . anse dans un lac. 
+« WÂPEKINIGAN, a, (n.f.) c'est te |t WÂSAKÂM. (ado. ) autour de l'a 
+tabac que s'envoient les sauvages, | du lac. 
+qui est enveloppé dans une peau |t WÂSAKÂMEW, ok, (0: n.) ive 
+` blanche, ou, un morceau de coton. | autour du lac, de l'eau 
+Cet objet a ccompagnetoujours Les |t WÂSAKÂMEWIN, a, (n. f} action 
+ambassades et il est fumé en con-| d'aller autour de fen, : 
+seil ou rejeté, selon qu'on accepte |« WÂSAKAMUTTEW, ok, (v.n) i 
+la pair, ou qu'on rejette ce qui est| marche autour de l'eau. - 
+proposé. - u WÂswew, [V o ) SAN, SUWEW, St 
+« WÂPISKOWEW, ok, (a. a.il est| xew, il le coupe à lentour, 
+cendré. blafard. « WÂSÂPEW, ok, (v. n.) d taile 
+D WÂPISKOWES, ak, (n. f.) cen-| . autour: v. g., tailler des cordes 
+dré, il a le poil blafard. ` aulour d'une peau. b 
+« WÂPISKASÂAKAY, a, (n. f) ca-lu WÂSAHIGAMAW, (v. im) ya 
+pot blanc, habit baue une baie (dans un lac.) 
+« WÂPISTÂN, ak, (o. f.) martre. x WÂSK, (méme racine) autour, D 
+N. B. On se' sert presque loujours | Tentour, en cercle. 
+du diminutif, wâpistänis, ak. o WÂSKÂPAYIW. ok, a, (a a. à 
+« WÂPISTIKWAÂN, RM (n. f) téte] in.) il tourne en cercle, en rond. 
+blanche. « WÂSKÂPAYIEUW, ok, (v. r) 8 
+D WÂPISTIKWÂNEW, ok, (a. a.) tourne en rond;. en "faisant des 
+il a la téte blanche. mouvements. ` i 
+a WÂPITEW, ok, (a. a.) fané, pále, | « WÂSKÂPÀWIWOK, je e il 
+brun, de couleur sale. sont debout en rond; 

--- a/OCR/Peel/660.txt
+++ b/OCR/Peel/660.txt
@@ -1,0 +1,148 @@
+YÂK. 
+
+
+v. gy yêkki ot ayåttay peyak ayi- 
+siyiniw, jadis il y avait un hom- 
+me, ekusi otiji hikäsuttay: yäkki, 
+(videtur sic nominalum esse.) 
+
++ YÂKWÂMEYIMEW, (0.0.)TTAn, 
+
+
+MIWEW, TCHIKEW, il est attentif 
+
+
+auprès de lui, prévenant, il s'en 
+occupe beaucoup, il lui fait la cour, | . 
+det persévérant auprès de lui. 
+A B. Pour cette rac. et ses déri. 
+
+
+ves, c'est la méme chose, que ayåk- 
+
+
+wåâmeyimew. : 
+
+H YÂKWÂMEYIMOW, ok, (w: n. ) 
+il est persévérant, ù donne ses 
+soins de plus en plus. 
+
+« YÂKWÂMEYIMO WIN, a, (n. f) 
+persévérance, attention. 
+
+«YÂKWÂMIMEw, etc., (v, a.) à 
+Fencourage, il est sans cesse à lui 
+parer de cela. 
+
+« YÂKWÂMISIW, ok, (a. a.) i est 
+
+
+, Sur ses gardes, précautionné, cir- | 
+
+
+conspect, (cautus, providus), per- 
+sévérant. 
+H YÂKWÂMISIWIN, a, 
+Sévérance, prévoyance, précaution. 
+x YÂS, ‘(rac.) descendre, s'abaisser. 
+D YÂSÂPEK Inew, (w: à) NAM, NI- 
+WEW, NIKEW, ille descend, il la- 
+baisse au moyen d'une corde, v.g, 
+“abaisser un pavillon, ‘une voile, 
+ete. 
+‘a  YÂSINEw, Ia, oi de, désend avec 
+la main. 
+` YÂSIPAYIEUW, ok, (v. r. ) as va: 
+_ baisse, ùl se glisse en bas. 
+` YÂSIPAYIW, ok, a, (a. a. et Ni 
+` d destend, il va en bas. ' 
+« « YÂSIPA YInew, In, a.) TTAW; BI- 
+
+
+‘WEW, TCHIKEW, d le descend, A le, 
+
+
+lait’ s'abaisser. Ès 
+
+
+660 
+
+
+
+
+
+
+
+
+Géi 
+
+
+Eise 
+
+
+
+
+
+
+YÂW 
+
+« VASITINE W, etc., (v. a.) il Pen- 
+voie au bas, il le descend à lerre. 
+
+a YÂSITISAHAMÂWEW, ete., (v. 
+
+a.) ille lui descend à terr D 
+
+« YÂSISTAWEW, etc, (V. oi 
+descend vers lui, v. g Jesus- 
+Ghrist ki ki pe-yâsi-täkonow, 
+Jésus-Christ a descendu vers nous. 
+
+« YÂSITOTAWEW, ete, (v. a) 
+idem. >- 
+
+a YÂSIW, ok, (v. ai D descend d. 
+s'abaisse vers la terre. 
+
+« YÂSIWIN, a, (7. f.) descente, ac. 
+tion de descendre sur la terre. 
+
+« YASASKEW ok, (v. n.) il des- 
+cend sur la terre. : 
+x YÂTTOKAMIK, od) Voy. Ayåt- 
+tokamik, dans une autre maison, 
+
+dans une autre loge: 
+
+x YÂW, (rac.) indique qu'il nya 
+pas assez, insuffisant, étre Dréi 
+de ‘manquer avant d'atteindre, 
+au. dessous. , . 
+
+«YA WÂPANMEW, (v. a) TTAN, 
+EKEW, etc., A ne peut le voir par- 
+
+` cequ'il est trop loin, sa vue n'est 
+pas assez longue pour le voir. 
+
+«VA WImawEw, (V. a) Nim, Ni 
+KEW, NÂTCHISEW, idem. N. A 
+
+Toute cette racine renferme l'idée 
+-dë nottow. Voy. plus haut. 
+
+« YÂWINÂKUSIW, ok, (a a)i 
+esthors de vue, il est impercep- 
+tibié. 
+
+« YÂWINÂKWAN, wa, (a. in.) id. 
+
+« YA WINEW, (v. a.) NAM, NIWEW,' 
+NIREW, A ne peul le saisir avec la 
+main il ne peut l'atteindre. 
+
+« YAWASIrrawEv, (v, ol TTAM, 
+
+TTÂKEW, TTÂTERIKEW, Ù ne peut 
+
+saisir sa ; voie, ailne peut le com- 


### PR DESCRIPTION
Added the OCR-transcribed versions of the LaCombe pages which have already been manually transcribed. The Oxford OCR was left out due to severe transcription errors resulting in significant portions of some pages being missing, as well as due to the generally poor quality of the Oxford OCR overall.