### PR TITLE
Added Full Manual Translation of LaCombe

### DIFF
--- a/translations/FullManualLaCombe.txt
+++ b/translations/FullManualLaCombe.txt
@@ -1,0 +1,14453 @@
+ÂBA
+
+x ÂBAT (rac.) Useful, suitable for rendering service, make use of.
+« ÂBATEYImew, (v. a.) TTAM, MIWEW, TCHIKEW, he finds it useful, he thinks he likes to be of service, v.g. misiwe âbateyimâwok mistatimwok, horses are found useful everywhere; ayamihawin eoko piko osâm âbateyittamuk; only find religion useful, or, there is only one thing needed, religion.
+« ÂBATEYITTÂKUSIW, ok, (a. v.) he deserves to be done a service, to be helped.
+« ÂBATEYITTÂKWAN, wa, (a. in.) it is considered useful.
+« ABATEYITTAMOWIN, a, (n. f.) utility, the act of thinking about something useful, v. g. nijinwa âbateyittamowina, wâbiwin, mina pikiskwewin; there are two things worthy of being useful thoughts, the sight and the word.
+« ÂBATJIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, this word has two meanings, it means: he uses it, and he helps. This, however, does not cause ambiguity, because the nature of the sentence is ordinarily sufficient to understand in which sense it is used, v. g. pepoki n't'âbatjihâwok attimwok, in winter I use dogs, kekway ke âbatjittâyan? what are you going to serve? nama kekway n't'âbatjittân, I have nothing to use, or, I have nothing to help me ,âbatjimkuk ki nikihikowâwok, render service to your fathers and mothers, mitchetwaw âbatjihew witjayisiyiniwa, often it is useful to his neighbor, ata ni ki âbatjihâwok eka ka wiâbatjihitjik, despite all that I have done for them in service, they don't want to be useful to me.
+
+279
+
+ÂBA
+
+x ÂBATISIW, ok, (a. a.) it is useful. The ending atisiw always indicates the character, v. g. tepwe mistahi âbatisiw ayamihewiyiniw, in truth the priest is very useful, nama nando itâbatisiw, he is of no use, it is for iji. this way, this way, kekwanok etâbatisiyan? what are you good for?, or, what profession are you?
+
+ÂBA
+
+« ÂBATAN, wa, (a. in.) It is useful. This word is used in many sentences, v. g. âbatan paskisigan, the rifle is useful, âbatan emiyo pimâtisik, it's useful to live well, eoko piko âbatan ota askik, that's all you need is here below.
+« ABATISIWOKEYIMEW, (v. a.),TTAM, MIWEW, TCHIKEW, he thinks it useful, he firmly believes it to be useful. This word is different from âbateyimew, which means, he finds it useful, while âbatisiwokeyimew, he believes so etc.
+« ABATJITJIGAN, a, (n. f.) tool, instrument.
+« ÂBATJITJIKEWIN, a, (n. f.) action of using something.
+« ABATJIHUW, ok, (v. r.) He offers service, it is useful to itself, v. g. âbatjihuw e sipwettet it is useful for him to be gone, namawiya kit âbatjihun orna ka totaman, you're doing yourself a disservice, where do you hurt yourself by doing that, nikân ni wi âbatjihun, firstlyI want to be useful, or, I want to see for myself.
+« ÂBATJIHISUW, ok, (v. r.) idem.
+« ABATJIHUWIN, a, (n. f.) The action of being useful to oneself.
+« ABATJIHITUW, ok, (v. m.)' He helps himself, he helps one another. This verb in singular, is a misunderstanding in French, yet in Cree, one uses it a few times like this, v. g ni peyaku-âbatjihitun, I am alone to help me, e âbatjihituk âbatan, it's a useful thing to help one another, appo âskaw âbatjihiluwol pijiskiwok, so even that the animals help each other sometimes.
+
+280
+
+ÂBO
+
+« ÂBATJIHITUWIN, a, (n. f.) action of helping each other.
+ÂBISK, ending denoting metal or stone, v. g. mikkwâbisk, wa, red metal, maskawâbisk, wok, hard stone.
++ ÂB (rac.) To return to, etc., to return.
+« ÂBAMUW, ok, (v. n.) He returns on itself, v. g. to see behind.
+« ÂBAMIKÂBAWIW, ok, (v. n.) He turns himself while standing. The ending kâbawiw indicates the action of standing.
+« ABASÂBIW, ok, (v. n.) he returns to see, he looks back
+« ÂBASÂBAMEW, (v. a.) TTAM, MIWEW, TCHIKEW, while looking back, he sees it.
+« ÂBAMUSTAWEW, (v. a.) TAM, TÂKEW, TCHIKEW, he turns around on him, v. g. I'm chasing an animal, all of a sudden if he turns around on me, I would say n't'âbamustâk.
+« ÂBAMUTJIWAN, wa, current turning back on itself, v.g. a river where there are eddies. The tjiwan ending indicates a stream.
+« ÂBOKKÂWAW, a (a. v.) idem.
+
+ÂBA
+
+« ÂBAMEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he's thinking about it again, he regrets it.
+« ÂBEWEYIMEW, TTAM, he thinks he knows, he believes he has discovered knowledge, he thinks he is so.
+ÂBITTAW, (ad.) Half, v. g. âbittawaskinew. it is filled to half, âbittaw miyin, give me half, âbittasiyaw, half of the body, âbittawikijikaw, the half day, noon, âbittawitibiskaw, half the night, half night.
+AHÂSIW, ok, (n. r.) Crow, so named after his cries ha ha.
+AHUYA! or, ahussa! (ex.) express sudden pain, for men; women say o! o!
++ A, (rac.) Place, put, put down.
+AHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he places it, nahayew, or, miyo ahyew, he places it well.
+AIHETTÂN (ironically). This word is difficult to understand, it is close to synonymous with tiyakwatch and from appo, v. g. ahettân kitîmâkeyimew e matchi ayiwiyit, he takes pity on it no matter how cruel it is, aihettan kaskittaw, kutaka eka e ki kaskittâyit, it comes to the end, and the one who seemed more capable did not perform as he could have done, or, look now as it comes to pass, (with) he that we did not not suppose capable, aihettan nipahew maskwa, o nejowisi! he really has killed a bear, this sloth! we would therefore use this word, when something happens, or is done differently than what we would naturally be inclined to believe. See the root ajiwa.
+
+281
+
+AKÂ
+
+AKAKKWAY, ak, (n. r.) Leech.
+AKAKKWÂTJIMIN, ak, (n. f.) snail
+AKAKKWE, (irony.) it's to be believed that, v. g. akakkwe ituke ke totak, it looks like he's going to do it.
+AKÂM, ending indicating water, v. g. tchikakâm, close water, close to shore, âbittawakâm, in the middle of the water, a river or lake, ayitâwakâm, on both sides of the water.
+x AKÂM (rac.) on the other side, from the other side.
+« AKÂMIK, (ad.) On the other side of the river or lake; otakâm, of this side.
+« AKÂMASKIK, (ad.) On the other side of the earth, but this word is perceived as meaning across the sea; v. g. akâmaskik ituttew, he goes to Europe.
+« AKÂMÂTTIK, (ad.) On the other side of the woods, forest.
+« AKÂMÂSKWEYÂK, (ad.) Idem; N. B. âttik and âskweyaw, are endings that indicate wood, v.g., neyâttik, or, neyâskweyaw, point of wood.
+« AKiMISKUTEK, (ad.) On the other edge of the fire.
+« AKÂMÂYIK, (ad.) On the other side; N. B. ayîk is a kind of local term, v. g., tchikâyik, close to the; awasâyîk, there, further.
+« AKÂMAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he places it from the other edge
+
+AKÂ
+
+« AKÂMAHAM, wok, (v. n.) he goes from the other side of the river or lake.
+« AKÂMAPIW, ok, (a. a.) he is seated on the other side.
+« AKÂMASTEW, a, (a. in.) it is placed on the other side.
+« AKÂMIPEK, (ad.) On the other side of the water; pek is an ending which has the same meaning as akâm, v. g., tchikakâm, or, tchikipek, near the water.
+x AKAM, (rac.) more, in addition, further, etc.
+« AKAMIPAYIW, ok, a, (a. a. and in.) it surpasses, it acts more; N.B. payiw is a very common suffixal adjective which is attached to a large number of roots
+« AKAMOTINEW, (v. a.) NAM, NIWEW, NIKEW, he takes more, in addition, v. g., akamotinam wiyâs eyikok ka ki miyak, he takes more of the meat than I gave to him
+« AKAMABITTAW, (ad.) More than half, or, half more, v. g., nijwattày akamâbittaw nitipahamâk, he pays me two more (furs) and a half; mitâtatasiwok akam niyânan, there are ten of them, plus five.
+« AKAMEYIMOW, ok, (v. n.) it takes courage, he hastens, v. g., akameyimow e wi ayamihât, it takes courage to pray; akameyimuk tchi ​​kiskinohamâkawiyek, hurry up to get educated.
+
+282
+
+AKÂ
+
+« AKAMWEW, ok, (v. n.) he encourages himself to speak.
+« AKAMImew, (v. a.) TTAM, MIWEW, TCHIKEW, he encourages him by speech, v. g., akamimik kit awâssimissak kita nitta-atusketjii encourage your children so that they know how to work.
+« AKAMEYImew, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks it takes courage, ardor for, etc., he wishes him courage.
+« AKAMIKkawew, (v. a.) KAM, KÂKEW, TCHIKEW, he encourages himself to act on it.
+« AKAMÂTEW, (v. a.) tam, idem.
+« AKAMIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he busies himself a lot with him
+« AKAMEYIMOWIN, a, (n. f.) encouragement.
+« AKAMEYIMIWEWIN, a, (n. f.) idem, action of encouraging.
+« AKAMINEW, (v. a.) NAM, NIWEW, NIKEW, he takes more,additionally, like akamotinew.
+« AKAMISIW, ok, (a. v.) He always wants to take more.
+AKASK, wok, (n. r.) Arrow which has a large end.
+AKASKOW, ok, (n. r.) Doing.
++ AKÂW, (rac) without purpose, uselessly, hardly.
+« AKÂWÂTGH, (ad.) With difficulty, v.g., akâwâtch takusin, it happens with difficulty; akâwâtch pimâtisiw, he barely saw.
+« AKAWI (ad.) Without purpose, without reason, v. g., akâwi nakatam, leave it for no reason.
+
+AKÂ
+
+« AKÂWISKAW, ok, (v. n.) it works or proceeds unnecessarily.
+« AKÂWUTTEW, ok, (v. n.) Idem.
+« AKÂWISIW, ok, (a. v.) he is mentally unwell, half mad, loony, crooked in character, he acts unnecessarily.
+« AKÂWÂTISIW, ok, (a. v.) idem, N. B. âtisiw, is a suffix which designates character, v. g., miyowâtisiw, he is a good character; sokkâtisiw, it is of a strong character.
+« AKÂWAN, wa, (a. in.) that which does not not succeed.
+« AKAWAKKAMIKISIW, ok, (a. v. in.) he busies himself without reason, he is acting unnecessarily.
+« AKÂWAKKAMIKAN, wa, '(a. v. n) it does not give any result,it is without purpose, this action. N.B. The animate and inanimate suffixes, kkamikisiw, kkamikan, denote the action of being busy, to occupy oneself, v. g., tanisi etakkamikisiyan? what are you occupied with? what is bothering you? tanisi etakkamikan? what is the news? what is bothering you
+« AKÂWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks he acts aimlessly, he thinks it does not have his mind; v. g., n't'a kâweyimaw to your e mâmitjimot, even though he is bragging, I don't think he is able
+« AKÂWIMEW, (v. a.) TTAM, WIMEW,TCHIKEW, he told her that without having the intention to act, he told him, without intending to do it for him, v, g, someone promises me something, and does not give it to me, I would say: n't'akâwimik, he told me without purpose
+
+283
+
+AKÂ
+
+« AKÂWIHEW, (v. a.) TTAM, HIWEW, TCHIKEW, same verb as akâwimew, but this denotes an action on, etc., while the other indicates speech; v. g., we play a trick on someone, we make him hope in vain, we will say: akâwihaw, he's frustrated.
+« AKÂWIPAYIW, ok, a, (a. v.) See. akâwisiw, he acts unnecessarily
+« AKÂWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he desires it unnecessarily, without being able to obtain it; v.g., ata n't'akâwâten kita ayamihayân, yet I wish to pray (implying the idea that I do not act on my desire.)
+« AKÂWÂTAMOWIN, a, (n. f.) useless desire, not followed by the effect.
+« AKÂWÂTAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he envies her, he desires something of him, without being able to see her; at. g., konata kit akâwâtamâwin, namawiyamissawâtch ki ka ki miyitin, it's useless that you envy me that, I will not will not give anyway.
+« AKWEYIMEW,) v. a.) TAM, MIWEW, TCHIKEW, same meaning.
+« AKWEYITTAMAWEW, (v. a.) idem
+« AKÂWÂTEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he always thinks of him/her, without being able to obtain him/her, v. g., a young man who cannot have the girl he wants.
+
+AKA
+
+« AKAWÂTJIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he hardly keeps at it, he is barely making it live.
+« AKAWÂTJIHUW, ok, (v. r.) he barely speaks, he can barely keep himself alive.
+« AKAWATJIH1SUW, ok, (v. r.) idem
+« AKÂWÂSIW, ok, (v. n.) he sighs for something, but uselessly.
+x ÂKÂW (rac.) in the shelter, on the other side.
+« ÂKÂWÂYIK, (ad.) On the other side; v.g., âkâwâyik watjik pimuttew, he walks in the shelter of the mountain.
+« ÂKAWÂTTIK, (ad.) Away from wood; v. g., âkâwâttikwesimow, or, âkâwâttikwekâbâwiw, it is standing on the other side of the tree.
+« ÂKÂWÂSKWEYÂK, (ad.) In the shelter of the forest.
+« ÂKÂWATCHÂK, (ad.) in the shelter of a hillock; v. g., âkâwatchâk itâmow he shelters himself with an elevation in the land.
+« ÂKÂWÂMATIN, (ad.) in the shelter of the mountain, or a hill.
+« ÂKÂWÂSKUSIWOKKAK, (ad.) in the shelter of the hay, grass.
+« ÂKAWISKAMIKÂK, (ad.) in the shelter of the ice.
+« ÂKAWÂKUNAKÂK, (ad.) in the shelter of the snow.
+« ÂKAWÂWOKKAK, (ad.) in the shelter of the sand.
+« ÂKÂWÂSUW, ok, (a. v. an.) the sun is obscured, it is covered.
+« ÂKÂWASTEW, a, (a. v. in.) it is in the shade, sheltered from the sun.
+
+AKA
+
+284
+
+« ÂKÂWÂSTESIMOW, ok, (v. n.) he sits in the shade of the sun.
+« ÂKÂWÂSTEPIW, ok, (v. n.) id
+« ÂKAWASKWEW, ok, (v. im.) the sun is obscured by a cloud N. B. askwe, denotes the cloud
+« ÂKAWASTEHWEW, (v. a.) HAM, HUWEW, HIKEW, he put it in the shade, in shelter
+« ÂKÂWASTEHIGAN, a, (n. f.) shelter from the heat of the sun.
+« ÂKÂWASTEHUN, a, (n. f.) idem
+« AKÂWASTEHUW, (v. r.) He shelters himself from the sun.
+« AKÂWASTESKAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he puts himself in front of it to hide the light
+« ÂKÂWÂSKAWEW, (v. a.) KAM, KAKEW, TCHIKEW, idem.
+« AKAWÂSTEPAKAHAM, (v. n.) he sits in the shade with leaves.
+AKAYÂSIW, ok, (n. f.) English. This word seems to come from the root ak, or, akwa.
+AKAYÂSIMOW, ok, (v. n.) He speaks English.
+AKAYÂSIMOWIN, a, (n. f.) English language.
+AKAYASIMOTOTAWEW, (v. a.)  TAM, TÂKEW, TCHIKEW, he speaks English to him.
+AKAYÂSIWASKIY, a, (n. f.) England.
+AKAYÂSIWAYAMIHAW, ok, he is protestant, he prays in English
+AKAYÂSIWAYAMIHÂWIN,(n. f.) Protestantism, or, English prayer.
+
+AKW
+
+x AKWÂ, (rac.) reach the shore, the dry land, through water or fire,
+« AKWÂHWEW, (v. o.) HAM, HUWEW, tchikew, he withdraws it from the water or fire, v. g. akwâh askik, take the boiler off of the fire.
+« AKWÂKAHWEW, (v. a.) HAM, HUWEW, TCHIKEW, idem.
+« AKWÂNEW, (v. a.) NAM, NIWEW, NIKEW, he removes it with his hand, out of the water or fire.
+« AKWÂSIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, idem, with the arm.
+« AKWÂPITEW, idem.
+« AKWÂYÂSIW, (a. an.) it is pushed towards the shore, by the wind.
+« AKWÂYÂSTAN, wa, (a. in.) it is pushed to shore by the wind. Note: The adjective endings âsiw, astan, indicate the action of the wind, v. g. wepâsiw, stan, carried away by the wind.
+« AKWÂYÂHUKOW, ok, (a. an.) it drifts towards the shore.
+« AKWÂYÂHUTEW, a, (a. in.) idem
+« AKWÂYÂHUYEW, (v. a.) TAW, HUWEW, TCHIKEW, he makes it drift towards the shore, like, nâtahuyew, he's going to fetch it by making it drift on the water. Note: These suffixes, hukow, hutew, huyew, indicate an action on the water.
+« AKWÂYÂPOKOW ^ ok, (a. an.) he is drawn to the ground by the current of the water.
+« AKWÂYÂPOTEW, a, (a. in,) idem.
+
+285
+
+AKI
+
+« AKWÂYÂPOYEW, (v, a.) TAW, YIWEW, TCHIKEW, he leads him to land by current. These suffixes pokow, potew, poyew, indicate the current of the water, v.g. wepâpokow, an. wepâpotew, in. he is carried away by the current.
+AKIK, wok, (n. r.) A cold, ot akikumiw, ok, he has a cold, kit akikum, ak, your snot, senikikumew, ok, he blows his nose.
+x AKI, (rac.) count, evaluate.
+« AKIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he counts it, v. g. akimewokot'emiwâwa, they count their horses, ekusi itakimew, this is how he evaluates it, iyiniwok mistahi akittamok maskikiya, the savages give great value to medicines, tanisi ​​itakitchikeyan? how do you count?
+« AKITTAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he counts him, he evaluates him, v. g. taneyikok itakittamâwiyan kit'em? what price will you give me for your horse? nemitano tattwattay kit itakittamâtin, I'll do it for you for forty more (furs].
+« AKITTAMOWIN, a, (n. f.) the action of counting.
+« AKITTÂSUW, ok, (v. n.) He counts, he calculates.
+« AKITTÂSUWIN, a, (n. f.) Calculation.
+« AKITTISUWINIKKEW ,. ok, (v. n.) he does calculations.
+« AKITTASUWINIKKEWIN, a, (n. f.) Action of doing calculations.
+
+AKI
+
+« AKINÉ, (continuation of the same root) following each other, alternately.
+« AKINEPAYIW, ok, a, (v. v. an. and in.) it happens one after the other.
+« AKINEPAYISTAWEW, (v. a.) TAM, TAKEW, TCHIKEW, he passes them there: one after the other, (as if counting them) on horseback.
+« AKINEHWEW, (v. a.) HAM, HUWEW, TCHIKEW, he passes them one after the other, on the water.
+« AKINEYÂBAMEW, (v. a.) TAM, KEW, TCHIKEW, he spends looking at them one after the other, as in counting them.
+« AKINEHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he acts on him alternately.
+« AKINESKAWEW, (v. a.) KAM, KÂKEW, TCHIKEW, he passes them one after the other.
+« AKINENEW, (v. a.) NAM, NIWEW, TCHIKEW, he takes it with the hand one after the other, v. g. somebody turning the pages of a book.
+x AK, (rac.) above, again, over, a thing that is stuck, which is applied something else.
+« AKOKKEW, ok, a, (a. v. an. and in.) it's stuck to something; v. g., pikiw nitta akokkew, the eraser sticks easily.
+« AKOKKEMOW, ok, a, (a. v. an, and in.) it holds to, etc. 
+« AKOKKEHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he sticks it, he applies it
+« AKOKKATEW, (v.a.) TAM, SIWEW, TCHIKEW, idem.
+
+286
+
+AKO
+
+« AKOKKATCHIGAN, a, (n. f.) that which is used to paste.
+« AKOKKÂBÂWEW, ok, a, (a. v. an. and in.) the water sticks to itself, attaches to him, or to that,
+« AKOKKÂBAWAYEW, (v. a.) TAW, YIWEW, TCHIKEW, he sticks it to, applies it to, etc., with the aid of a liquid.
+« AKOKKWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he sews it to, he puts it on with the help of a needle.
+« AKOKKWÂTCHIGAN, ak, (n. f.) tavelle (a piece of sewing equipment), so named because usually one sews it to another piece.
+« AKUPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he ties him up, he tapes it, he bandages it, he applies a plaster.
+« AKUPISUW, ok, (a. v.) He's taped, bandaged, he attaches a plaster
+« AKUPISUWIN, a, (n. f.) plaster, tie, tape.
+« AKOKKASWEW, (v. a.) sat, wew, tchikew, he makes it stick using heat, fire.
+« AKOKKASUW, ok, (a an.) He is stuck, being burnt (on).
+« AKOKKATEW, a, (a. in.) idem N. The adjective endings suw, tew, indicate the action of fire.
+« AKOSKAWEW, (v. a.) KAM, KÂKEW, TCHIKEW, he makes it stick with pressure, v. g., pressing it down.
+« AKOW, ok, (v. n.) it approaches as if wanting to stick.
+« AKOPAYIHUW, ok, (v. n.) idem
+
+AKO
+
+« AKOKKAWEW, (v. a.) KAM, KÂKEW, TCHIKEW, he sticks to him, he coaxes, as if sticking to his person. One also uses this word to say: he panders to him, using flattery to win his favour; ayakokkawew.
+« ATOKKÂSUW, ok, (v. n.) He panders, uses flattery.
+« AKOKKAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, see akokkawew
+« AKOKKASAMÂWEW, (v. a.) as one would say: it makes it stick by burning it. One uses this word when someone, whether by medicine or spells strives to make themselves loved by a person.
+« AKOKKASAMÂSUW, ok, (v. n.)I do spells to make him love.
+« AKOKIW, ok, (a. an.) He sticks to it, he joins it, v. g., two trees which, by growing, join, converge on one another.
+« AKOKIN, wa, (a. in.) Idem.
+« AKOPAYIW, ok, a, (a. v. an. and in.) idem.
+« AKWAMOW, ok, a, (a. v. an. and in.) it is due to, etc. N. mow is an animate and inanimate adjective ending indicating that it holds, etc., attached to, etc. It is also a verbal ending, indicating speech, v. g., âtjimow, he tells; kisimow, he talks angrily. It is also an ending for impersonal verbs, v. g., paskemow, forked path; kistamow, beaten path.
+
+287
+
+AKO
+
+« AKWAMOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it stick to, etc., it fixes it to something.
+« AKWÂKUNEW, ok. (a. v.) the snow sticks on it.
+« AKOMOW, ok, (a. v.) e. g. a duck which stands on the water, (including looking as if it is stuck.)
+« AKUSTAHWEW, (v. a.) HAM, HUWEW, TCHIKEW, he sets it to, etc., v. g., a button to a suit.
+« AKUSTAHAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he poses him, he fixes him in place
+« AKOSIW, ok, (a. v.) it is fixed on, etc., v. g., someone who is securely on his horse, or even better, a bird that is perched; v. g, kâkâsiw ka akosit, the raven that is perched.
+« AKOTCHIN, wok, (a. an.) It is hanging from, etc .; v. g., atchâkus sak kijikok akotchinwok, the stars are suspended in the sky.
+« AKOTTIN, wa, (a. in.) It is suspended, hanged. However this adjective is more often used to say something which is in the water, v. g., sâsay wiyâs akottin askikok, the meat is already in the boiler (in the water to boil.)
+« AKOTEW, (v. a.) TAM, SIWEW, TCHIKEW, he hangs it, he hangs it, he hooks it to.
+« AKOTEW, a, (a. in.) It's hanged,suspended.
+« AKOTCHIMOW, ok, (a. v.) It is held stuck, tight to something.
+« AKONEW, (v. a.) NAM, NIWEW, TCHIKEW, he hugs him, as if wanting to stick him there, v. g., a mother hugging her child on her breast. N. B. The few words which follow, seems to derive from the same root, although having a different meaning, they still indicate the idea of ​​something which is suspended, who holds on to the surface, which floats, etc.
+
+AKW
+
+« AKWÂKUSIW, dk, (a. an.) He is moldy, spoiled, c. g, provisions covered with white fuzz, etc.
+« AKWÂKUTEW, a, (a. in.) he is musty.
+« AKWÂKUSIN, wok, (a. an.) idem.
+« AKWÂKUTTIN, wa, (a. in.) idem.
+« AKWAKUPAYIW, ok, a, (an. and in.) idem.
+« AKWÂKUPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, it blackens it.
+« AKWAKUPIY, a, (n. f.) a green and dirty grass that covers some lakes in summer.
+« AKWÂKUPISÂKAHIGAN, (n. f.) green lake (covered with green grass).
+« AKOTAYOW, (v. im.) When the snow is hanging from the trees or from something else.
+« AKOYÊSIKWA, (v. im.) Ice in a heap, piled up, (Burgundian).
+« AKUP, ak, a, (n. an. and in.) covered, cover. This word is animate when talking about objects covered with hair. For some buffalo dresses, one says,: akupak.
++ ÂK, K (rac.) Bitterness, bitterness, pain, wickedness. N. In this root, sometimes there are two ks and other times only one (I do not know the cause.)
+
+288
+
+ÂKW
+
+« AKKOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he tortures him, he torments him, he makes her suffer a great deal of pain.
+« ÂKKUSIW, ok, (o. a.) He is sick; kiwinew, ok, he is dying
+« ÂKKUSIWIN, a, (n. f.) Sickness; kiwinewin a, the last agony (of death); nanântok itâspinew, he has different diseases. N. The suffix pinew indicates sickness
+« ÂKKWÂPPINEW, ok, (a. v.) he has a very painful ailment.
+« AKWÂTAN, wa, (a. in.) It is onerous, harsh, cruel.
+« ÂKWÂTISIW, ok, (a. a.) he is cruel, savage, barbarous; âkwastimow, a fierce dog.
+« ÂKWÂTAN, wa, (a. in.) He is cruel.
+« ÂKWÂTEYIMEW, (v. a.) t. miwew, tchikew, he found it ferocious, cruel.
+« ÂKOTONÂMOW, ok, (v. n.) an angry, stern, vicious tone of voice \
+« ÂKWÂSTEW, (v. im.) it is very hot. N. The ending astew indicates heat; nipâhâstew, killing heat,
+« AKWÂKATOSUW, ok, (a. v.) it is hardened as it dries.
+« AKWÂKATOTEW, a, (a. v.) it is hardened, summer.
+« AKWATCHIW, ok, (a. a.) it is cold, it's frozen, it's cold and hard.
+« ÂKWATIN, wa, (a. in.) it hardened by the cold.
+
+ÂKW
+
+« ÂKWEKISIW, ok, (a. a.) it is hardened, it is weakened by dryness.
+« ÂKWEKAN, wa, (a. in.) idem.
+« ÂKOTEWISIW, ok, (a. a.) it is ruthless, rough, hard.
+« ÂKOTEWAN, wa, (a. in.) Idem.
+ÂKWÂWAN, a, (n. r.) grid, scaffolding to dry meat.
+x ÂKWÂ (rac.) deeply, sunken long before, far away.
+« ÂKWÂTCH, (ad.) Deeply, far, forward; v. g. , âkwâtchispayiw, it sinks far ahead; one would also say: sâsay osâm âkwâtchispayiw, the case is already too advanced; âkwâtch ni pimitisahwaw, I'm chasing him far; âkwâtch payipaham, he drills it well before; âkwâkijikaw, late in the day; âkwâtibiskaw, advanced night, it also means: with difficulty, as in akâwâtch; v. g., âkwâtch pimâ'isiw, he barely lives, or, his life comes from afar, eg. somebody who escapes with difficulty from a danger; sâsay âkwâtch kiskeyittam, he already knows a lot; âkwâtch kinakatchihitin, I am well accustomed to your ways.
+« ÂKWÂSIN, wok, (a. a.) It is very sunken, it has arrived from very far away.
+« ÂKWÂTTIN, wa, (a. in.) idem.
+« ÂKWÂSIMEW, (v. a.) it is with pain that he makes it live.
+« ÂKWÂSK, (ad.) At the front, by the front.
+« ÂWÂSKAWEW, (v. a.) KAM, KÂKEW, tchikew. he cuts the trail to pass in front of him; v. g., kakwe âkwâskaw mayowes wâyo e ayât, try to cut in his way before he is far away.
+
+289
+
+AKW
+
+« ÂKWASKAM, (ad.) More, in addition; v. g., âkwâskam mustawinam, he wants more.
+« AKWASKISPAYIW, ok, a, (a. v. an. and in.) he, or, it acts like it wants to cut the path, wanting to go by in front.
+« AKWASKINEW, (v. a.) NAM, NIWEW, NIKEW, he holds it in his arms, he holds it in armfuls; v. g., âbittasiyaw âkwaskinaw, it is held by the middle of the body.
+« ÂKWASKITINEW, (v. a.) NAM, NIWEW, NIKEW, idem.
+« ÂKWASKISKAWEW, (v. ​​a.) KAM, KÂKEW, TCHIKEW, he cuts the path passing in front of him, making a detour.
+x AKWAN, (rac.) Cover, shelter, put in cover.
+« AKWANÂHWEW, (v. a.) HAM, HUWEW, HIKEW, he covers it
+« AKWANINEW, (v. a.) NAM, NIWEW, NIKEW, idem.
+« AKWANÂSIMEW, (v. a.) TTITAW, SIMIWEW, SITCHIKEW, idem.
+« AKWANÂHUW, ok, (v. r.) he covers it.
+« AKWANÂHUWIN, a, (n. f.) a cover, shawl.
+« AKWANAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he places it in the covering.
+« AKWANABOHWEW, (v. a.) HAM, HUWEW, HIKEW, he covers it, v. g., a vase.
+
+AKW
+
+« AKWANÂBOHIGAN, a, (n. f.) cover of a vase, of a boiler, etc.
+« AKWANÂBOWESIN, wok, (a. a.) it is covered.
+« AKWANÂBOWETTIN, wa, (a. in.) idem.
+« AKWANÂKKWEW, ok, (v. n.) he covers his face.
+« AKWANÂKKWEHWEW, HAM, HUWEW, HIKEW or akokkwehwew, or, akokkwepi tew, he covers his face.
+« AKWANÂKKWEPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he bandages his face.
+« AKWANÂKKWEPISUWIN, a (n. f.) face covering.
+« AKAWÂYIK, (ad.) To the shelter, to cover, v. g. akawâyik pimuttew, he walks to the shelter, akawâtik, to the shelter of the woods, of the forest, akawâmatin, in the shelter of the mountain, akawâtin, to the shelter of the hill.
+« AKAWÂBIKKWEW, ok, (a. v.) his eyes are covered.
+« AKAWÂBIKKWEHWEW, (v. a.) HAM, HUWEW, HIKEW, he covers his view.
+« AKAWÂKKWEPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he blocks his eyes.
+« AKAWAWESIMOW, ok, (a. v.) he took cover from something.
+« AKAWÂWESIMEW, (v. a.) TTITAW, MIWEW, TCHIKEW, he places it in shelter.
+« AKOSIMOW, ok, (a. v.) Like akawâwesimow.
+« AKOSKAWEW, (v, a.) KAM. KÂKEW, TCHIKEW, he covers it completely- v.g. mustuswok misiwakoskamok askïy, the buffaloes cover the earth.
+
+290
+
+AWK
+
+x AKWEB, (rac.) encumberment, that which takes up lots of space, a lot, in great quantities.
+« AKWEBÉS, (ad.) when one has many things, to the point of being encumbered, v. g. akwebes n't'yâwâwok kiuusewok, I have an abundance of fish.
+« AKWEBISIW, ok, (a. a.) he is encumbering, and, he is encumbered, he has a lot of things that encumber him, v. g. awiyak weyositji mistahi akwebisiw mâna, he who is rich has many things for his use.
+« AKWEBAN, wa, (a. in.) it is encumbering.
+« AKWEBEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he finds it encumbering.
+« AKWEPAPIW, ok, (a. v.) he is encumbering, v. g. someone who takes up too much space.
+« AKWEPASTEW, a, (a. v.) it's encumbering by its volume, etc.
+« AKWEPINEW, (v. a.) NAM, NIWEW, NIKEW, he doesn't know where to put it because he is so encumbered.
+x AKWAN, (rac.) the same as above, under cover, etc.
+« AKWANOKIJOWEW, ok, (v. n.) he speaks in covered words, he speaks in parables.
+« AKWANOKIJWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he says it in covered words, in parables.
+
+AKW
+
+« AKWANOKIJOWEWIN, a, (n. f.) covered word, parable.
+x ÂKWETTAW, (rac.) double up, put one on top of the other,
+« ÂKWETTÂWAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he puts them one on the other,
+« ÂKWETTAWIKWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he sews them one on top of the other, he doubles it.
+« ÂKWETTÂWESKISINEW, ok, (v. n.) he puts on a double pair of shoes, or, ayâkwettâweskisinew, (Red.)
+« ÂKWETTÂWESÂKEW, ok, (v. n.) he puts on a double coat, hood.
+« ÂKWETTÂWEWEYONISEW, ok, (v. n.) he wears double layered clothing.
+« ÂKWETTÂWAPIW, ok, (a. r.) v. g. mustusweyânak âkwettawapiwok, buffalo dresses are piled on top of each other.
+« AKWETTÂWASTEW, a, (a. in.) it's doubled, it's one on top of the other.
+« ÂKUST, (rac.) Soak in water, to wet.
+« AKUSTIMEW, (v. a.) TAW, MIWEW, TCHIKEW, he puts it in water.
+« AKUSTÂBAWAYEW, (v. a.) TAW, YIWEW, TCHIKEW, idem.
+« ÂKUSTIMOW, ok, (n. a.) he is wet.
+« ÂKUSTIN, wa, (a. in.) it is wet.
+x AJIW, (rac.) Incapable, who does not succeed.
+« ÂJIWISIW, ok, (a. a.) he does not succeed, (synonyms) nayoyuw, akawisiw.
+
+291
+
+AMA
+
+« AJIWAN, wa, (a. in.) it does not happen, it does not succeed, nama ajiwan, it always happens, without fail, v. g. ekuyikok mânanama âjiwan eka kitchi mispuk, it is the weather in which it snows without fail.
+« ÂJIWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks it incapable to do such and such a thing, to succeed, etc., nama kekway n't'âjiweyimaw Kijemamto, I think God able to succeed in all things.
+« ÂMAK, wok, (n. r.) needle for lacing snowshoes.
+x AM, (rac.) scare away, scare.
+« AMÂMEW, (v. a.) TAM, MIWEW, TCHIKEW, he scares him away, v. g. someone who wants to approach a wild animal, and doing so makes some noise, scaring it away, spooking it.
+« AMÂHEW, (v. a.) TTAW, HIWEW, TCHIKEW, idem.
+« AMÂHAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he runs away from him, he is the reason that someone else's animal runs off.
+« AMÂWEHAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, idem.
+« AMÂTAMÂWEW, (v. a.) idem.
+« AMÂWEKAHIKEW, ok, (v. ind.) he scares him away, by blows with an axe.
+« AMAWESWEW, (v. a) SAM, SIWEW, SIKEW, he scares him away by shooting a rifle.
+« AMATISUW, ok, (v. n.) he is on the lookout, he fears some surprise, he is on his guard.
+
+AMA
+
+« AMATISUWIN, a, (o. f.) Fear of being surprised.
+« AMATISUSTAWEW, (v. a.) TAM, KEW, TCHIKEW, he fears some surprise on his part, he is on guard against him.
+« AMATISUSTAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he is on lookout on his account, v. g. eoko iskwew amatisustamâwew oko sissa, that woman fears for her son. Note. This root always indicates that one is scared, that one is on the lookout because one has seen, or that one thinks that one saw, something; this is quite different from another word, astâsiw, which although appearing to mean the same thing, is in fact very different.
+x ÂMAT, (rac.) climb a hill, an elevation, height.
+« ÂMATCHIWEW, ok, (v. n.) he goes up a hill, up a hill. Note. The ending tchiwew, indicates a hill, 'mountain, c. g. nittatchiwew, he goes down a hill.
+ÂMATCHIWEYAW, (a. in.) it is going up, it is a height.
+« ÂMATGHIWETCHAW, (a. in.) it is an elevation in the ground, which climbs up.
+« ÂMATGHIWEHEW, (v. a.) TTAW, HIWEW, HIKEW, he climbs it.
+« ÂMATGHIWEPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he climbs it by pulling himself to him.
+« ÂMATGHIWETISAHWEW, (v. a.) HAM, HUWEW, HIKEW, he makes it go up promptly.
+« ÂMATCHIWEWIN, a, (n. f.) A climb.
+
+292
+
+ÂMI
+
+« ÂMATCHIWESKANAW, a, (n. f.) A way up, a climbibf path
+« ÂMATIN, ending that indicates a mountain, mound, hill, v.g. takkutchâmatin, on the mountain, awasâmatin, from the other side of the hillock, astamâmatin, of this side of the hill; thus, these words are adverbs, and are not inflected
+AMATITTE, (ad.) aside the others, like, pikonata ite.
+ÂMI, (ad.) Almost, kekâtch, this word always goes between the pronoun and the verb, and it is never used alone as kekâtch, v. g n't'âmi miyik, he almost gave it to me, he was about to give it to me, wâbaniyik 'kita âmi takusinwok, tomorrow they will almost arrive (probably)
+AMISK, wok, (n. r.) Beaver.
+« AMISKOWIW, ok, (a. a.) he is a beaver.
+« AMISKWEYAN, wa, (a. in.) it is beaver, made of/by beaver
+« AMISKWEYÂN, ak, (n. f.) beaver pelt, with the hair. N. The suffix weyân indicates a pelt with the hair, and this name conforms to the qualities of animate nouns, v. g., mustus weyân ak, buffalo skin with hair; osekamist, wok, butchered beaver; awetis, ak, little beaver; poyawesis, ak, one year old beaver; patamisk, wok, two-year-old beaver; nâbemisk, wok, male beaver; nojemisk, wok. the female.
+ÂMIW, ok, (v. n.) spawning fish
+
+ÂMI
+
+ÂMIWIN, a, (n. f.) spawning season.
+ÂMOW, ok, (n. r.) Bee, big wasp.
+ANAKKÂTCH, (ad.) N. It is very difficult to translate this word, which roughly means: something that one regrets, and which, although of little value, is of value in the situation. Examples will make this easier to understand. Anakkâtch ki webinaw eoko mistikus, it's regrettable that you rejected that little piece of wood (implied) although of little value, yet it would have been useful; anakkâtch eoko! It's better than nothing, it's still something ; o miyopimâtisiyi, anakkâtch ka kikkamât it is still a good living, it is regrettable that he disputes it; anakkâtch ni wanittân, I regret having lost it, although it was not much; anakkâtch ki webinaw, eyiwek ki ka ki âbatjitta; it's unfortunate that you turned it down, you could have used it; anakkâtch ni wi-miyikottày, it's unfortunate that the thing happened the way it did, yet he still wanted to give it to me.
+ANAKATCHAY! (ex.) admiration for something extraordinary; v. g., anakatchày tapwe misikitiw kit'em! What a big horse you have!
+ANAKKWAY, ak, (n. r.) Sleeve of a dress; n'otanakkwân, I have sleeves; kiskanakkwày, ak, cut or cropped sleeves.
+
+293
+
+ANI
+
+« ANAKWÂKKAWEW, (v. a.) KAM, KÂKEW, TCHIKEW, he makes him sleeves.
+x ANÂSK, (rac.) to extend something on the floor, etc.
+« ANÂSKEW, ok, (v. n.) He extends something on the floor.
+« ANÂSKATTEW, (v, a.) TAM, SIWEW, TCHIKEW, he extends something on the floor, to sit or lie down on.
+« ANÂSKATTOWEW, TWÂKEW, idem
+« ANÂSKASUW, ok, (v. n.) He puts a carpet under him, he spreads something on the floor to serve as a rug, or bed.
+« ANÂSKATTEW, a, (a. in.) It is upholstered, the place is prepared to sit on, or to lie down on.
+« ANÂSKASUN, ak, (n. f.) Carpet, something to put under oneself.
+ANÂH, (pro.) This one; v. g., anah ni'stes ka petchâstamuttet, this one coming over here is my brother; eoko-ni ânihi ka pakamahwât, that's the one that he hit.
+« ANIKI, (pro. pl. an.) Those; v.g., eokonik aniki ka ki nipattâketjik, these are the ones who commmitted a murder ; aniki eka ka wi-ayamihâtjik, those who do not want to pray.
+ANDÊ, or, ANDA, (ad.) By there, somewhere; v. g., an de ka astek ki mokkumân, your knife is around somewhere.
+ANI, (ad.) (After the word) to give more strength to what one says; v. g., tapwe ani, it is quite true; ota ani, it's here; ni wi-ituttân, I definitely want to go; ki wittamâtinawaw ani, I'm telling you so. This word is used to more strongly affirm what one is proposing.
+
+ANI
+
+ANIYÊ, (ad.) One uses this word much like ani; v. g., ot'âkkusittày aniyê, he was indeed sick then; sipwettew aniyê, So here he is; takusin aniyê, So here it is. One also sometimes hears it said in front of the word; v. g., aniyê ka wâbamak, while I saw it.
+ANATA, (ad.) (After the word) definitely, really, like kusha; v. g., wiya anata, it is definitely him.
+ÂNIHUW, ok, (v. n.) He is wasting away, he loses weight, for example an animal after working too much.
+« ÂNIHUHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it wither away.
+x ÂN, (rac.) to think differently, to disobey, to contradict; âniseyimew, ttam, anisistawew, he disapproved of it.
+« ÂNIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he remands by speech, he does not approve of his conduct, v. g., someone who would say: I do not approve of his behavior, I myself would not do so.
+« ÂNEYIMEW. (v. a.) TTAM, MIWEW, TCHIKEW, he does not approve of his conduct, in his thought; v. g., n't'âneyitten niya, eoko nama ekusi ni pa to ten, I do not approve of that, I would not do so.
+« ÂNWEYIMEW, etc., idem.
+
+294
+
+ANI
+
+« ANITTAWEW, (v. a.) TTAM, TTÂKEW, TCHIKEW, he disobeys her, he does not approve of his words; v. g, awiyak ayânittawâtji ayamihe wiyiniwa tabiskotch e ânittawâ Kije manitowa, he who disobeys the priest, disobeys God.
+« ÂNWETTAWEW, etc., idem.
+« ÂNIKKEMOW, ok, (v. n.) He reproves, he disapproves.
+« ÂNWETTÂKEWIN, a, (n. f.) Disobedience.
+« ÂNITTAMOWIN, a, (n, f.) Idem.
+« ANIKKEMOWIN, a, (n. f.) idem.
+« ÂNISIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, it destroys the effect (of). One uses this word when someone destroys the effect of a poison by medicine or a spell, etc.
+« ÂNISITCHIGAN, a, (n. f.) Antidote, counter-remedy; v.g., ^ yamihewinanatâwihuwina ânisitchiganiwiwa passtâhuwin e âkkusiskâkuyak, the sacraments are antidotes against the sin that poisons us.
+« ÂNISIHIWEWIN, a, (n. f.) Idem.
+ANIMA, (pro. in.) That one; eoko anima ki mokkumân, it's your knife, that one.
+ANIHI, (pro. in. pl.) Those; v. g., eokoni anihi ki mokkumâna, these here are your knives.
+ANISIKIS, (ad.) This is why, therefore ; like, tasipwa, tesikote; v. g. , anisikis ki miyin, that's why you give it to me; namawiya anisikis ki ka sipwettân, that's why you don't leave; anisikis namawiya ki wi-ayamihân, eka k'o pe kiskinohamâkusiyan, therefore, thus, you don't want to pray, since you didn't teach yourself.
+
+ÂNI
+
+x ÂNISK, (rac.) one after the other, at the continuation, to unite one after the other, unite one end to the other.
+« ÂNISKÂTCH, (ad.) Or, ayâniskâtch, successively, v. g. takki âniskâtch ki pe-ayâwok ayamihewiyiniwok, the priests have always followed one another
+« ÂNISKUTCH, or, ayâniskutch,(ad.) idem.
+« ÂNISKÂWISIW, ok, (a. an.) it is end to end, it comes after it.
+« ÂNISKAWAW, a, (a. in.) it is end to end.
+« ÂNISKUSIN, wok, (a. a.) idem.
+« ÂNISKUTTIN, wa, (a. in.) idem.
+« ÂNISKAMUW, ok, a, (a. a. in.) he stands end to end.
+« ÂNISKAMOHEW, (v. o.) TTAW, HIWEW, TCHIKEW, he attaches it end to end.
+« ÂNISKOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, it lengthens it by adding, or, âniskohyew, etc.
+« ÂNISKI, (ad.) Voy. âniskâtch.
+« ÂNISKESTAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he comes after him, he replaces it.
+« ÂNISKESKAWEW, (v. a.) KAM, KÂKEW, TCHIKEW, he replaces him.
+« ÂNISKESKAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he ties it to her, he staples it to him.
+« ANISKUKWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he makes the ends meet by sewing. Note. The suffix kwâtew, indicates the action of a needle.
+« ÂNISKAWAHUW, ok, (v. r.) It staples (to itself), it attaches (to itself).
+
+295
+
+ANO
+
+« ÂNISKAWAHUTCHIGAN, a,(n. f.) staple, also, thimble for sewing, but one says more often kaskikwâsunâbisk, metal for sewing.
+« ÂNISKAMÂN, ak, (n. f,) lapel pin, staple.
+« ÂNISKAMÂSUW, ok, (v. r.) he grabs himself, he attaches himself.
+« ÂNISKOSÂN, ak, offspring, descendant.
+« ANISKOSÂNIWIN, a, offspring.
+« ANISKOSÂNIKKAWEW, he descends from his race.
+« ANISKOTTEW, (v. a,) TTAM, SIWEW, TCHIKEW, he attaches it end to end.
+« ÂNISKOPITEW, (v. a.) TAM, SIWEW, TCHIKEW, idem.
+ANITTUY, a, (n. r.) Dart made with a piece of wood.
+ANOTCH, (ad.) However, as atawiya.
+ANOTCH, (ad.) Today, presently, v. g. anotch ka kijikâk, today, on this day, anotch piko, presently, anotch ki wittamâtin, I just said it to you, anotch ikke, very recently, anotch ikke ka nipit, it is very recently that he died, anotch piko ka takusik, sâsay ka wi-kiwet, he's only just arrived, and he already wants to go, anotch iteyittâkwan ka ponâbamak, it's only been a moment since I've stopped seeing it.
+x ÂP, (rac.) untie, twist, go back, go back on, etc. see the same root ab.
+
+ÂPA
+
+« ÂPAHWEW, (v. a.) HAM, HUWEW, HIKEW, he unties it, he detaches it, he untwists it, v. g. someone who undoes a suit.
+« ÂPAHAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he unties him, etc.
+« ÂPAKKAWIHEW, (v. a.) TTAW, HIWEW, HIKEW, he heals him, he makes it come back to him, v. g. somebody who would have lost their mind and has had it put back right.
+« ÂPAKKAWIHUW. ok, (v. r.) he is cured, he returns to his senses, he comes back to reason.
+« ÂPÂKKAWIMEW, (v. a,) TTAM, MIWEW, TCHIKEW, he soothes her by his words, he calms him down, he pipes him down.
+« ÂPÂKKAWISIW, ok, (a. a.) He is better, he went back to his normal self.
+« ÂPAKKAWAN, wa, (a. in.) It has returned to as it was before.
+« ÂPUKKAYAW, (v. im.) The cold suddenly ceases.
+« ÂPÂSTEW, (v. im.) He makes a scorching heat.
+« ÂPATOPAYIW, ok, (v. n.) He returns from war. Note. This suffix topayiw indicates war, v. g. nantopayiw, he goes to war, kiwetopayiw, he comes back from war, but one uses this last sense only when one has killed someone in combat.
+« APASÂBIW, ok, he's looking back.
+« APASÂBAMEW, TTAM, he looks at him, turning backwards.
+« APAMOTJIWAN, eddies.
+
+296
+
+ÂPE
+
+« ÂPEHUW, ok, (v. n.) he takes revenge, he takes his revenge.
+« ÂPEHUPAYIW, a, (v. n.) Âpehumagan, ow, âpehupagan, it acts in revenge.
+« ÂPEHUSTAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he takes revenge for another.
+« ÂPISISSIN, wok, (v. n.) he is resuscitated, he comes back to life.
+« ÂPISISIMEW, (v. a.) TTAW, MIWEW, TCHIKEW, he resuscitates him.
+« ÂPISISINOKIJIKAW, a, (n. f.) Day of Resurrection, Easter.
+« ÂPUTTEW, ok, (v. n.) He comes back from hunting, bring back meat
+« ÂPENAWEW, (v. a.) NAM, NÂKEW, TCHIKEW, he recognises it, he finds it the same, he finds it similar.
+« ÂPENÂKUSIW, ok, (a. a.) It is recognizable.
+« ÂPEWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks he is capable of producing such an effect, v.g. someone who cares for me and whom I trust will heal me, I would say: n't'âpeweyimaw; a medicine, the effects of which I believe, I say: n'âpeweyittea eoko maskikiy; n't'apeyitten ayamihâwin, I discover the truth of religion, I have confidence in religion.
+« ÂPEWEYITTÂKUSIW, ok, (a.a.) it is recognizable, v. g. e wâbattamut Kijemanito ot ojitjigana, semâk âpeweyittâkusiw e ittât, seeing the works of God, we recognize that He exists.
+
+ÂPE
+
+« ÂPEWEYITTÂKWAN, wa, (a. in.) that's understandable, v. g.âpeweyittâkwan ayamihâwin, the religion is understandable for what it is.
+APAKKWÂTIS, ak, (n. r.) Bat.
+APAPPEW, ok, (v. n.) He sighs, he moans.
+APIKUSIS, ak, (n. r.) mouse.
+x AP, (rac.) sit on it, sit down on it.
+« APIKKEW, ok, (v. n.) He braids, or, he makes mats; that is sure because one uses it for a mat, to sit on.
+« APIKKÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he braids it, v.g., apikkâtam pasastehigan, he braids a whip.
+« APIKKÂTAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he braids it for him.
+« APIKKEPAYIW, (a. a. and in.) it braids itself, it mixes, but even better one could say, wânâpikkepayiw.
+« APIKKÂN, a, (n. f.) Canoe bar.
+« APIKKAN, a, (n. f.) collar, necklace, (also the strap one uses to wear things on ones back.)
+« APIW, okay, (a. a.) He's, he's sitting, he is in such a position, v. g. apiw tchi? is he there? namawiya apiw, he is not there, wâbaki nama ni ka apin, tomorrow I will be absent, pittuke mina api, come in and sit down.
+« ASTEW, a, (a. in.) it's there.
+« APIWIN, a, (n. f.) seat, nikân apiwin, seat of honor.
+
+297
+
+API
+
+« APIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he sits it down, he makes it sit.
+« APIWINEYAW, (v. im.) there is a seat, it is a seat.
+« APIWINIKKÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he prepares for him a seat.
++ APA, (rac.) To cover, provide a cover to a building.
+« APAKKWEW, ok, (v. n.) he does shelter from bad weather, he puts down a blanket.
+« APAKKWEWIN, a, (n. f.) Action of covering.
+« APAKKWÂSUW, ok, (v. r.) he takes cover, he takes cover.
+« APAKKWÂSUN, a, (n. f.) cover, shelter, this is also how one refers to the savage's lodge, or, mikiwâp, a.
+« APAKKWAY, a, (n. f.) idem.
+« APASUY, a, (n. f.) Pole for building lodges, large poles on which lodges are extended.
+« APAKKWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he makes him a shelter, cover.
+« APISWEW, (v. a.) SAM, SUWEW, SIKEW, he heats it over a fire:
+« APISUW, ok, (v. r.) It is heating up on the fire fire.
+« APITTEW, a, (a. in.) it gets hot on the fire.
+« APÂWATEW, ok, (v. n.) idem.
+« APISITESUW, ok, (v. r.) He warms his feet.
+« APIKKWESUW, ok, (v. r.) he heats his face.
+
+API
+
+« APIKKUTESUW, ok, (v. r.) He warms his nose.
+« APITCHITCHESUW. ok, (v. r) he warms his hands.
+« APITONESUW, ok, (v. r.) he warms the mouth.
+« APIPITUNESUW, ok, (v. r.) He heats up his arms
+« APITITTIMANESUW, ok, (v. r.) he warms his shoulders.
+« APIPISKWANESUW, ok, (v. r.) he warms his back.
+« APASKIKANESUW, okay, he warms his stomach.
+x ÂPIK, (rac.) open, detach, see. âpahwew.
+« ÂPIKKUNEW, (v. a.) Nam. miwew, nikew, he unties it.
+« APIKKUPITEW, (v. a.) TAM, SIWEW, TCHIKEW, idem.
+« ÂPIKKUW, ok, (v. r) he detaches himself, he frees himself from what he is attached to, it loosens its ties.
+« ÂPIKUKWAHWEW, (v. a.) HAM, HUWEW, HIKEW, he opens it with a key.
+« ÂPIKUKWAHIGAN, a, (n. f.) key.
+« ÂPIKKWAHIKÂSUW, ok, (v. a.) it is opened by the key.
+« ÂPIKKWAHIKÂTEW, a, (a. in.) idem
+APPIN, a, (n. r.) Parchment.
+APPINEGIN, wa, (n. f.) Parchment skin N. The suffix egin designates a skin, an Indian fabric, something thin; v. g., mikkwegin, red cloth; masinahiganegin, page of a book, paper, etc.
++ APIS, (rac.) A little, small.
+
+298
+
+APP
+
+« APISIS, (ad.) A little; ayâpisis, emanis.
+« APISISIW, ok, (a. a.) he is small, he is not large.
+« APISÂSIN, wa, (a. in.) It's small.
+« APISISIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it small.
+« APISÂSITTAW, he does this thing small.
+« APISTIMOSUS, ak, (n. f.) roe deer, small moose.
+« APISTATIKKUS, ak, (n. f.) kid goat.
+« APISTATIMUS, ak, (n. f.) Small horse, or small dog,
+« APISTIKÂKÂKIS, ak, (n. f.) Magpie from France, little crow, (thus, in following by adding the root apisti in front of the word; v. g., apistimasinahigan, little book; apisti tchikahigan, a small ax, etc.
+« APISISTIKWEYAW, a, (v. im.) there is a river with a small course. N. The suffix stikweyaw indicates a watercourse; misistikweyaw, there is big stream.
+« APISOTTAKAW, a, (v. im.) a little piece of wood, that is to say: it's a small canoe.
+x APPITISIW, ok, (a. a.) v. g., someone who received a blow that has made his flesh black.
+« APPITTEW, a, it's black.
+« APPITÂBIW, ok, (a. a.) He has a black eye from a blow.
+« APPITTEHWEW, (v. a.) HAM, HUWEW, HIKEW, he makes a mark on him by hitting him.
+« APPITTÂBAHWEW, (v. a.) HAM, HUWEW, HIKEW, he gives him a black face by a blow.
+
+APP
+
+« APPITTEWEBAHWEW, (v. a.) HAM, HUWEW, HIKEW, he makes it black by hitting it.
+APPO, (ad.) Or (vel.) This word has three meanings, v. g., 1 ° niya appo kiya, me or you; appo ni ka nipan, or else I'm going to sleep; api appo nibâwi, remain seated or standing; 2 ° appo kiya, it's like you will want; appo wiya, it's like he will want, that's his business; 3 ° appo niya ni pa ki toten, even I could do it; appo kiya, ki sâkweyimon, it disgusts even you.
+APPOTCHIKAYE, or, appotchika, (ad.) same, as far as to; v. g., appotchikaye mamiyiyat, eka ka wi-miyiyan, you go as far as to give it to him, yet you do not want to give it to me; appo tchika nama ki wi-ayamihân, even you don't want to pray.
+APPONÂNI, (ad. Irony) yet (verumtamen); v. g., apponâni ke ayimisit, yet it's not him who's worth it! eg. someone orders me to do something laborious, telling me that it is easy, I would tell him: it's not difficult for him to tell me that it's easy, since he will not be doing it, and I alone must suffer from it; apponâni ke ayimisit! it's almost like iyekama, that we will see later; apponâni ke atusket, since it is not him who will work; apponâni ke pekiwet, there is no fear that he will come back.
+
+299
+
+APW
+
+x APUT, (rac.) set backwards, turn on the opposite side.
+« APUTINEW, (v. a.) NAM, NIWEW, NIKEW, he turns it upside down, ex. clothing; aputinam oskutakày, he turns his coat inside out.
+« APUTAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, idem.
+« APUTCHIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he turns it upside down by pulling it.
+« APUTISIN, wok, (a. a.) It is turned upside down.
+« APUTITTIN, wa, (a. in.) Idem.
+« APUTAPIW, ok, (a. a.) idem.
+« APUTASTEW, a, (a. in.) Idem.
+« APUTAHYAW, a, (a. in.) Idem.
++ APWE, (rac. To be hot, to heat.
+« APWESIW, ok, (a. a.) He's hot, he is sweating.
+« APWEYAW, (v. im.) it is hot.
+« APWESIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it sweat, he makes him feel hot.
+« APWEKKASWEW, (v. a.) SAM, SUWEW, SIKEW, he makes it hot, it makes him sweat.
+« APWEKKASUW, ok, (a. a.) It burns with heat, he sweats from the fire.
+« APWEKKATTEW, a, (a. in.) It's hot enough to sweat, kisowikkattew, a.
+« APWESKAWEW, or, APWESISKAWEW, KAM, KAKEW, TCHIKEW, he makes it sweat; mikko apweskâkuw, he's sweating blood.
+« APWESIPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, idem.
+
+ÂPW
+
+x ÂPWÂNÂSK, wok, (n. r.) skewer for roasting meat.
+« APWÂNÂSKOKKEW, ok, (v. n.) he makes spits for roasting meat.
+x ASAWÂB, (knock) he watches attentively.
+« ASAWÂBAMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he looks at it at from far away as if to see it coming.
+« ASAWÂBIWIN, a, (n. f.) place from which one looks in the distance, observatory.
+x ASW, (rac.) watch, watch.
+« ASWAHWEW, (v. a.) HUWEW, HAM, HIKEW, he watches for him, he waits for him in a hiding place; v. g., n't'aswahwaw e wi-paskiswok, I'm watching it in order to shoot it; aswahuk mahiganak, watch out for the wolves.
+« ASWAHUWEWIN, a, (n. f.) Place from which one watches, from which one surveys. This is also how one refers to the bastions of a fort '.
+« ASWEYIMEW, (v. a) TTAM, MIWEW, TCHIKEW, he stands on his guard towards him, he watches him; v. g., asweyitta eka kita sisikutchihikuyan nipuwhi, be on guard so that death does not surprise you; asweyitta, ketattawe, ki ka mitâten, beware, you could well regret that; takki n't'aswe yitten, I'm still on my guard.
+x ABUIY, ak, (n. r.) oar, paddle, piwâbiskabuiy, ak, iron shovel.
+x ASÂM, ak, (n. r.) Snowshoe
+« ASÂMIKKEW, ok, (v. n.) He makes snowshoes.
+
+300
+
+ASA
+
+« ASÂMIKKAwew, (v. a.) TAM, KEW, TCHIKEW, he makes him snowshoes.
+x ASAmew, (v. a.) TTAM, KKEW, TCHIKEW, he gives him to him to eat. This verb is irregular. Asattuwok, they come down together to eat.
+« ASATTUWIN, a, (n. f.) the action of giving oneself something to eat.
+« ASAKKEWIN, a, (n. f.) the action of giving something to eat.
+x ASÂStew, (v. a.) TAM, SIWEW, TCHIKEW, he tattoos it.
+« ASÂSUW, ok, (v. r.) He's tattooed
+« ASÂSUWIN, a, (n. f.) Tattoo.
+x ASÂWI, or, ASO, (ad.) hand in hand; v. g., asâwi miyituwo, they give it from hand to hand; aso âtjimustâtuwok, they tell each other the thing; ayâsowipayiw, it is communicated from hand to hand
+« ASOSKAMÂwew, (v. a.) TAM, KEW, TCHIKEW, he communicates to him; v.g., asoskamâtuwok âkkusiwin, they communicate the disease to each other; Adam ki ki asoskamâkunow pastahuwin, Adam communicated to us sin
+« ASOSTAWEW, (v. a.) TAM, TAKEW, TCHIKEW, idem
+« ASOSTAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, idem
+« ASOSKAMÂTUWIN, a, mutual communication.
+« ASOSKAMÂKEWIN, a, communication.
+x ASA, or, AYASA, or, ASAWÂTCH, AYASAWÂTCH, (ad.)(malo animo, de industria), v. g. asa totam, he does it all wrong (deliberately); ayasawâtch pikiskwew, he talks crookedly, in a bad way; ayasawâtch ituttew, he goes on the wrong side; pikonata ite; a child who says his prayers all wrong, I would say: ayasawâtch itwew, he says (it) badly.
+
+ÂSW
+
+x ÂSWAY, (ad.) awasite, further, Above; v. g, âswây kit astân, you put it farther away, too far; someone who skips words while praying, âswây itwew.
+« ÂSWESKAWEW, (v. a.) KAM, KÂKEW, TCHIKEW, he passes him, he goes farther than him; âswây wikiwok, they remain further away.
+« ÂSWEPAYIW, ok, a, (a. in.) It goes too far, it acts too much.
+x AS, (rac.) In heaps, in heaps.
+« ASEYAS, (ad.) En masse, together; v. g., aseyas pakitinamok ot ayâniwâwa, they pile up their things; mâmawi.
+« ASAHYEW, STAW, YIWEW, TCHIKEW, (v. a.) he puts it in a heap; v. g., asahyewok pakkwejigana, they pile up the loaves.
+« ASAPIW, ok, (a. a.) it is a heap; v. g., asapiwok asshnyak, the stones are in a heap.
+« ASASTEW, a, (a. in.) is in a heap; asastewa mitchet mitta, there is a lot of wood in a heap.
+« ASIKÂBAWIW, ok, (v. n.) It is standing in a heap; v. g., misiwe asikâbawiwok mustuswok, the buffaloes are everywhere in droves, in a crowd, as if forming in heaps.
+« ASIKÂBAWISTAWEW, (v. a.) tam, tkew, tchikew, a. g. asikâbawistawewok, they stand in a crowd around him.
+
+301
+
+ASA
+
+« ASIPAYIW, ok, a, (a. a. and in.) it is in a heap.
+« ASÂSIW, ok, (a. a.) he is in a heap, v. g. kona asâsiw, the snow is in a heap, m a wasakwâsi w.
+« ASÂSTAN, wa, (a. in.) or, asâttin, wa, idem.
+« ASÂTTIN, wa, (a. in.) blunt, that which does not cut.
+« ASINEW, (v. a.) NAM, NIWEW, NIKEW, he puts it in a pile.
+« ASITISAHWEW, (v. a.) HAM, HUWEW, HIKEW, he brings them together in a heap; synonym, mâw asakutisahwew.
+« ASITJIMEW, ok, (v. n.) they come together in crowds, v. g. the fish..
+« ASÂPOKOW, ok, (a. a.) it gathers together in a heap, by the current:
+« ASÂPOTEW, a, (a. in.) idem.
+« ASÂHOKOW, ok, (a. a.) idem.
+« ASÂHOTEW, a, (a. in.) idem,
+x ASAYAWEW, ok, (a, a.) he is naked to the waist.
+« ASAYAWEPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he puts him naked up to the waist, dragging his clothes.
+« ASAYAWEPIW, ok, (a. a.) It is sitting naked to the waist.
+« ASAYAWESIN, wok, (a. a.) He is lying naked to the waist.
+x ASAWE, or, isawe, (n. r.) the sharp part, or, sharp edge a thing, v. g. isawe otchi pakamah, strike it with the edge.
+ASAWESIW, ok, (a. a.) Or, isawesiw, it is sharp, cutting :.
+
+ASA
+
+« ASAWEYAW, a, (a. in.) or, isaweyaw, it's sharp.
+« ASAWEKANAKISIW, ok, (a. a.) or, isawekanakisiw, ”. g. a thin animal whose spine seems to jut out sharply.
+« ASAWEKANAKAN, wa, (a. in.) v. g. a bone that would be shaped sharply.
+« ASAWEKKUtew, (v. a.) TAM, SIWEW, TCHIKEW, he cuts it into a sharp edge, or, isawekkutew.
+« ASAWEHEW, (v. a.) TTAW, HIWEW, HIKEW, or, isawehew, etc., he makes it into a cutting edge.
+« ASAWESWEW, (v. a.) SAM, SIWEW, SIKEW, or, isaweswew, etc., or, ayisaweswew, etc., he whittles it down to a cutting edge.
+« ASAWESK, wa, (n. f.) Or, isawesk wa, sword saber and isaweskokkumân.
+« ASAWEK, wok, (n. f.) Or, isawek, wok, square needle.
+« ASAWENEW, (v. a.) NAM, NIWEW, NIKEW, or, isawenew, etc., it turns on the sharp edge.
+« ASAWEPUW, ok, (v. n.) he misses while cutting the meat near his mouth. Note. The suffix puw, designates the action of eating.
+« ASAWEPWÂGAN, a, (n. f.) instrument for cutting meat near the mouth, it is the knife, mokkumân, which one sometimes refers to as such
+x ASSAN, (rac.) hard, compact, pressed, solid.
+« ASSANISIW, ok, (a. a.) It is hard, solid, having been pressed.
+
+302
+
+ASS
+
+« ASSANAYAW, a, (a. in.) Idâ
+« ASSANINEW, (v. a.) NAM, NIWEW, NIKEW, he hardens it, v. g. assannew pakkwejigana, he hardens the dough (kneading it] with his hand.
+« ASSANISKAWEW, (v. a.) KAM, KEW, TCHIKEW, he hardens it by trampling it with his feet.
+« ASSaNIWEPAHWEW, (v. a.) HAM, HUWEW, HIKEW, he hardens it by striking.
+« ASSANIW, oh, (a. a.) the sap stops flowing, the bark solidifies on the tree, v. g. assaniwok mistikwok, the trees have no more sap.
+« ASSANISKAW, (v. im.) There is no more sap.
+« ASSINIY, ak, (n. f.) stone, rock, one also says: kiniputchigan, ak, to sharpen.
+« ASSINIWIW, ok, (a. a.) He is a stone.
+« ASSINISKAW, (v. im.) It's rocky. Note. The âbis particle denotes stone or metal, v.g. kiskâbiskaw, cut rock
+« ASSINIBWÂTIS, ak, (n. f.) Assiniboine, the Sioux of the rocks.
+x ASSONÉ, (ad.) a lot, too much, mainly, osâm, v. g. ni matchipiraâtisin maka assone kiya, i'm mean, but mainly to you, assoné ekwa mayipayiw, it's going very badly at the moment, assoné ekwa ni wissakeyitten, now I'm suffering severely as well, kissinoban otikusik, maka assoné anotch, it was very cold yesterday, but mainly today, assoné ekwa matchi ayiwiw, he is very mean now.
+
+ASS
+
+« ASSOPAYIW, ok, a, (a. a. and in.) it acts too much, it goes too far.
+« ASSONEHWEW, (v. o.) HAM, HUWEW, HIKEW, he acts too much on him, v. g. someone who shoots an animal and misses because he pulled (his bowstring) too far.
+« ASSONEPAYISTAWEW, (v. a.) TAM, TÂKEW, TCHIKEW, he exceeds it by too much, kâsispupayistawew.
+« ASSONESKAWEW, (v. a.) KAM, KÂKEW, TCHIKEW, idem.
+« ASSONESKUYUW, ok, (a. a.) he ate too much.
+x ASÉ, (rac.) backing up, to go back.
+« ASEPAYIW, ok, a, (a. a. and in.) it goes backwards.
+« ASÂKEW, ok, crayfish, because he goes backwards.
+« ASETTEW, ok, (v. n.) he goes back, he walks in reverse.
+« ASEPATTAW, ok, (v. n.) he run back, backwards.
+« ASSEPIW, ok, (a. a) he goes backwards while seated.
+« ASEKÂBAWIW, ok, (v. n.) he goes back while standing.
+« ASEPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he pulls it backwards, asewepahwew, ham, he throws it back, backwards
+« ASETISAHWEW, (v. a.) HAM, HUWEW, HIKEW, he sends it back.
+« ASEYAKKINEW, (v. a.) NAM, NIWEW, NIKEW, he makes it go back by pushing it.
+« ASETJIMEW, ok, (v. n.) He goes back by rowing.
+
+303
+
+ASK
+
+« ASEYÂHUKOW, ok, (a. a.) He goes back into the water.
+« ASEYÂHUTEW, a, (a. in.) Idem
+« ASEYÂPOKOW, ok, (a. a.) he drifts back, backwards in the current
+« ASEYÂPOTEW, a, (a. in.) idem.
+« ASEYÂSIW, ok, (a. a.) he is carried back, backwards by the wind.
+« ASEYÂSTAN, wa, (a. in.) idem.
+« ASESIN, wok, (a. a.) he goes back, backwards while lying down.
+« ASETTIN, wa, (a. in.) Idem.
+« ASEWEW, ok, (v. n.) He returns in his footsteps.
+« ASETTAMEW, ok, (v. n.) He returns on his path, his way.
+« ASEHÂTTEW, (v. a.) TTAM, SIWEW, TCHIKEW, he follows his trail as he returns on the way/path.
+« ASETAHÂTTEW, etc., idem.
+« ASESKAWEW, (v. a.) kam, kâkew,tchikew, he backs him up.
+« ASETTAMEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he returns to his thoughts about him.
+« ASSENEW, (v. a.) NAM, NIWEW, NIKEW, he pushes it back, he rejects it, he reproves it, v. g. ayamihawin assenam, he rejects religion, he denies prayer.
+« ASSENAMÂwew, (v. a.) TAM, KEW, TCHIKEW, he rejects him, he refuses him, he despises him.
+« ASEHYEW, (v. a.) Staw, yiwew, tchitchikew, he places it on the back, backwards.
+« ASESIN, a, (n. f.) The top of the shoe.
+x ASKAMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he watches for him, v. g. someone who secretly awaits another person in order to strike him, he waits in ambush for him.
+
+ÂSK
+
+« ÂSKAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, idem.
+« ASKATAW, ok, (v. n.) Get into rank to stand watch. One uses this word when the savages line up on two sides to bring the buffaloes into a clearing.
+x ASITJI, (ad.) or, asitchi, with, v. g., kiyà asitji ki sim, you with your brother; sipwettew asitji ot'ema, he leaves with his horse. However, in these sentences: he hits it with a stick, he cuts it with a knife, we use otchi, v. g., pakamahwew mistik otchi, môkkumân otchi manisam. It can also take the form: mokkumâo manisikâkew, tchikahigan otchi tchikahikew, or, tchikahigan tchikahikâkew, he logs with an ax. See the word Avec in the French-Cree Dict.
+« ASITJIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he puts it in the same rank, for example, a person on account whom one speaks badly with others, one would say: asitjimaw, he is joined to him in his conduct.
+« ASITJIPAYIW, ok, a, (a. a. and in.) it goes with, it joins, it meets at. 
+« ASITAPIW, ok, (a. a.) he is seated with others.
+« ASITASTEW, a, (a. in.) Idem.
+« ASITINEW, (v. a.) nam, niwew,nikew, he mixes it up with.
+« ASISUY, a, (n. f.) Slice of iron, piece of iron used to break ice.
+
+304
+
+ÂSI
+
+« ASITÂSKWATAHWEW, (v. a.) HAM, HUWEW, HIKEW, he nails it to another piece.
+« ASITASKAMIK, (ad.) From the earth, on the earth, with the earth.
+« ASITASKAMIKINEW, (v. a.) NAM, NIWEW, NIKEW, he's got it on the earth 'he holds it against the earth, he him bites the dust.
+x ASI, ASE, ASA, (rac.) spoiled, putrified, rotting.
+« ASIPIJISKIW, ok, (n. f.) dead animal, alone in rotting.
+« ASITAMEK, wok, (n. f.) dead fish, already spoiled.
+« ASAWI, a, (n. f.) Spoiled, rotten egg
+« ASISIY, a, (n. f.) tall dirty grasses that grow in the depths of lakes and rivers.
+x AJIGAN, ak, (n. r.) worn-out old clothes, stockings, slipper.
+« AJIKEW, ok, (a. a.) he has stockings on his feet.
+« AJIKEHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he puts stockings on his feet.
+« AJIKEKKAWEW, (v. a.) KAM, KÂKEW, TCHIKEW, idem.
+x ÂSIHEW, (v. a.) TTAW, HIWEW, HIKEW, he brings him bad luck, v. g., someone who would see an extraordinary being or thing, and from that would suppose that some accident will befall him, for example, the death of a parent, would look like: eoko n't'âsihik, or, n't'âsihikun; âsihik otema, his horse brings him misfortune.
+« ÂSIHUW, ok, (v. r.) something happens to him that makes him foresee that some accident will befall him; âsiwisiw, he brings bad luck; âsiwan, it brings bad luck.
+
+ÂSI
+
+x ÂSITÂSKAMIK, wa, (n. r.) a sort of very thin foam near lakes.
+« AJISKIY, a, (n.) dust, mud, earth; v. g., n't'ajiskim, my land, my field; nâtajiskiwew, he goes looking for dirt, mud, mortar
+« AJISKIWIW, ok, (a. a.) It is earth, dust; .v. g., ajiskiwin kit, ekusi mina kâwi ki ka ajiskiwin, pulvis est et in pulverem reverteris.
+« AJISKIWAN, wa, (a. in.) it's earth, dust.
+x ÂSIYÂN, ak, (n. r.) loincloth; ot'siyâniw, he has a loincloth.
+x ÂSITCH, ÂSITE, (rac.) that which exceeds, which goes further.
+« ÂSITEPAYIW, ok, a, (a. at. and .in.) it goes beyond, it goes further.
+« ÂSITEPAYISTAWEW, (v. a.) TAM, TAKEW, TCHIKEW, he overtakes him on a horse, miyâskawew.
+« ÂSITEMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he reasons with him, he contradicts it, he replies to him; naskwewojimew, v. g., âsitemew ottâwiya, he reasons with his father.
+« ÂSITEMOW, ok, (v. n.) He reasons, he contradicts, naskwewojimow.
+« ÂSITEMUW, a, (v. im) it exceeds, it intersects while exceeding, going ahead, v g., two intersecting paths, âsitemuwa meskanâwa.
+« ÂSITESIN, wok, '(a. a.) He exceeds, extends, he crosses paths lying down.
+« ÂSITETTIN, wa, (a. in.) it exceeds, extends, crossing each other.
+
+305
+
+ÂSI
+
+« ASITESIMEW, (v. a.) TITAW, MIWEW, tchikew, he makes it exceed, extend, cross, by placing it.
+« ÂSITESKAWEW, (v. a.) KAM, KÂKEW, TCHIKEW, he meets him while passing; v.g., âsiteskâtuwok, they intersect.
+« ÂSISKAWEW, (v. a.) KAM, KÂKEW, TCHIKEW, he arrives before him, he exceeds it, for example, I leave with someone who, by passing through another path, arrives before me at the designated place, I would say: n't'âsiskâk; âsiskâkuw nipuwin, death arrives from ahead, that is to say, without being expected.
+« ÂSISKUN, (ad.) Forward, in front of, in front; v. g., âsiskun totam, like someone who acts secretly, to enjoy an opportunity to be alone; âsiskun ki totawin, you wish to supplant me.
+« ASISKUNAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he supplants him, he arrives before him, he deprives him of a good opportunity; v. g., ni wi-atâwâtây mistatimwa, maka Paul n't'âsiskunamàk, I wanted to buy a horse, but Puul got in the way of the opportunity; ki wi-miyi-ti. maka ki sim kit âsiskunamâk, I wanted to give it to you, but your younger brother got in the way, fraudulently supplanting you; Jacob ki âsiskunamâwew ostesa Esauwa, Jacob supplanted his elder brother Esau.
+
+
+
+x AJIWA, (*) (rac) cross a river. (*By forgettance, this root is not placed in its alphabetical order.)
+« AJIWÂHAM, wok, (v. n.) he crosses a body of water.
+« AJIWAKÂMEHAM, wok, (v. n.) idem
+« AJIWAHUYEW, (v. a.) TAW, YIWEW, TCHIKEW, he crosses it, he makes him cross.
+« AJIWAHAMAWEW, (v. a.) TAM, KEW, TCHIKEW, he crosses it to him.
+« AJIWAHUNÂN, a, (n. f.) Crossing, place where one crosses.
+« AJIWAHUW, ok, (v. r.) He crosses himself
+« AJIWAKÂSIW, ok, (v. r.) idem.
+« AJIWAKAMEMUW, a, (v. im.) Path where the crossing is.
+« AJIWAWÂSIW, ok, (a. a.) He crosses by the current.
+« AJIWAWÂSTAN, wa, (a. in.) idem
+« AJIWAHUKOW, ok, (a. a.) he crosses by the current,
+« AJIWAHUTEW, a, (a. in.) idem.
+« AJIWÂPOKOW, ok, (a. a.) he crosses by being swept away by the current.
+« AJIWAPOTEW, a, (a. in.) idem.
+« AJIWISKUTTEW, ok, (v. n.) he crosses on the ice.
+« AJOGAN, a, (n. f.) Bridge.
+« AJOGANIKKEW, ok, (v. n.) he makes a bridge.
+« AJOGANIKKAWEW, (v. a.) TAM, KEW, TCHIKEW, he bridges it.
+x AJIWAY (rac.) put in, v.g. in a bag.
+
+306
+
+ASO
+
+« AJIWAyew, (v. a.) TAW, YIWEW, TCHIKEW, he puts it in a bag; v.g., ajiwày k'ospwâgan kit aphpitik, put your pipe in your bag; otâmaskinahew, etc.
+« AJIWATCHIGAN, a, (n. f.) bag, room for storing something.
+« AJIWASUW, ok, (a. a.) it is in a bag, a hole; v. g., ajiwasuw mahigan, the wolf is in his hole; nam a kekwày ajiwasuw n'ospwâganik, there is nothing in my pipe.
+« AJIWATEW, a, (a. in.) it is closed in; v. g., nijo monsassiniya ajiwatewa ni passkisiganik, two bullets are in my rifle.
+« AJIWATÂSUW, ok, (v. n.) he presses it by putting it in a bag; ajiwâyiwew, asânaskihew.
+x ASOMEW, (v. a.) TAM, MIWEW, TCHIKEW, he spies an opportune occasion either to dispute it or hit it, he takes the resolution for, etc .; asweyimew, he waits for it, he spies on it, v. g., n't'asomaw mayo nan do isitji, ni wi-naskweojimaw, I wait for him, as soon as he tells me something, I shall reply to him.
+« ASWEYIMEW, TTAM, MIWEW, TCHIKEW, he spies on him, he seeks an occasion to surprise him.
+« ASOTAMÂWEW, (v. a,) TAM, KEW, TCHIKEW, he promises her; v. g., kit asotamâtin kitchi witjewitân, I promise to go with you; asotamâwin kitchi miyiyan, promise me to give it to me.
+
+ASO
+
+« ASOTAM, wok, (v. n.) he promises; v. g., asota ekwa ekaekusi kitchi totaman, promise not to do anymore that.
+« ASOTAMOWIN, a, (n. f.) Promise, wish; v. g., awiyak piyekunaki ot asotamowin pastâhuw, he who misses his wish commits a sin.
+x ÂSUW, ok, (v. r.) it rests on, standing or sitting, or, he puts his hands (on it).
+« ÂSUTOTAWEW, (v. a.) TAM, KEW, TCHIKEW, he leans on him, or, he lays his hands on him; v. g. , mistik âsutotam, it is resting on a piece of wood; âsutotawin, lean on me. N. Indians also use these words to say: impose one's hands.
+« ÂSUKÂBAWIW, ok, (v. n.) he leans on, etc., while standing.
+« ÂSUKÂBAWIStawew, (v. a.) TAM, KEW, TCHIKEW, he leans on him standing.
+« ÂSOSIMEW, (v. a.) TITAW, MIWEW, tchikew. he presses, or, he makes it press, v. g., for setting someone along a wall, supported on it, I would say: n't'âsosimaw, or, a patient that I lift up a little to keep seated supported by something to lean on, n't'âsosimaw.
+« ÂSOSIN, wok, (a. a.) It is pressed while lying down.
+« ÂSOSIMOW, ok, (a. a.) idem
+« ÂSOTTIN, wa, (a. in) idem.
+x ÂSKAW, (ad.) or, âskawi, or, ayâskawi, sometimes, from time to time, v. g. âskaw piko ka pikiskwet, he speaks only rarely, e ati-wâbamât, passkiswew ayâskawi, as he sees them, he shoots them.
+
+307
+
+ASK
+
+« AYÂSKAWEYIMEW, (v. a.) TTAM,miwew, tchikew, he sometimes thinks of him.
+« AYÂSKAWÂTISIW, he is the type of person to only sometimes act.
+« AYASKAWÂTAN, wa, (a. in.) idem
+x ASK, (rac.) raw, green in color.
+« ASKITIW, ok, (a. a.) It is believed, v. g. eoko sisiû namawiya kisisuw, eyâbitch askitiw, this duck is not cooked, it is still raw.
+« ASKITIN, wa, (a. in.) It's believed.
+« ASKIN, wa, (a. in.) Idem, v. g. kik'askin n't'asamik, he gives me something raw to eat.
+« ASKEGIN, wa, (n. f.) Raw skin, which is not yet tanned.
+« ASKIWIYÂS, a, (n. f.) Raw meat.
+« ASKÂSKUSIY, a, (n. f.) Green wood.
+« ASKÂWEW, ok, (v. n.) He eats raw eggs. Note, The suffix âwew indicates eggs.
+« ASKIPUW, ok, (v. n.) He eats raw things.
+« ASKIPUYEW, (v. a.) He makes him eat raw things.
+« ASKIPWAW, a, (n. f.) (wild root) this is generally how one refers to potatoes.
+« ASKITTAK, wa, (n. f.) Spruce, on which there is a green moss.
+
+ASK
+
+« ASKITAKKISIW, ok, it is green, not dry; also, it is of green color.
+« ASKITAKKAW, a, green.
+« ASKIPETAKISIW, idem
+« ASKIPETAKAW, a, (a. in.) idem.
+x ASKIY, a, (n. r.) Earth, the universe, waskitaskamik, on earth, down here. The ending skamik indicates Earth, ekute otaskiw, this is his country, nama nando n'otaskin, I do not have my own country, misiwe k'otaskin, all the earth is your homeland.
+« ASKIWINIKKEW, ok, (v. n) he has it as his country, v. g. moniyâk n't'askiwinikkân, in Canada is my country. N. It is from that root that the following expressions: wetaskiw, he makes peace with him, this, which means: he has the same land as him, owetaskimâgana, the one with whom he made peace, wetaskiwemew, he has the same homeland as him, he is one of his compatriot, owetaskiwimâgana, his compatriot.
+« ASKIYA, (n. f.) moss. N. This word is not used in the singular.
+x ASKIK, wok, (n. r.) boiler, mistikwaskik, wood boiler, drum.
+x ASKIMEW, ok, (v. n.) he laces snowshoes.
+« ASKIMÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he ties it up, he weaves it.
+« ASKIMÂTAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he laces him.
+
+308
+
+ASK
+
+x ASKAWIW, (v. im.) there is a pond but this is only used when it is in the ice, there are places where the water is not frozen.
+x ASKUNAW, ok, (v. n.) he dams a river with woods in order to take the fish, this appears to come from the root askamâwew, spy, but the word askunaw does not need to be said when speaking of fish.
+« ASKUNÂTEW, (v. a) TAM, SIWEW, TCHIKEW, he spies on it to surprise it, hit it, if it's a fish, because one catches only from these barriers.
+x ASKOKEW, ok, (v. n.) he follows, he walks after, behind.
+« ASKOWEW, (v. a.) TTAM, KEW, TCHIKEW, he follows him, he walks after him, askottuwok, they walk one after the other, awiyak e askowit namawiya kita wanitibiskokkew, he who follows me does not walk in darkness.
+« ASKOWISKAWEW, (v. a.) TAM, KEW, TCHIKEW, he's after him , he is preceded by him, it only comes with age, v. g. awah n't'askowiskâk, this one comes after me, or, I am his elder brother, or, n'ostesiskawaw.
+« ASKUTCH, or, ayaskutch (ad.) one after another, after, turn for turn, vicissim, voy. iyaskutcb v. g. kiya ayaskutch pikiskwe, speak in your turn.
+x ASKOTAWISKAW, ok, (v. n.) he comes back with nothing, someone who goes hunting and brings back nothing, v. g, tattwaw miyâtjiyân n't'askotawiskân, whenever I go hunting, I come back empty-handed.
+
+ASK
+
+« ASKOTAWISIW, ok, idem.
+x ASP, (rac.) Use something to act, using, with the help of, put on, apply on.
+« AYSPAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he puts it on, he covers it, he stretches it out, v. g. a tablecloth on a table.
+« ASPASTÂGAN, a, (n. f.) Tablecloth, apron.
+« ASPASKUSÂWÂN, a, (n. f.) this is for the aid of those who smoke tobacco, something to mix with tobacco.
+« ASPAKUW, ok, (v. r.) He covers himself using, etc., v. g. nijo mustusweyânak n't'aspakun, I covers me with two dresses. Note. The ending kuw, designates the action of stretching something on oneself, moyâbitasekuw, he covers himself by putting his blanket on backwards.
+« ASPAHÂKEMOW, ok, (v. n.) He asks for help to, etc., he hopes in, v. g. e ittât Kijemanito n't'aspahâkemowân tchi ​​kitimâkeyimit, God being, I hope He will have mercy on me; he trusts.
+« ASPAHÂKEMOWIN, a, (n. f.) trust.
+« ASPAHÂKEMOTOTAWEW, (v. a.) TAM, KEW, TCHIKEW, he trusts him, v. g. aspahâkemototaw kitchitwaw Marie, ekusi Kijemanitowa ki ka kitimâkevimikoyiwa, put your trust in Mary and God will have mercy on you.
+
+309
+
+ASP
+
+« ASPEYIMOW, ok, (v. n.) He trusts.
+« ASPEYIMOWIN, have, confidence.
+« ASPEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, I think that he trusts.
+« ASPEYIMOTOTAWEW. (v. a.) tam, tikew, tchikew, he trusts him.
+« ASPI-KÂKISIMOW, ok, (v. n.) I beg in the name of, etc., by means of, etc.
+« ASPI-KÂKISIMOTOTAWEW, (v. a.) TAM, TAKEW, TCHIKEW, he begs for it by means of, on behalf of, v. g. okijewâtisiwiniyiw ot aspikâkisimototawâttay, he begs in the name of his charity, ki kosis Jesus Christ kit aspi-kâki-simototâtin, I beg You in the name of Jesus Christ Your Son.
+« ASPATOTEW, (v. a.) TAM, SIWEW, TCHIKEW, he makes him work at such price.
+« ASPIMEW, (v. a.) TAM, MIWEW, TCHIKEW, (idem) he promises her so much, v-g. tamëyikok kit aspimik? how much did he promise you?
+« ASPAPIW, ok, (v. n.) he puts something under him, to sit there, or, he sits with the help of something.
+« ASPAPIWIN, a, (n. f.) Saddle for riding a horse.
+« ASPISKWESIMOW, ok, (v. n.) he puts something under his head.
+« ASPISKWESIMOWIN, a, pillow
+
+
+
+« ASPISKWESIMOWINIKKEW, ok, (v. n.) he prepares a pillow.
+« APISKWESIMOWINIKKAWEW, etc., (v. a.) he prepares a pillow for him.
+« ASPÂBOWEW, ok, (v. n.) he seasons his food by means of, etc.
+« ASPÂBOWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he seasoned it by means of, etc., with, v. g. pimïy n't'aspâbowâten, I season it with fat.
+« ASPATCHIKEW, ok, (v. n.) he eats while adding something else to it, v. g. miyosiw pakkwejigan, kispine e aspatchikek totosâbu-wipi-mïy, the bread is good, if one eats it with butter, namakekway aspatchikew, he eats dry, unseasoned, without having fat to join.
+« ASPATCHIKEWIN, a, (n. f.) accompaniment with fat.
+« ASPISKOYEW, (v. a.) TAW, YIWEW, TCHIKEW, he puts something on him, v. g. to put some cloths between the horse's back and the saddle.
+« ASPISKOSUW, ok, (a. a.) he has a cushion on it.
+« ASPISKOTEW, a, (a. in.) Idem.
+« ASPISKOTCHIGAN, ak, (n. f.) cushion which one places between the back of the horse and saddle.
+« ASPINEW, (v. a.) NAM, NIWEW, NIKEW, he takes it by means of, etc
+« ASPIKINÂGAN, a, (n. f.) rifle case, rifle cover
+« ASPI, (ad.) By means of, using, etc .; v.g., oyâgan n't'aspiminikkwân, I drink with a dish, or better yet: ni minikkwâkân oyâgan. This adverb also means, even, all the same; v. g., askikwa aspi-mi-nikkwew, he even drinks from the boiler.
+
+310
+
+ASP
+
+x ÂSPIS, or, AYÂSPIS, (ad.) from time to time, from distance to distance; v. g., ayâspis piko koniw: there is only snow in some places. It also sometimes means the same thing as âskaw; v. g. , ayâspis piko ekwa wissakeyittarr, he now only suffers occasionally.
+x ASPIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes him jealous by not giving him as much as others, he does him injustice. ; Kije-manito nama awiya aspihew, God does injustice to no one (in the distribution of his gifts]
+x ASPIN, (ad.) since, afterwards, since then; v. g., kayâs aspin ka wabamak, it has been time since I have seen him; aspin namawiya otchi pe-kiwew, he has not come back since; ekusi tchi aspin? has it been since? is that how he disappeared?
+x ASPO, (rac.) stingy, to keep for oneself.
+« ASPONISIW, ok, (a. a) he is egotistical, he keeps everything to himself; v. g. someone who has something to eat and does not want to give anything to those who are hungry.
+« ASPONEYIMOW, ok, (v. n.) He is selfish, he only thinks of himself.
+
+ASP
+
+« ASPONEYIMOTOTAWEW, (v. a.) TAM, TÂKEW, TCHIKEW, he is selfish towards him.
+« ASPONEYIMOWIN, a, (n. f.) selfishness:
+« ASPONEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he finds it selfish.
+« ASPONÂKÂTCH, (ad.) in a miserly or selfish way; v. g., asponâkâtch totam, he acts selfishly.
+x ASTAM, (rac.) Below, over here, closer.
+« ASTAM, (v. 2nd pers. of the singular imperative) come on! astamitik, plur. come ! This verb has only these two person-inflections.
+« ASTAMAPIW, ok, (a. a.) he presents his face; v. g., e astamapit, in his presence; otchiskawapiw.
+« ASTAMAPIWIN, a, (n. f.) presence.
+« ASTAMEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks him lesser, he has a lesser idea of ​​him, he thinks ​​him weak; astamiwo keyimew, ttam, he believes it less; astamiwokeyimow, or, misuw, he thinks himself lesser; astamiwokeyimowin, low self-esteem.
+« ASTAMISIN, wok, (a. a.) It is lying on this side, over here.
+« ASTAMITTIN, wa, (a. in.) idem.
+« ASTAMISIMEW(v. a.) TITTAW, MIWEW, TCHIKEW, he places or lays it below.
+« ASTAMIK, (ad.) Less, less, last, lowest; v. g., astamik kimiwan ekwa, it's raining less now; mâmawiyes astamik eoko iyiniw, it is the last of the men.
+
+311
+
+AST
+
+« ASTAMEYIKOK, (ad.) Idem; v. g., astameyikok kissin, it is less cold; astameyikok matchi-pimâtisiw, he is less cruel; astameyikokés, a little less.
+« ASTAMITA, (ad.) Over here, (closer); astamite, by there, (farther) ; v. g., astamita pe-api, come sit over here.
+« ASTAMISPI, (ad.) Since that time then, (one indicates that it is after such a duration of time); v. g., astamispi nama-wikkâtch ekusi totam, since then he never does that.
+« ASTAMÂTTIK, (ad.) On this side of the wood, forest.
+« ASTAMÂSKWEYAW, (ad.) idem.
+« ASTAMÂMATIN, (ad.) On this side of the hill, of the mountain.
+x ASTÂSIW, ok, (v. n.) he is afraid, he fears some surprise; v. g., konata kit astâsin, you scare yourself for no reason ; ekawiya astâsi, namawiya ekusi ki ka totâtin, fear not, I will not do this to you.
+« ASTÂSIWIN, a, (n. f.) anticipated fear.
+« ASTÂHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he holds it in fear, v. g., for someone who is always wary about me, I would say: n't'astâhaw, for someone of whom I am wary, towards whom I must be on my guard, I would say: n't'astâhik. kit astâhin, mâskutch namawiya ki tapwewokeyitten, I distrust you, perhaps you do not have faith; astâhiwewok eokonik iyiniwok, we distrust these people, or, they make us afraid.
+
+AST
+
+« ASTÂHUWIN, a, (n. f.) fear made by oneself.
+« ASTÂUUW, ok, (v. r.) he makes himself afraid.
+x ÂST, (rac.) to cease to be, to cease to exist.
+« ÂSTAWEW, a, (a. in.) it's off, extinguished.
+« ÂSTAWEHWEW, (v. a.) HAM, HUWEW, HIKEW, he turns it off, extinguishes it.
+« ÂSTEPAYIW, ok, a, (a. a. and in.) it stops.
+« ÂSTESIN, wok, (a. a.) he stops being tired.
+« ÂSTEYOTIN, (v. im.) the wind stops.
+« ÂSTEMATCHIHUW, (v. r.) he ceases to experience such a pain. NOTE. And so on, adding the suitable word for the root âst.
+x ASTÂWEW, ok, (v. n.) he puts feathers in arrows.
+« ASTÂWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he puts feathers on it; v. g., n't'astâwâten ni nipisima, I put feathers on my arrows.
+x AST, (rac.) keep in reserve, conserve.
+« ASTÂWINITTAW, ok, (v. n.) he puts firewood in the lodge or house, in a heap, for the fire.
+« ASTÂWINÎTTÂN, a, (n, f.) Pile of wood, all ready in the lodge or house.
+« ASTOPATEW, (v. a.) Tam, SIWEW, TCHIKEW, he puts a liquid in reserve, he saves something for him to drink.
+« ASTOPASUW, ok, (v. r.) he reserves it for himself to drink.
+
+312
+
+AST
+
+« ASTWAW, ok, (v. n.) He puts it in reserve to eat.
+« ASTWÂWIN, a, (n. f.) reserve of provisions.
+« ASTOWEW, (v. a.) he reserves it for him to eat. Note. One also uses this word to say: he bets with him, he gambles with him; v. g., astwâtutâk, let's bet; n't'em kit astwàtin, I bet you my horse.
+« ASTWÂKEW, ok, (v. n.) he bets, he gambles; v. g., kakiyaw ayâna astwâkew, he gambles all of his wealth.
+« ASTWÂKEWIN, a, (n. f.) bet
+« ASTWÂTUWIN, a, (n. f.) Idem.
+« ASTUSWEW, ok, (v. n.) he puts the meat in a cache, v. g., someone goes hunting and caches their meat to return and fetch later.
+« ASTUSWEWIN, a, (n. f.) action of putting meat in a cache
+« ASTUSWÂTEW, (v. a.) TAM, WEW, TCHIKEW, he puts it in a cache (the animal he killed.)
+« ASTATJIKUW, ok, (v. n.) He puts something in a cache, he deposits something.
+« ASTATJIKUWTN, a, (n. f.) deposit, reserve, hide.
+x ASTIS, ak, (n. r.) mitten; iyekastis, ak, glove.
+x ASTIS, sa, (n. r.) nerves or sinew of the kidney, for other nerves one says: otchestatây, a.
+« ASTINWÂN, a, (n. f.) sinew, prepared for sewing.
+« ASTINWANIKKEW, ok, (v. n.) he prepares sinew for sewing.
+
+AST
+
+« ASTINWÂNIKKAWEW, (v. a.) TAM, KEW, TCHIKEW, he prepares sinew for sewing.
+x ASTOTIN, a, (n. r.) cap, hat, hood.
+x ASTOYUW, ok, (v. n.) he makes a canoe.
+« ASTOYAWEW, (v. a.) TAM, KEW, TCHIKEW, he makes him a canoe.
+« ASTINEPIW, ok, (v. n.) she broods, she remains on her eggs, or, kikatchistwânepiw.
+x ÂTA, or, ATAWIYA, (ad.), however, nevertheless ; v. g., Atawiya ni wi-kakwe ayamihân, I want, however, to pray; sâsày ki wâbamew âta, he has already seen it nevertheless. If I ask someone: sascy tchi ki ki toten? have you already done that? he could answer me: âta, which means: I did it, however, it was perhaps not done well; âta tchi ki kiskisin? Have you got your mind right? âta, I still have it.
+« ÂTAKUSHA, (ad.) yet, however; v. g., âtakusha sâsây ki ki miyitiu, but I already given it to you; âtakusha k'oskijikun eka ka wâbattaman, you have eyes and yet you still do not see.
+x ATAK, wok, (n. r.) star.
+« ATCHAKUS, ak, (n. f.) small star.
+x ATÂM, or, ITÂM, (rac.) at the bottom, on the inside. Note. It makes no difference whether one says atâm or itâm, in any of the words that have this root.
+« ATÂMIWEW, ok, it's deep, or, atâmâgan.
+
+313
+
+ATA
+
+« ATÂMIK, or, itâmik, (ad.) At the bottom, v. g. atâmik wâtik, at the bottom of a hole.
+« ATÂMIPEK, (ad.) At the bottom of the water.
+« ATÂMASKAMIK, (ad.) Atâmaskamikok, deep in the earth.
+« ATÂMÂKUNAK, (ad.) At the bottom of the snow.
+« ATÂMÂTTIK, (ad.) Or, atâmâttak , or, atâmâmâskweyaw, at the bottom of the wood, deep in the forest.
+« ATÂMASKAW, (ad.) Or, atâmaskusiwok, at the bottom of the hay.
+« ATÂMUSKIWOKAW, (ad.) at the bottom of the mud.
+x ATÂMIMEW, (v. a.) TAM, MIWEW, TCHIKEW, he suspects it, he says that it was him who did that.
+« ATÂMEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he suspects it, he thinks he has done this, v. g. n't'atâmeyimaw kitchi totawit, I suspect that it is him who did that to me, a't'atâmeyitten, eoko otchi k'o àkkusiyân, I think that's why I'm sick.
+« ATAMEYITTÂKUSIW, ok, (a. a.) one can suspect it, he deserves to be suspected.
+« ATÂMEYITTÂKWAN, v. in) idem.
+x ATAMEK, wok, (n. r.) dead, rotten fish which is alone, asikinusew, asatamek, idem.
+x ATAM, (rac) happy, satisfied.
+« ATAMINAW, ok, (a. a.) he is happy.
+« ATAMINÂWIN, a, (n, f.) Contentment, satisfaction, happiness.
+
+ATA
+
+« ATAMIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he pleases him in telling him such and such a thing.
+« ATAMIHIWEW, ok, (v. ind.) he is happy, he pleases someone.
+« ATAMIHIWEWIN, a, (n. f.) the action of pleasing.
+« ATAMIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes him happy.
+« ATAMISKAWEW, (v. a.) TAM, KEW, TCHIKEW, he greets him. Note. The real meaning of this word is: he acts on him to make him happy.
+« ATAMISKÂTUWIN, a, (n. f.) reciprocal greeting.
+« ATAMISKÂKEWIN, a, (n. f.) greeting.
+x ATÂ, (rac) buy, sell.
+« ATÂMEW, (v. a.) he buys him, and, he sells him. The meaning of the sentence makes it clear, v. g. ki ka atâmitin kit em, I'm going to buy your horse, ki ka atâmitin n't'em, I will sell you my horse, atâmin, buy from me.
+« ATÂWEW, Ok, (v. n.) He buys, or, sells, or deals.
+« ATÂWEWIN, a, (n. f,) sale or purchase.
+« ATTÂTUWIN, a, (n. f.) Mutual sale.
+« ATTÂTUW, ok, (v. m.) Sell to each other, ka attâtunânow,; I will sell to you, and you will buy from me.
+« ATÂWÂKEW, ok, (v. n.) he buys by means of, etc., v. g. atâwâkew otema, he buys something by selling his horse.
+« ATÂWEWIYINIW, ok, (n. f.) merchant, seller.
+
+314
+
+ATA
+
+« ATÂWEWIKAMIK, wa, (n. f.) store, ekawiyaatâwewikamikokâtamuk n'ottâwïy o wâskahigan, Do not make my Father's house a marketplace.
+« ATÂWESTAMÂWEW, (v. a.) KEW, TCHIKEW, he sells, or, buys for him.
+« ATÂWÂTIttew, (v. a.) same, atâwestamâwin mokkumân buy me a knife, ki ka atâwâtittitin kit'em, I will sell your horse for you.
+« ATÂMÂGAN, ak, (n. f.) Buyer, seller.
+« ATÂWÂGAN, ak, (n. f. what one uses to buy or sell, however one hears this more generally to describe furs.
+x ATAW, (rac.) despise, detest, scorn.
+« ATAWEYIMEW, v. a.) TTAM, MIWEW, TCHIKEW, he scorns it, he does not find it to his liking.
+« ATAWITTAWEW, (v. a.) TTAM, TÂKEW, TÂTCHIKEW, he scorns (him) with his words.
+« ATAWINAWEW, (v. a.) NAM, NAKEW, NATCHIKEW, he scorns it by looking at it.
+« ATAWEYITTÂKUSIW, ok, (a. a.) he is contemptible.
+« ATAWEYITTÂKWAN, wa, (a. in.) idem.
+« ATAWEYITTAMOWIN, a, (n. f.) contempt, disdain.
+« ATAWEYITCHIKÂSUW, ok, (a. a.) he is despised.
+« ATAWEYITCHIKATEW, a, (a. in.) idem.
+
+ATT
+
+x ATTAY, ak, (n. r.) more, pelts, fur, v. g. tantattwattay ki tipahen? how much more do you pay? nistwattayesiw nikikkweyân, otter pelt is three more, nijwaltayeyaw, it's two more, manatawâganew, ok, he works the pelt.
+« ATCHÂS, sak, small furs, pelts.
+x ATÂWIKAW, (v. im.) the dusk.
+x ÂTT, (rac.) Put in another position, change place, redo again.
+« ÂTTAHYEW, (v. a.) Staw, yiwew, tchitchikew, he changes its place, v. g. taneki k'o âttastâyan ki wâskahigan? why have you moved your house?
+« ÂTTINEW, (v. a.) NAM, NIWEW, NIKEW, he puts it in another place, v. g. âttin kit awâssimis, put your child in another place.
+« ÂTTAPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he ties it up again.
+« ÂTCHI, (ad.) Or, ayâtchi, again, more, more and more, v. g. ata e kitahamâwok, âtchi ni sasibittâk, the more I defend him, the more he disobeys me, e sâkihit Kije-manito âtchi wi-sâkihaw, when one loves God, one would like to love him even more.
+« ÂTCHIPIKO, (ad) idem, v. g. ata e nanatawihuyan âtchipiko ni wissakeyitten, no matter how well I treat myself, I suffer more.
+« ÂTCHIW, ok, (v. n.) It changes position.
+« ÂTCHIWIN, a, (n. f.) A change of position.
+
+315
+
+ÂTO
+
+« ÂTCHESUW, ok, (a. a.) She's wearing something new, she is carrying something small, this, means animals, although sometimes one says this about women, very coarsely; pwâwiw, is understood for all females of all species.
+« ÂTCHIMOW, ok, (v. n.) he says.
+« ÂTCHIMOWIN, a, (n. f.) story, news.
+« (ÂTCHIMEW, (v. a.) MIWEW, he tells it, he makes his story, he speaks of him.
+« ÂTOTAM, (v. a. in.) TCHIKEW, he tells (of) that.
+« ÂTCHIMISUW, ok, (v. r.) he confesses, ayamihewâtchimisuw, he confesses sacramentally.
+« ÂTCHIMISUWIN, a, (n. f.) Confession, admission, ayamihewâtchimisuwin, sacramental confession.
+« ÂTCHIMISUSTAWEW, (v. a.) Tam, takew, tâtchikew, he confesses to him,
+« ÂTCHIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he does it again.
+« ÂTCHIWESIW, ok, (a. a.) he remakes himself, he becomes better.
+« ÂTCHIWETTIN, wa, idem.
+« ÂTCHEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks of him again, or in a new light.
+« ÂTTEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he changes his mind on his account.
+« ÂTOTEW, (v. a.) TAM, SIWEW, TCHIKEW, he tells it, he makes the story. Note. Only the inanimate form here is usual, v. g. atota ka totaman, tell us what you did, nama kekway ni ki atoten, I have nothing to say.
+
+ÂTO
+
+« ÂTOTIKUSIW, ok, (a. a.) one tells (a story) about him.
+« ÂTOTÂKWAN, wa, (in.) one tells that, etc.
+« ÂTAYOKKEW, ok, (v. n.) He tells tales, fables.
+« ÂTAYOKKEWIN, a, (n. f.) The action of telling tales.
+« ÂTAYOKKAN, ak, (n. f.) tale, fable. Note. One also uses this word to refer to the fabulous spirits, which one could call the gods of the Indians.
+« ÂTAYOKKAWEW, (v. a.) kam,kew, tchikew, he tells him tales, fabulous stories.
+« ÂTTOKEW, ok, (v. n.) he changes his place.
+« ÂTTOKEWIN, a, (n. f.) action of moving one's home.
+« ÂTTOKAMIK, (ad.) Or, ayâttokamik, in another house, in a stranger's house.
+« ÂTCHIYINIW, ok, (n. f.) Or, more commonly ayatchiyiniw, foreign man, this is how the Cree refer to the Blackfoot, and more generally to all those who they consider their enemies.
+« AYÂTCHATIM, wok, (n. f.) foreign dog or horse. Note. One may continue so forth by putting ayâtch in front of a word, v. g. âyâtchi mokkumân, foreign knife, âyâtchi oyâgan, foreign dish,
+x ATTATCHISTAWEW, (v. a.) tam ,takew, tchikew, he is ashamed of him, nepewisisfcawew.
+
+316
+
+ÂTI
+
+x ATCHIT, (rac.) in the opposite sense, inverted, head down.
+« ATCHITCHIW, ok, (a. a.) He has his head down, v. g. kitchitwaw Peter ki atchistahâskwâtaw. Saint Peter was nailed with his head down
+« ATGHITCHAYAW, a, (a. in.) it's upside down
+« ATCHITAPIW, ok, (a. a.) he is placed upside down.
+« ATCHISTASTEW, a, (a. in.) it is placed upside down.
+« ATCHITISIN, wok, (a. a.) He is lying upside down.
+« ATCHITTIN, wa, (a. in.) idem.
+« ATCHTAHYEW, (v. a.) STAW, WEW, TCHIKEW, he places it upside down.
+« ATCHITINEW, (v.a.) NAM, NIWEW, NIKEW, he holds his head up
+x ATTAN, ak, (n. r.) bracelet, large ring.
+« ATCHANIS, ak, (n. f.) bangle, ring.
+x ATCHAKÂS, ak, (n. f.) scabbard, sheath, small animal with beautiful fur. N.B. It should be remembered that this word comes from the undignified word, wittakây, (sua genitalia,) which in the indefinite and diminutive takes the forms atchakâs, or, attakas; but to be more decent, one says, sâkwesiw, ok.
+x ATIBIS, ak, (n.r.) leather babiche (sinew or rawhide cord used for snowshoes, harpoon lines, etc.)
+x ATCHÂBIY, ak, (n. r.) bow.
+x ÂTIT, (pro.) or, AYÂTIT, some people. This word is always plural, v. g., âtit ayamihâw maka ayâtit piko miyo-pimâtisi wok, there are a few who pray, but there are very few who live well.
+
+ÂTT
+
+x ÂTTIK, suffix indicating wood; v. g., miskawâttik, hardwood, oak, waskwayâttik, birch wood.
+x ATIM, wok, (n. r.) dog. N.B. The suffix atim, or, astim, always indicates 'dog'; v. g, mistatim, big dog (the horse); matchatim, or, matchastim, bad dog! (imprec.) To say: my dog, your dog, etc., one must say: n't' em, ak, kit'em, ak, otema, etc., which also means: my horse, etc. The latter expression is only used with the possessive pronoun; and the first (atim) is always used without this pronoun.
+x ATIMAN, ak, (n. r.) string which used to tie snowshoes to the feet.
+x ATI, (ad. always accompanying a verb) to begin; v. g. , ati-miyo-ayaw, it starts to go better; ekwa n't'ati-nissototten, now I'm starting to understand; ati-'nipiw, he is beginning to die; ati-tibiskaw, it goes away at night. N. B. One can also put this after the word; v. g., nipaw ati, he starts to sleep; mitjisuk ati, or, ati mitjisuk, always start eating; mâtji, of which we will see more later, has the same meaning.
+x ATIM, (rac.) turn back, turned in the opposite direction.
+« ATIMIKÂBAWIW, ok, (v. n.) He turns the his back while standing.
+« ATIMIKÂBAWISTAWEW, (v. a.) tam, takew, tatchikew, he turns his back to him while standing.
+
+317
+
+ATI
+
+« ATIMAPIW, ok, (a. a.) he his sitting with his back turned.
+« ATIMASTEW, a, (a. in.) Idem.
+« ATIMAPISTAWEW, (v. a.) Tam, takew, tatchikew, he turns his back to him while seated.
+« ATIMIPAYIW, ok, a, (a. a. and in.) it is turned in the opposite direction; v. g., atim ipayi wok otettapiwok, the riders turn their backs.
+« ATIMAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he places it with his back turned.
+« ATIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he joins it.
+« ATIMINEHWEW, HAM, etc., idem.
+« ATIKKEMOW, ok, (v. n.) He reattaches
+« ATIMINEHIKEW, ok, (v. ind.) idem
+x ATITIKKWÂMIW, ok, (v. in.) he goes to bed without supper.
+x ATIMIW, ok, (a. a.) he's bored, tired, nestuw.
+x ATISUW, ok, (a. a.) it is ripe, or, it is dyed, because that which is ripe changes color as if it was dyed.
+« ATITTEW, a, (a. in.) It's ripe, or dyed.
+« ATISWEW, (v. a.) SAM, SUWEW, SIKEW, he dyes it, makes it ripen.
+« ATISIGAN, a, (n. f.) tincture.
+« ATISÂWIYEW, TTAW, YIWEW, TCHIKEW, he dyes feathers for shoes. Âwïy, designates these kinds of feathers; v. g., mikkwanâwïy, ak, dyed red feather.
+« ATISÂWEYÂN, a, (n. f.) dye, tincture.
+« ATISIKÂSUW, ok, (a. a.) one has dyed it.
+« ATISIKÂTEW, a, (a. in.) Idem.
+
+ATT
+
+x ATTIK, wok, (n r.) caribou; mayattik, wok, degenerate caribou (sheep).
+« ATIKKWEYÂN, ak, (n. f.) caribou pelt with hair.
+« ATIKKWEGIN, wa, (n. f.) tanned caribou pelt, or caribou pelt prepared for parchment
+x ATIKKAMEK, wok, (n.) White fish. N. B. It is likely that this noun is formed from the word attik, caribou, and the suffix mek, which refers to fish; nojemek, female fish.
+x ATOHUW, ok, (v. r.) he chokes while trying to swallow something.
+« ATOHUYEW, (v. a.) TTAW, YIWEW, TCHIKEW, he suffocates him.
+x ATOTEW, (v. a.) TAM, SIWEW, TCHIKEW, he orders it, he gives him a job. Only the animate form is used for this verb.
+« ATUSKEW, ok, (v. n.) he works.
+« ATUSKEWIN, a, (n. f.) work, job.
+« ATUSKEMOW, ok, (a. n.) he gives work to be done, he employs; v.g., atuskemow kitchi ojittamâttchikahigan, he has an ax made; sâsày ni ki atuskemon kitchi pe-nâtikawiyân, I have already given the orders for someone to come look for me; ni wi-atuskemon, kitchi ayamihestamât n'ottâwïy, I want to ask for or order prayers for my father.
+« ATUSKEMOWIN, a, (n. f.) employment, occupation.
+« ATUSKAWEW, (v. a.) TAM, KEW, TCHIKEW, he works for him.
+
+318
+
+ATC
+
+« ATUSKAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it work.
+x ATUS, a, (n. r.) arrow; atusis, a, small arrow.
+x ATUSPIY, a, (n. r.) wood which the savages use themselves for vomiting, aune (an obsolete unit of measurement, 1.18 metres)
+x ATOSPUW, ok, (v. n.) he uses a dish, etc. , to eat; v. g., nama kekway n't'atospun, I have nothing to put my food on; nandomaw kisik kila atosput, we call him at the same time as he brings his dish.
+« ATOSPUWIN, a, (n. f.) Action of eating with a dish.
+« ATOSPOYÂGAN, a, (n. f.) Dish, for eating.
+« ATOSPUHYEW, (v. a.) TAW, YIWEW, TCHIKEW, it serves it to him to eat in a dish.
+« ATOSPWÂTEW, etc., idem.
+x ATCHI, (rac.) below, minus, sometimes also means: more.
+« ATCHITCH, (ad.) Less; v.g., atchitch miyew, he gives less of it to her (than what he had promised); abittaw ni wi-miyik, maka atchitch ni miyik, he wanted to give me half, but he gave me less.
+« ATCHITCHIPAYIW, ok, a, (a. and in.) it becomes less, it diminishes. The savages say; atchitchipipon, the winter is half passed.
+« ATCHITCHIHUW, ok, (v. r.) His half is shared poorly, he gives himself less.
+
+ATC
+
+« ATCHIWIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, it makes it less, smaller, of smaller dimensions; v. g., wi-atchiwiwittâwok wikiwâwa, they want to make their homes smaller.
+« ATCHIWIYEW, etc., (v. a.) idem.
+« ATCHIWINEW, (v. a.) Ham, niwew, nikew, idem; v. g., kakwe ekwa atchiwina ki matchipimâ-tisiwis ;, task of improving your bad life.
+« ATCHIWIKKUTEW, (v. a.) TAM, SIWEW, TCHIKEW, he thins him, he shaves it down with a knife or a plane.
+« ATCHIWIKKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he reduces its size with an ax.
+« ATCHIWIKKASWEW, (v. a.) SAM, SIWEW, TCHIKEW, he reduces its size with fire.
+« ATCHIWISWEW, etc., with scissors.
+« ATCHIWIPAYIW, ok, a, (a. a. et in.) it gets smaller, v. g., dry fish become smaller, one says: atchiwipayiwok; atchiwipayiw ni maskawisiwin, my strength is diminishing.
+« ATCHIYAW, (ad.) A moment, an instant, synonymous with kanak; v. g., atchiyaw ni witjewaw, I accompany him for a moment; ni ka sipwettân atchiyaw n't'eyitten, for a moment I am thinking of leaving; atchiyaw ki sipwettew, maka semâk pe-kiwew, he only left for a moment, he returned immediately; atchiyaw ni miskawaw, kiyipa ni wanihaw, I had only just found it before I'd lost it; atchistawinatew, he almost kills it:
+
+319
+
+AYA
+
+x ATCHITCHÂBIW, ok, (v. n.) he look askance, lopsidedly.
+« ATCHITCHÂBAMEW, (v. a.) TTAM, KEW, TCHIKEW, he looks at him askance.
+x ÂTTÂSKUSImew, (v. a.) ttaw, miwew, tchikew, he hangs it in a spot, v.g., someone who is carrying an object on his back, and while passing under something hooks it there.
+« ÂTTISIN, wok, (a. a.) he cannot go through it, the space is too small for his body.
+« ATTITTIN, wa, (a. in.) It's too narrow, it does not offer enough space.
+x ÂTTATCHISTAWEW, (v. a.) TAM, TAKEW, TCHIKEW, he is ashamed of it, nepewesistawew.
+x ATOTCHI, (ad.) to tell the truth; v. g., atotchi nisokkamâtam k'o kwatakittât, do not be surprised that he suffers, as he favours his evil, pittaw.
+« ATOTCHIPAYIW, ok, a, (a. a. and in. ) it acts more than is necessary, tatchipayiw, kâsispopayiw.
+x AY! AY! (ex.) thanks. often one attach this to the adverb winâkkoma, which still means the same thing; v. g., ày! ây! winâkkoma, ki nanâskumitin, thank you! I thank you.
+x AYÂH, k, (pro. an.) one whom I don't know, whose name one cannot remember at the moment; v. g., matchi ayissak, the bad beings.
+
+AYI
+
+« AYIH (pro. in.) One which I do not know, that which cannot be named immediately. Note. For this form there is no plural.
+« AYIK, (ad.) In a place that cannot be named immediately.
+x AYAKASK, (rac.) large, of a large extent.
+« AYAKASKISIW, ok, (a. a.) He is wide; v. g. , osâm ayakaskisiw k'otâbânâsk, your car is too wide.
+« AYAKASKAW, a, (a. in.) it is wide; v. g., ayakaskaw meskanaw, wide path; mistahi ayakaskâyiwoskutâkây, her dress is very large.
+« AYAKASKÂBISKISIW, ok, (a. a.) it is done with a wide piece of metal or stone.
+« AYAKASKÂBISKAW, a, (a. in.) idem
+« AYAKASKIGAMAW, a, (a. in.) wide lake.
+« AYAKASTIKWEYAW, a, (a. in.) river with a wide bed.
+« AYAKASKIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he widens it, he makes it wide.
+« AYAKASKAHEW, etc. , idem
+« AYAKASKISWEW, (v. a.) SAM, SUWEW, SIKEW, he carves it, he shapes it wide.
+« AYAKASKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he cut it wide with the ax,
+x AYÂKWÂMAS, (ad.) too much. See. piyis; v. g., ayâkwâmas osâm mistahi ni totâk, he is making me do too much, I cannot stand it any longer.
+
+320
+
+AYA
+
+« AYÂKWÂMIMEW, (v. a.) TTAM. MIWEW, TCHIKEW, he encourages him.
+« AYÂKWÂMEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks he is encouraged.
+« AYÂKWÂMEYITTAM, wok, (v. n.) he is encouraged.
+x AYAMI, (rac.) to speak, to converse with. Note. Most often this root refers to matters of religion, as we will see
+« AYAMIW, ok, (v. n.) He speaks (pikiskwew); v. g., awiyak mistahi eyamit, watakame kiyâskiw, someone who talks a lot is exposed as lying.
+« AYAMIWIN, a, (n. f.) speech (pikiskwewin).
+« AYAMIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he talks to her; v. g. , ekweyâk anotch ni pe-ayamihik, it is only today that he came to talk to me. Note. Ayamihew would also mean, in a religious context, to pray, but it is almost never used; ayamittaw, which is the inanimate active verb, is taken to mean; he reads it; v. g., kit ayamittân masinahigan, you read a letter or book, although in truth this means: you speak to a book; ekawiya ayamittâk matchi masinahigana, do not read bad books.
+« AYAMIHITUW, ok, (v. m.) they talk to each other; v. g., kayas otchi namawiya wi-ayamihituwok, for a long time they have not wanted to speak.
+« AYAMIHITUWIN, a, (n. f.) Speaking
+
+AYA
+
+« AYAMITTOWEW, (v. a) TTWATTAW, TTWÂKEW, TTWÂTCHIKEW, he reads to him, v. g., a letter; v. g., ki ka ayamittwâtin ki masinahigan, I will read your letter to you; anotch ki wi-ayamittwâtinâwaw k'etwemagak manito masinahigan, today I want to read you what the Holy Scriptures say; nama kwayask kit ayamittwâkowawok manito masinahigan eoko-nik, those (ones) don't read you the Holy Scriptures correctly.
+« AYAMITTÂKUSIW, ok, (a. a.) he declaims. This word is only used for sorcerers or minstrels who make superstitious speeches before starting their spells; v. g., matwe ayamittâkusiwok mitewok, we hear the sorcerers make their harangues; iyiniwok wa-matotisitwâwi, ayamittâkusiwok, when the Indians sweat themselves, they harangue. Note. This way of speaking always tends towards the superstitious. One could not say of the priest: ayamittâkusiw, he makes a speech.
+« AYAMIHAW, ok, (v. n.) He prays, he is of religion, or, ayamihewijittwaw, ok; v. g., awiyak ka mitoni eyamihât, kwayask meskanaw mittimew, it is only those who pray well who follow the right path; otayamihaw, ok, the praying (people), the Christian; otayamitchikew, ok, idem. This word comes from the verb above, ayamihew; v. g., namawiya kakiyaw otayamihâwok kita wâbamewok Kijemanitowa, all prayers will not see God; nâspitch kitimâkisiw awiyak eka eyamitchiketji, he is worthy of compassion, he who does not pray.
+
+321
+
+AYA
+
+« AYAMIHÂWIN, a, (n. f.) prayer, religion.
+« AYAMITCHIKEWIN, a, (n. f.) Idem.
+« AYAMIHEWIJITTWÂWIN, a, (n. f.) idem. N. B. All times that the root ayamihe is in front of a name, or a compositive particle, or an adjective, it indicates an object of religion, or that which has a relation to prayer.
+« AYAMIHÂHEW, (v. a.) HIWEW, etc., he makes him pray, he makes him take up religion.
+« AYAMITCHIKEHEW, etc. Idem; v. g., Kije manito ki miyew otayamihewiyinima kita ayamihâhayit kakiyaw ayisiyiniwa, God gave his priests (the obligation) to make all men.
+« AYAMIHEWIYINIW, ok, (n. f.) the priest, the man of religion; kitchi ayamihewiyiniw, ok, the high priest, bishop; Mâmawiyes kitchi ayamihewiyiniw, the very high priest, the pope. One says also: ka peyakut kitchi ayamihewiyiniw, the only high priest. N. B. Protestant ministers call themselves ayamihewokimaw, the chief, or, the bourgeois, of prayer.
+« AYAMIHEWISKWEW, ok, (n. f.) the woman of religion, sister.
+« AYAMIHEWIYINIWIWIN, a, (n. f,) the Order, the priesthood. Note. In catechism one says: ayamihewiyinijihituwin, but I think that the first word expresses this better.
+
+AYA
+
+« AYAMIHEWIYINIWIHEW, (v. a.) hiwew, he makes him a priest; v. g., kitchi ayamihewiyiniw piko kita ki ayamihewiyiniwihew awiya, only the bishop can make somebody a priest.
+« AYAMIHEWI-SASKAMOWIN, (n. f.) or, saskamun, communion.
+« AYAMIHEWIKITTUWIN, a, (n. f.) marriage.
+« AYAMIHEWI-NAKAMOWIN, a, (n. f.) or, nakamun, a, hymn.
+« AYAMIHEWIKAMIK, wa, (n. f.) house of prayer, or of religion, Church.
+« AYAMTHEWIKIJIKAW, a, (n. f.) the day of prayer, Sunday; v. g. , tattwaw ayamihewikijikâ ki, n'tawi witjiayamihâmâkkan ayamihewiyiniw Lamessikketji, every Sunday, you will pray with the priest saying the Mass; witji-ayamihâmew, he prays with him, or, he is the same religion as him.
+« AYAMIHESIKÂTJIKÂSUWIN, a, baptism.
+« AYAMIHESIKAHÂTTAWEW, (v. a.) TTAM, TÂKEW, TATCHIKEW, he baptises him.
+« AYAMIHEWITOTAWEW, (v. a.) TAM, TÂKEW, TCHIKEW, He performs some rite of religion on him, v. g., iskweyâtch ayamihewitotawaw, it is administered, in articulo mortis.
+« AYAMIHESTAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he prays, he intercedes for him, v. g. kijikok eyâtjik kit ayamihestamâkonowok, those who are in Heaven intercede for us.
+
+322
+
+AYA
+
+« AYAMIHESTESTAMÂWEW, (v. a.) TAM, KEW, TCHIKEW. He prays for him, v. g. kitchitwaw Marie ki kosis Jesus ayamihestestamâwinân, Saint Mary pray to your son Jesus for us. N. B. This is why, at the end of Confiteor, instead of kitchi aya mihestamâwiyâk, one should say kitchi ayamihestestamâwiyâk tebeyitchiket, etc., to pray for us the Lord. One says, ayamihestamâtam, ok, he prays over it, he blesses it.
+« AYAMIHEWÂTTIK, wok, (n. f.), prayer wood, the cross, v. g Katolik otayamihâwok manâtjihewok ayamihewâttikwa, the Catholics venerate the cross. 
+« AYAMIHEWÂTTIKOKEW, ok (v. n.) he makes the sign of the cross, v. g. eka kwayask ka aya mitchiketjik nama wi-ayamihewâttikokewok, those who are not of the true religion do not want to make the sign of the cross.
+« AYAMIHEWÂTTIKOKEWIN, a, (n. f.) sign of the cross, v. g. ayamihâwinik takki nikân astew ayamihewâttikokewin, in religion, the sign of the cross is always put forward.
+« AYAMIHEWÂTTIKOKAWEW, (v. a.) KAM, KÂKEW, TCHIKEW, he makes the sign of the cross.
+« AYAMIHEWÂTTIKONAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, or, ayamihewâttikototawew, he makes the sign of the cross over him, v. g. ayamihewiyiniw e ayamihewâttikonamâtak nipïy, ekusi ayamihewâbuttaw, by making the sign of the cross over the water, the priest makes it holy water.
+
+AYA
+
+« AYAMIHEWÂTTIKONAMÂSUW, ok, (v. r.) or, ayamihewâttikokâsuw, ok, he signs the sign of the cross.
+« AYAMIHEWÂTTIKONAMASUWIN, a, (n. f.) Or, ayamihewâttikokâsuwin, a, the action of signing oneself (with the cross)
+« AYAMIHÂKKÂSUW, ok, (v. n.) or, ayamitchikekkâsuw, ok, he pretends to pray, he mimics religion, hypocrite.
+« AYAMIHEMIN, ak, (n. f.) (do not say this in the plural) prayer beads, rosary, v. g. n't 'akimâwok ayamiheminak, I count the prayer beads, I say the rosary, akimâtânik ayamiheminak, let's say the rosary, one also says, ayamihemikisissak, but this is seldom used, one may also say, ayaminakinew, he has beads.
+« AYAMIHEWÂBUY, a, (n. f.) Holy water, v. g. piyettukeyani ayamihewikamikok otinamokkan ayamihewâbuïy, ekusi ayamihewâttikokâkekkan, when you enter the church, take some holy water and sign yourself with it.
+« AYAMIHESTCHIKÂSUW, ok, (a. a.) or, ayamihewitotchikâsuw, ok, we prayed to him, we did some sacred rites on him, v. g. for a child that one takes to baptise, one would say, sâsây ayamihewitotchikâsuw, we have already done holy things to him, nameskwa ayamihestchikâtew oma wâskâhigan, this house is not yet blessed, N. B. One also uses the term ayamihâwin, a, prayers that are usually recited , as one always uses this term in the plural, there is no ambiguity, to refer to religion in general, it is always ayamihâwin, or, ayamihewijittwâwin, Christian belief, ayamihewitâpwewokeyittamowin.
+
+323
+
+AYA
+
+« AYAMIHE-MASINAHIGAN, a, (n. f.) prayer book.
+« AYAMIHE-KISKINOHAMÂKEWIN, a, (n. f.) Religious instruction, education.
+« AYAMIHEWÂTISIW, ok, (a. a.) he is pious, religious.
+« AYAMIHEWÂTISIWIN, a, (n. f.) piety, religious character.
+x AYAK, wok, (n. r.) ayakus, ak, little bird that cries at night.
+x AYAP, (rac.) quantity, large number, succession of objects.
+« AYAPIY, ak, (n.) Nets, net, so called because of the great number of meshes from which they are formed, manayapew, ok, he visits the net, nâtayapew, he will fetch the net, misahayapew, he mends the net, nakwâtew, he takes it in a net, nakwâsuw, he is taken in a net, pakitawaw, he tends a net.
+
+AYA
+
+« AYAPIKKEW, ok, (v. n.) he makes a net.
+« AYAPIKKAWEW, (v. a.) KAM, KÂKEW, TCHIKEW, he makes him a net.
+« AYAPÂTTIK, wa, (n. f.) buoy tied along the net tp hold it in the water.
+« AYAPIPAYIW, ok, a, (a. A. And in.) is a succession of objects.
+« AYAPATINAW, (v. im,) there are mounds, or hills.
+« AYAPIGAMAW, (u. Im.) There is a succession of lakes, several lakes separated by small straits.
+« AYAPANAKAW, (v. im.) There are islands, near to one another.
+« AYAPIMINISTIKWEYAW, (v.im.) idem.
+« AYAPÂSKWEYAW, (v. im.) small bunches of wood which follow after one another closely, there are wooden islands. Note. Meaning of suffixes above, atinaw hill, butte, mountain, v. g. ispatinaw, high hill, gamaw, lake, c. g. misigamaw, this is big lake, tikweyaw, island, water, âskweyaw, wood, forest, see. at the end of the letter A.
+x AYÂT, (rac.) solid, strong, that which is well attached.
+« AYÂTISIW, ok, (a. a.) He's of a solid, strong character.
+« AYÂTAN, wa, (a. in.) It holds well, it is solid, v. g. e ayâtak wâskâhigan nama kita kawâstan, a solid house will not be blown over by the wind.
+« AYÂTISIWIN,, a, (n. f.) solidity, strength of character.
+
+324
+
+AYÂ
+
+« AYATAMUW, ok, a, (a. a.) it holds firmly, difficult to tear off.
+« AYÂTAMUHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he fixes it solidly.
+« AYÂTAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he places it solidly, v. g. ayâtastaw owâskâhigan, he places his abode solidly.
+« AYÂTAPIW, ok, (a. a.) he is seated, placed solidly, v. g. for someone who is on horseback, one would say of him: ayatapi eka kitchi nitchipayiyan, sit well so you don't fall.
+« AYÂTASTEW, a, (â. In.) securely placed.
+« AYÂTASKISUW, ok, (a. a.) he is firmly planted, v. g. mistahi ayâtaskisuw eoko mistik, nama ni ki manipitaw, this piece of wood is too firmly planted, I can't detach it.
+« AYÂTAPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he attaches it solidly.
+« AYÂTAPISUW, ok, (a. wing) he is tied, tied securely.
+« AYÂTAPITEW, a, (a. in.) idem
+« AYÂTEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he think that he finds it of a strong character, solid, v. g. peyakwaw nando etwetji ayâteyittam, when he says something once, he sticks to it.
+« AYÂTASOMEW, (v. a.) ayâsomew, TTAM, MIWEW, TCHIKEW, he tells him to watch over himself, v. g. kit ayâsomitin ekawiya ekusi totamokkan, I repeat it to you strongly, don't do that, or, I'm warning you, etc., ata Kijemanito ki ayâtasomew, Adama, eka kita mitjiyit, nonetheless God warned Adam well not to eat it.
+
+AYÂ
+
+x AYÂTCH, (rac.) Foreign, of another country, different.
+« AYÂTCHIYINIW, ok, (n. f.) foreign man, another enemy, this is what the Cree call the Blackfoot, the Blood People, and the Piéganes.
+« AYÂTCHEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks or finds it foreign, different; pituteyimew, idem.
+« AYÂTCHINAWEW, (v. a.) TTAM, NÂKEW, TCHIKEW, looking at it, he finds it different, ayâtchâbamew.
+« AYÂTCHITTAWEW, (v. a.) TTAM, TTÂKEW, TTÂTCHIKEW, he finds him different, strange, hearing him speak or shout; pitusittawew, idem
+« AYÂTCHATIM, wok, (n. f.) foreign dog or horse, or else, ayâtchi-mistatim. N. B. And so on, one may add before the root ayâtch: v. g., ayâtchi-wâskâhigan, different house; ayâttokamik, another domicile, a foreign house; ayâtchi-mokkumân, foreign knife.
+x AY, (rac.) To have, to possess.
+« AYÂWEW, (v. a.) YAW, YÂWIWEW, YÂTCHIKEW, he has it, he possesses it; v. g., nama awiyak mistatim n't'ayâwaw, I have no horse.
+
+325
+
+AYA
+
+« AYAW, ok, (inan.) He's got that; v. g., nama kekwày ayâwok, they don't have anything.
+« AYAW, ok, (verb to be) he is; v. g., miyo ayaw, he's fine; tande eyâyan? where are you, misiwe ayaw Kije manito, God is everywhere.
+« AYÂN, ak, a, (n. f.) belongings, possessions, goods, loot. N. B. One must be quite careful, as this word, ayân, used in the animate, is the polite word to say: genitalia viri sive mulieris. One says: n't'ayân, ak, otayâna, etc., etc.
+« AYÂWIN, a, (n. f.) action of being. Also: (personal) effects, possessions.
+« AYONIS, ak, a, (n. f.) belongings, effects, merchandise.
+« AYOWINIS, ak, a, (n. f.) idem. N. B. We mainly use these two words to talk about merchandise.
+x AYÂBEW, ok, (n. r.) yâbew, ok, male. We use this expression only for some animals; v. g., ayâbew moswa, moose male; ayâbewâwâskejîw, the stag; ayâbe-mustus, the bull. For the others we say: nâbew
+x AYA, (rac.) to cover, bury.
+« AYAHWEW, (v. a.) HAM, HUWEW, HIKEW, he covers it with earth, he puts it on.
+« AYAPAKINEW, (v. a.) NAM, NIWEW, NIKEW, he covers it with leaves.
+« AYATÂWOKKINEW, (v. a.) NAM, NIWEW, NIKEW, he covers it with earth, mud, mortar.
+
+AYA
+
+« AYAKUNEHWEW, (v. a.) HAM, HUWEW, HIKEW, he puts it at the bottom of the snow, he covers it with snow.
+« AYASITTAKINEW, (v. a.) NAM, NIWEW, NIKEW, he covers it with spruce branches.
+« AYASKUSIWOKINEW, NAM, NIWEW, NIKEW, he covers it with hay.
+« AYASKINEW, (v. a.) idem.
+AYÂSOWI , or, AYÂSO, (ad.) see. the rac. Âso.
+x AYE, (rac.) to lose the speed that one initially had, to lose what one was.
+« AYEPAYIW, ok. a, (a. a. and in.) it is decreasing.
+« AYEKUTCHIN, wok, (a. a.) he loses speed, v. g. , a horse.
+« AYEKUTEW, a, (a. in.) it loses its speed, v. g., a ball.
+« AYEK, ak, (n. f.) Frog.
+« AYEKIS, ak, (n. f.) Small frog.
+« AYEKIWIPISIM, wok, (n. f.) month of April, the moon of the frogs.
+« AYENIW, ok, (a. a.) he is not an eater, he is sober, he eats very little.
+« AYENOSEW, ok, she's sterile.
+« AYENOSEWIN, sterility.
+« AYESKUSIW, ok, (a. a.) It is tired, bored.
+« AYEYIMUW, ok, (v. n.) he sneezes. But more often, one says: tchatchâmuw, ok, or, tchatchâmusuw, ok.
+x AYEKKWE, wok, (n. r.) castrated male, eviratus; v. g., ayekkwewatim, neutered horse or dog, ayekkwe-mustus, castrated bull. Also, one can use this to refer to that which is neither male nor female: qui utrumque sexum habent, Hermaphrodite.
+
+326
+
+AYI
+
+x AYIK, wok, (n. r.) ant.
+« AYIKUS, ak, (n. f.) Small ant
+x AYIM, (rac.) difficult, painful.
+« AYIMÂTCH, (ad.) barely, with difficulty, v. g. ayimâtch pimâtisiw, he lives, but it's quite fair; ayimâtch takusin, he arrives with difficulty; ayimâtch n't'ayâwâttày mistatim ka n'tawi-nipit, with difficulty, I came to the end of having a horse, and now he is going to die.
+« AYIMISIW, ok, (a. a.) This adjective has two meanings. 1, Difficult, of a painful nature; v. g., ayimisiwok kita nipahitjik, they are difficult to kill; kit ayimisin namawikkâtch ki ponihin, you are annoying, you never leave me alone; tapwe mistahi ayimisiwok oki awâssissak, these children are very difficult (tiresome). 2. he suffers, he is in pain, in misery; v. g., nâspitch ni ki ayimisinân, we had much misery; kakiyaw ayisiyin ayimisiw waskitaskamik, every man on Earth is in misery, ayimisiw e wi-pimâtjihut, he has difficulty in making a living.
+« AYIMAN, wa, (a. in.) Is troublesome, it's difficult, it's bad, v. g., ayiman kessiki, it's difficult when it's cold; nama kekwày ayiman kitchi ayamihi, it's not difficult to be religious! ayiman, nama ni ki toten, it's difficult, I can't do it; ayiman pimâtisiwin, life is painful.
+
+AYI
+
+« AYIMISIWIN, a, (n. f.) difficulty, suffering, misery; v. g., mitchenwa ayimisiwina ota askik, there are many miseries on Earth>
+« AYIMAKKAMIKAN, (a. in.) It is too difficult.
+« AYIMANOK, (ad. in a difficult, dangerous place; v. g., ayimanôk k'otitenânow, we have arrived in a dangerous place.
+« AYIMIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he causes him misery, pain, trouble; e.g., ek wi-totameni ki ka ayimihitin, if you do not want to do it, I will cause you misery (you will remember it); n't'ayimisihikonânak n't'awâssimissinânak, our children cause us trouble; matjikutitân, ki ka ayamihikun ki kiiskwewin, you will see, your madness will cause you trouble
+« AYIMIHISUW, ok, (v. r.) he causes himself misery, pain, he gives himself suffering; Jesus Christ mistahi ki ayimihihisuw e wi pimâtjihkoyak, Jesus Christ suffered greatly to save us.
+« AYIMIHISUWIN, a, (n. f.) action of making oneself suffer.
+« AYIMIMEW, (v. a.) MIWEW, he causes him trouble, embarassment, because of what he says to him, or because of what he asks of him; v. g., ki pe-ayimimitin, I have come to ask you for something that will cost you, or, I have come to cause you misery with my words; tapwe kit ayimimin oma ka nandotamâwiyan, you embarrass me by asking me.
+
+327
+
+AYI
+
+« AYIMOMEW, (v. a.) TAM, MIWEW, TCHIKEW, he talks about himself, he speaks on his account. In using this root, one should take the resultant word to have a negative meaning. Its true meaning is: slander someone, especially if it is preceded by matchi; v. g., awena ka ayimomâyek? which one are you talking about? kekwày ka ayimotamek? what are you speaking of? ki wi ayimotamâtinâwaw peyak kekwày, I want to discuss something with you; matchi-ayimomew, he speaks ill about it, he slanders him; konata matchi ayimomew, he speaks ill about it, gratis, he slanders it.
+« AYIMWEW, ok, (v. n.) he speaks ill, konata ayimwew, he slanders; v. g., kispin nama ki miweyittenâwaw kita ayimomikawiyek, kistawaw ekawiya mâna ayimwek, if you are not happy that we speak ill of you, the you should not speak ill of others either.
+« AYIMWEWIN, a, (n. f.) propagation of bad gossip; konata ayimwewin, slander.
+« AYIMOWEW, ok, (v. n.) synonym of ayimiwew, above. He speaks in such a way as to cause embarrassment to those who hear it, he causes trouble, pain.
+
+AYI
+
+« AYIS! (ex.) what to do there, besides; v. g., ayis nama ni ki toten! What to do! I cannot come to the end of it! ayis wi-sipwettew, what to do! he wants to leave! ayis nama kekwây n't'ayân kitamiyitân, what to do! I have nothing to give you
+x AYISIPIY, ​​a, (n. r.) clear broth, nothing but water, that which tastes only like water.
+« AYISIPIWOKISIW, ok, (a. a.) it just tasted like water.
+x AYISÂWÂTCH, or, ayâsâwâtch (ad.) in the opposite sense, against common sense, v. g. ayâsâwâtch itwew, he speaks against common sense, ayisâwâtch ni naskwewojimik, he answers me all wrong.
+x AYI, (rac.) imitate, resemble.
+« AYISINAWEW, (v. a.) NAM, NÂKEW, NATCHIKEW, he imitates him, he does (it) like him, he takes him as a model, v. g. ekawiya ayisinâkuk metchi ayiwitjik, ki ka asoska-mâkowâwok o matchi pimâtisiwiniwa, don't imitate the wicked, they will spread their ill lives to you, miyo kekway wi-yâbattamani, kakwe ayisinamokkan, when you see good, try to imitate it.
+« AYISINAKEW, ok, (v, n.) He apes, imitates, otayisinâkesk, ak, a monkey.
+« AYISITOTTAWEW, (v. a.) TTAM, TTÂKEW, TCHIKEW, he imitates his voice, his cry, v. g. kakiyaw awiya ki ayisitottawew, he is able to imitate anyone's voice
+
+328
+
+AYI
+
+« AYISIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he does it by imitating a model, v. g. wejihatwâwi otâbânâskwok, kakwe ayisihik ka miyositjik, when you make sleighs, try to imitate the beautiful ones.
+« AYISITJIGAN, a, (n. f.) Model
+« AYISIHIWEWIN, a, imitation
+« AYISIYINIW, ok, (n. f.) Homi (homo) to be alike, v.g. Kije-manito ki ojihew ayisiyiniwa e wi-ayisihisut, God made man in his image.
+« AYISIYINIWIW, ok, (a. a.) he is a man.
+« AYISIYINIWAN, wa, (a. in) it's human.
+« AYIS1YINIWIWIN, a, (n.) humanity.
+« AYITISÂWÂTEW, (v. a.) TAM, WEW, TCHIKEW, he size it on based on a model.
+« AYIKIKUTEW, (v. a.) TAM, WEW, TCHIKEW, he cuts it up based on a model.
+« AYIKIKKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he squares it with an ax based on a model.
++ AYITAW, (ad.) On both sides, on both ends, v. g. ayitaw nibawiwok, they are standing on both sides.
+« AYITOWINISKEW, ok, (v. n.) he uses both arms, v.g. someone who also uses their left hand equally as well as their right
+
+AYI
+
+« AYITOWINEW, (v. a.) NAM, NIWEW, NIKEW, he holds it from both sides.
+« AYITÂWAKÂM, (ad.) Of both banks of the river or lake.
+« AYITÂWATINAW, (ad.) Of two sides of the mound, of the mountain.
+« AYITÂWÂMATINAW, (ad.) idem
+« AYITÂWAPIW, ok, (a. a.) It is on both sides.
+« AYITÂWISIN, wok, (a. a.) It is lying on both sides.
+« AYITÂWITTIN, wa, (a. in.) idem
+« AYITÂWAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he places it on both sides.
+x AYIW, (rac.) More, a lot, in addition, surpass.
+« AYIWÂK, (ad.) More, plus, too much, v. g. ayiwâk matchi pimâtisiw, it surpasses how wicked he is, ayiwâk ni sâkihaw, I like it a lot, ayiwâk kit âtamihin, you make me very happy, ekwa ayiwâk âkkusiw, now he is even sicker.
+« AYIWÂHUTCH, (ad.) Idem.
+« AYIWÂKES, (ad. dim. very often used) a little more, v. g. ayiwâkes n't'ati-miyo ayân, I am starting to get better, anotch ayiwâkes kissin, today it is a little colder.
+« AYIWÂKESIS, (double dim.) V. g. ayiwâkesis kakwe miyin, try to give me a little more of it.
+« AYIWÂKIKKIN! (ex.) it's amazing! it's extraordinary ! it happens strangely, v. g. ayiwâkikkin eyikok e kinosit! it's amazing how big he is! ayi-wâkikkin eji wiyinot! How very fat he is! ayi wâkikkin ki wissakahun! Oh how you hurt me! ayiwâkikkin ka wi-isit! isn't it so strange, what he dares say to me! we also say by emphasis, ayiwâkikkinoban! it's too amazing!
+
+329
+
+AYI
+
+« AYIWÂWISIW, ok, (a. a.) his manner of acting surpasses, dominates, he does more than the others.
+« AYIWAN, wa, (a. in.) it surpasses.
+« AYIWÂKIPAYIW, ok, a, (a. A. and in. ) it surpasses, supernumerary, there is more than enough, v. g. ayiwâkipayiwok mistatimwok, there are more horses than are needed, kit ayiwâkipayin, you are too much, takki mana ayiwâkipayiw ka mayâtak eyikok ka miwâsik, there is almost always more bad than good, ayiwâkipayiyiwa omatchitotamowina, his bad actions are great in number.
+« AYIWÂKIPAYIHEW, (v.a.) TTAW, HIWEW, TCHIKEW, he is too much for him, he is supernumerary; v.g., n't'ayiwâkipayihikonânak n't'atuskeyâganinak, there are too many of our workers for us; kit ayiwâkipayihikunânaw osâmitônéwin, you have too much language.
+« AYIWÂKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he cuts it too much with the axe.
+
+AYI
+
+« AYIWÂKISWEW, (v. a.) wew, sikew, he sizes it too much, or, burns it too much.
+« AYIWÂKISKAWEW, (v. a.) KAM, KÂKEW, TCHIKEW, he walks farther than him.
+« AYIWÂKÂTISIW, ok, (a. a.) he is of a superior character.
+« AYIWÂKAM? (a. in.) sort of interrogation. It is not uncommon that. etc., v. g., ayiwâkam na e totak? is it rare for him to do that? nama ayiwâkam ekusi ikkin, that happens a lot.
+« AYIWÂKEYIMOW, ok, (a. a.) or, ayiwâkeyimisuw, ok, he is thinks a lot of himself, he esteems himself too highly, he is proud.
+« AYIWÂKEYIMOTOTAWEW, (v. a.) TAM, TÂKEW, TCHIKEW, he thinks himself above him, he esteems himself higher than him; v. g., okijikowok e ki ayiwâkeyimototawâtjik Kije-manitowa, ki matchustehwâwok, the angels who were proud against God were cast into the fire.
+« AYIWÂKEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks much of it, he esteems him more highly; v. g, ayiwâkeyittamuk ayamihâwin eyikok kakiyaw kekwây, esteem religion more highly than any other thing; awiyak eka ayiwâkeyimitji ispitchi ottâwiya, etc., etc., nama tchi ​​nitta-witjewit, he who does not esteem me more highly than his father, etc., is not worthy of being with me.
+« AYIWÂWEYIMEW, etc., idem.
+« AYIWÂWEYIMOW, ok, or,
+
+330
+
+AYI
+
+AYIWÂWEYIMISUW, ok, like ayiwâkeyimow, etc.
+« AYIWEYIMOW, ok, or, AYIWEYIMISIW, ok, idem.
+« AYIWÂKEYIMOWIN, a, (n. f.), AYIWÂKEYIMISUWIN, self-love, vain glory.
+« AYIWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, like, ayiwâkeyimew.
+« AYIWISKAWEW, (v. a.) KAM, KÂKEW, TCHIKEW, he surpasses him, v. g., he is higher, bigger than him; kisim mistahi kit ayiwisk, your younger brother is much bigger than you; Saul ki ayiwiskawew kakiyaw Judawiyiniwa, Saul outweighed by size all of the men of Judah.
+« AYIWIHEW, (v. a.) TTAW, HIWEW, HIKEW, he wins over him he does more; v. g., kispin ayiwihiyani ki ka paskiyâwin n't'em, if you do more than me, you will win my horse from me.
+« AYIWIPEW, a, (v. im.) the water overflows, spills over; v. g., kakiyaw sipiya ayiwipewa, all rivers overflow.
+« AYIWÂKIPEW, a, (v. im.) idem
+« AYIWÂKIMEW, (v. a.) TTAM, WEW, TCHIKEW, he tells him a lot.
+« AYIWAKAKKIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he counts it supernumerarily, he overcounts it.
+« AYIWIW, ok, (v. n.) is a sort of auxiliary verb like ittiw, ayaw. These examples will demonstrate; v. g., miyo ayiwiw, he is good; matchi ayiwiw, he is cruel; kitchi ayiwiw, he is noble, he has great qualities; ata nama ki kitchi ayiwin, kitchi kisteyimoyan, nonetheless, you are not noble in being proud of yourself; omatchi ayiwiwok, the wicked; miyo ayiwiwiwok, the good, the virtuous.
+
+AYI
+
+« AYIWIWIN, a, (n. f.) Character, action, to be, kitchi ayiwiwin, a, nobility, greatness.
+« AYOWITWEWEMEW, (v. a.) TAM, MIWEW, TCHIKEW, he overwhelms him with his words.
+x AY, (rac.) To cease, to appease, to stop
+« AYOWÂSTIN, (v. im.) The wind ceases.
+« AYOWEBIW, ok, (v. n.) he rests.
+« AYOWEBIWIN, a, (n. f.) Rest.
+« AYOWEBIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it rest.
+x AYOSKAN, ak, fruit, raspberry. N. B. This word seems to come from the adjective yoskaw, soft, tender, which, when redoubled, makes, ayoskaw, from ayoskan.
+x AY! AY! (ex.) thanks; one also says, ay! ay! winakkoma! thank you! thank you!
++ AW! or, haw! (ex.) let's see! let's go! v. g. haw! sipwettetân! let's see! let's go! haw! itwe!, let's see, speak!
+x AWÂHEW, ok, (v. n.) He takes/has courage. Note. Although I think that this verb has all its tenses, it is only used in the first person imperative, v. g. awâhe! have courage, awâhek, have courage.
+
+331
+
+AWA
+
+AWAN, mist, vapor, kaskawokkamikaw.
+x AWAS, (rac. and ad.) further, earlier, v. g. if I say to someone 'get out of here', I would say awâs! which is a sort of verb which has only the first two subject persons in the imperative, awasitik, go away, all of you! we also say, awasite, go away.
+« AWASITE, (ad.) Further on, v.g. awasite n'tawi api, go sit down further away, awasite ituttewok, they go further.
+« AWASISPI, (ad.) Older, previously, v. g. awasispi otjiw eyiyok niya, he existed before me, awasispi ni ki wâbamaw, before that I saw it.
+« AWASISPIS, (ad.) (Dimin.) Idem.
+« AWASÂYIK, (ad.) On the other side, on the other end.
+« AWASEYIGOK, (ad.) More, in addition, v. g. awaseyigok wiyà iyinisiw ispitchi niya, he's more wise than me, awaseyigok ekwa ati-kissin, it starts to be colder now, awaseyigok n't'ati miyo ayân, I'm starting to get better.
+« AWASEYIKOKÉS, (ad.) (Dimin.) idem
+« AWASEW, (ad,) on the other side of a point, in a river or a lake.
+« AWASÂMATIN, (ad.) On the other side of a hill, a mountain.
+« AWASÂBISK, (ad.) On the other side of a rock. One uses this expression to say: on the other side of the Rocky Mountains.
+
+AWA
+
+« AWASEWEW, ok), he  disappears on the other side, v. g. someone in canoe diverting a point; sâsay pisim awasewew, the sun has already disappeared on the other side, that is to say, it has set, aspin e awasewet, that's how he disappeared on the other side.
+x ÂWASUW, ok, (v. r.) he is heating up at the fire.
+« ÂWATEW, a, (a. in.) there is a good fire.
+« AWASUWIN, a. (n. f.) the action of warming up.
+« ÂWASUHEW, (v. a.) TTAW, HIWEW, HIKEW, he heats it up.
+x AWA, (rac.) cart, carry a burden.
+« AWATEW, (v. a.) TAW, SIWEW, tchikew, he carries it, he transports it.
+« AWATÂSUW, ok, (v. n.) he carries things.
+« AWATÂSUWIN, a, (n. f.) action of carting objects.
+« AWATOWATEW, ok, (v. n.) He carries (it) on his back. N. B. The suffix towatew, denotes the action of carrying on one's back, v. g. nâtowatew, he will fetch (it) on his back.
+« AWATCHITÂBEW, ok, (v. a.) He transports it by means of a car.
+« AWATOPEW, ok, (v. n.) he carts water.
+« AWASIPEW, ok, idem; and so on, one may continue by joining suitable endings to the root awa.
+x AWÂH, (pro.) this one v. g. awah ki simis, this your younger brother; plur. oki, v. g. oki k'istesak, these your older brothers, e awâh k'ottawïy, this is your dad.
+
+332
+
+AWE
+
+x AWÂHITA, or, awehita, awihita, (pro. dem.) here it is, v. g., awihita kit'em, look, your horse, awehita ki kâwïy, here is your mother.
+« AWÂHITE, or, awehite, or, awihite, (pro. dem.) here it is, v. g., awâhite ka petchastamuttet, look who's coming, awihite ka nokusit, look who appears. The inanimate is oma-ita, here it is, oma-ite, here it is.
+x AWÂSIS, ak, (n. r.) child, apistawâsis, a, a small child.
+« AWÂSISSIWIW, ok, (a. a.) he is a child.
+« AWÂSISSIMIMEW, (v. a.) he has him as a child.
+« AWÂSISSIWIWIN, a, (n. f.) childhood, kâwi awâsissiwiw, he is in his childhood.
+« AWÂSISIKKÂSUW, ok, (v. n.) he is a child. N. B. The word awâsis is used when addressing the congregation in preaching, n't'awassimissitik! my children.
+« AWENA? (pro. interr.) what ? which? v. g. awena k'ottâwïy? who's your father ? awena ka takusik? who arrived? awena ituke, I don't know who, awena kiya? who are you ? or, ewenawiyan? awenawikwe, dubil quis est, awenawiwâkwenik, dubitatur qui sunt.
+« AWENIKI, (pro. interr. plur) v.g. aweniki eokonik? what are these?
+
+ÂWE
+
+x ÂWE, (rac.) start to recognise, to guess the meaning of, etc.
+« ÂWAN, (ad.) It makes you recognise, it helps to find out.
+« ÂWENAWEW, (v. a.) NAM, NÂKEW, NÂTCHIKEW, he begins to recognise, at first glance, he did not recognize him, v. g. ni wi-awenawaw awâh, he looks to me as if I recognize him.
+« AWETTAWEW, (v. a.) TTAM, TTÂKEW, TTÂTCHIKEW, he believes he recognises the sound of his voice.
+« AWEYIMEW, TTAM, MIWEW, TCHIKEW, he begins to recognize him in his mind, he finds out the meaning, the significance.
+« ÂWETCHIGAN, a, thing, through the use of which one discovers another thing, this is the word used by Protestants to say: paraboles.
+« ÂWENÂKUSIW, ok, he is recognizable by appearance, one thinks one recognizes him by looking at him.
+« ÂWENÂKWAN, wa, (inan.)
+« ÂWETTÂKUSIW, ok, one believes, one imagines one recognises it by sound its voice, it's him, it's his voice.
+« ÂWETTÂKWAN, wa, inan. N. there is only one use, which can properly encapsulate this root, see âbeyimew and its derivatives, which closely resemble âweyimew, etc.
+x AWESKI, or, aweska (pro.) a, much related to awâhita above, v. g. aweski eoko, here it is all of a sudden while, etc. This manner of speaking gives the idea that something happens suddenly, while one does not expect it, v. g. ni pe-kiwa, aweski ka nakiskawok, I'm was coming back, and here I met him, awesk'awâh ki apiw, and see, we find it well there, Kije-manito opapâmntta niuâwikitchiganik tepwâtew Adama, aweski eokoni ki mâtuyiwa, God was walking in the garden, he called Adam, and this was his cry.
+
+333
+
+AWI
+
+« AWESK-OMA (pro. inan.) Idem.
+x AWETISIS, ak, (n. r.) small beaver.
+x AWIYAK, (pro.) someone; in the plural, this word changes to âtit, and, ayâtit, a few; these expression also mean, that which, etc., those who, etc., v. g. matwân tchi ​​awiyak ni ka miskawaw, I don't know if I will find someone, tande kemiskawâyak awiyak? where will we find somebody? nama awiyak, nobody, nama awiyak ki kaskittaw, no one could do it, awiyak kwayask tiyotaki watakame miyo miskamâsuw, the one who does well, finds well, kakiyaw awiyak patinikowisiw ata tchi ​​ayamihât, ekusi âtit piko ayamihâwok, mâka ayâtit kita pikhkohuwok, everyone was intended by God to pray, and yet there are only a few who do pray, and few will be saved, mitchet awiyak, several.
+x AWI, (rac.) Lend to, etc.
+
+AWI
+
+« AWIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he lends her, he makes her use it; v. g., nametchi ki ka ki awihin kit'em? would you not lend me your horse?
+« AWIHÂSUW, ok, (v. n.) he borrows
+« AWIHÂSUMEW, (v. a.) he borrows from him; v. g., ki pe-awihâsumitin ki tchikahigan, I'm coming to borrow your ax.
+« AWIW, okay, (a. a.) He just manages to do it, tepwew.
+« AWAN, wa, (a. in.) It just manages to happen, ikkin.
+« AWIW, ok, (v. n.) he uses it; v. g., riama kekwày n't'awin, I have nothing I can use; awi eoko, use this; kekwày ka awiyek? what are you using? This neutral verb is sometimes used for both animate and inanimate forms; v. g., nijo emikkwânak n't'awin, I use two spoons, myself; kiyâm omokkumân ki ka awiwân, it doesn't matter, you are going to serve him with his knife; ot awiwiniw, ok, he makes use of it; v. g., ayamihewiyiniw otawiwiniw pakkwejigana kita Lamessiket, the priest serves himself bread to say mass; Kijemanito nama kekwày ki otawiwiniw kitchi otjchiket, God does not use anything to operate; nama n'ot'awiwinin ni'spitun, I do not have use of my arm.
+x AWOKKÂN, ak, (n. r.) slave.
+« AWOKKEW, ok, (a. a.) he is a slave.
+
+334
+
+EKA
+
+« AWOKKÂNIWIW, ok, (a. a.) idem
+« AWOKKÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he makes him a slave.
+x AWENIBAN, (ex.) disappointedly, it is over! v. g., aweniban n't'em! it is over with my horse! aweniban ekwa ke wâbamak! from now on, I'm done with seeing him! aweniban ke takusik? it is done, he is not arriving!
+E, sign of the subjunctive, seeing that; v. g., e wissakeyittamân, since I suffer; e sâkihitân, since love you ; e ki wi-sipwettet, since he wanted to leave.
+ENH-ENH, (ad.) Affirmation, or; v. g., nametchi ki wi-witjewin? enh-enh, namawiya, you don't want to come with me? Yes, no, that is to say yes, I do not want to; nametchi ki wi-ayamihân? enh enh, namawiya, you don't want to pray? yes, no, that is to say, yes, I do not want to; ki wi miyin tchi? enh-enh, will you give it to me? Yes.
+EKA, (ad.) Negation sign before the subjunctive; v. g., eka wi-ayamihâyani, nama ki ka wâbamaw Kijemanito, if you don't want to pray, you will not see God; eka e ki wâbamak, since I could not see it; nakatâkkan eka wipimuttetji, leave him, if he doesn't want to walk. N. B. Putting the namawiya negation before eka makes two negations, which thus becomes an affirmation; v. g., namawiya eka kitchi wâbamak, or, namawiya eka ni ka wâbamaw, I have to see it; namawiya eka ni ka kiskeyitten, I must learn it.
+
+EKA
+
+EKAWIYA, or, EKA, (ad.) Sign of the prohibitive. Noli. v. g., ekawiya ekusi tota, do not do so; eka pikiskwe, don't speak; he speaks only to himself; v. g., ekawiya, don't do that, noli; but eka is not said alone. Also, in these turns of phrase: ekawiya ekusi ni ka itik, don't speak to me like that; ekawiya ni ka wâbamaw ni wi-kikkâmaw, as I do not see it, I want to dispute it; ekawiya awiyak kita matchi ayimomaw, let no one say bad things about anyone. Note. I think that one may also say this with negation, v. g, ekawiya maka namawiya ki ka wi-toten,, be careful not to do it; ekawiya maka, nama ki ka atuskân kispin kiwi-mitjisun, don't imagine yourself not working, if you want to eat.
+EKAM, or, EKAMNA, (ad.) Or, eyakam, v. g., ekam wiya miyaw, taneki nama ni pa miyikawin? we gave him some, why not give me some? eyakam ki totam, ni ka ki toten, since he does it well, I will also be able to do it; ekamna wiya miyiyât, eka ka wi-miyit? he gives it to him, why does he not give some to me?
+
+335
+
+EKO
+
+EKASKAMIK, wok, (n. f.) This word, although used, is not Cree, it was the Whites who created this word: osikamisk, spared beaver, cut up and dried; from the root osik, which means something which becomes small as it dries.
+EKUSI, (ad.) As well; v. g, ekusi ni toten mâna, this is how I do things usually; ekusi tchi? is that so? namawiya ekusi, this is not so; ekusi iji, as well, as well, sic. sic. ; ekusi ituke, it is all probable; ekusi âni, it is so, it is enough; ekusi ka ijinipit, that's how he died.
+EKUSPI, (M) then, in this time; v. g., ekuspi ni miyo-ayâttày, I was fine then; ekuspi Jesus ka ki pe-ituttet waskitaskamik, that's when Jesus came to the Earth; ekuspi Jesus ekusi ki itew owitjewâgana, Then, Jesus said to his disciples. This word is very rarely used for a future time; v. g., ekuspi ki ka mitâten, that's when you will regret (it). One might rather say: tcheskwa ki ka mitâten.
+EKUTÂ, (ad.) It is there (closer); v. g., ekuta ayamihewikamikok ayaw, it is there, he is in the Church.
+EKUTÊ, (ad.) It is there (further); v. g., ekute kitchi kijikok ke wâbamâyak Kijemanito, it's there, in Heaven, that we will see God.
+EKOTOWA, (pro.) It's from this thing, it is of this kind, of this sort. That is, the root eoko, that's him, that's it, as one says: oma, that; omatowa, from this thing; v. g., ekotowik ka wissakeyïttak, it's in this part that he suffers; omatowik ka pikupayik, it is in this part that it's broken. By using these expressions, it is necessary to designate or indicate with the hand, the thing of which one is speaking; eyâbitch tchi ​​ekotowa? is it still the same? omatowikkumân, of this kind of knife; keyâbitch ekotowa ka ki miyiyan, it's still the same type that you gave me.
+
+EKO
+
+« EKOTOWIWIW, ok, (a. a.) he is of this kind, v. g., when one asks someone if he is from such a nation, he would say: namawiya n't'ekotowiwin, I'm not part of that group. St. John the Baptist responding to the Jews: namawiya n't'ekotowiwin ka iteyimiyek, I am not who you think I am; ekotowiwâbâne ka âwenawiyek, if I was that which you mistake me for.
+« EKOTOWIKKÂN, ak, (pro.) Of that sort of people; v. g., ekoto-wikkânak ka raatchi-ayiwitjik mâna, it is usually your kind of people who are cruel.
+x EOKO, or, EWOKO, (pro) this, it is he, this one, v. g., eoko ka wanihak n't'em, it's the horse that I lost; ewoko nisim, it is my younger brother; eoko Kijemanito ka ojittât kakiyaw kekwây, it is God who made everything; eoko ayisiyiniw, that man.
+« EOKONIK, (pro. plur.) These, those, these; v. g., eokonik ka ki wâbamakik, they are the ones I saw
+
+336
+
+EKW
+
+« EOKO, (pro. Inan.) This is it, this; v. g., eoko ni mokkumân, it is my knife; eoko wâskâhigan, this house.
+« EOKONI, (pro. plur. inan.) These things, these, etc.
+EOKOTCHI, (ad.) That's why, that is the reason, compared to that; v. g., eokotchi k'o pe-itutteyân, that's why I came; eokotchi kit âkkusin, compared to this, you are sick; eokotchi kitchi kakwe ayamihak kijikok kitchi ituttek, this is why we have to try to pray to go to Heaven.
+EKOYIGOK, (ad.) Enough, as much, quite, that's enough ; v. g., ekoyigok ki weyotisin, you are rich enough; ekoyigok, ni kiispun, that's enough, I am satisfied; ekoyigok kita takusin, that's when it will happen, poni-kimiwaki, ekoyigok ni ka sipwettân, when it stops raining, that's when I will leave; ekoyigok kâkebâtisiw ekusi kitchi totak, he's pretty crazy to do this.
+EOKWEKKA! (ex.) like aspin aweniban, eokwekkâban!
+EKWA, (ad) come on, let's see, now, at this time; v. g., ekwa kiwe, come on, go away; ki ka kiskinohamâtin ekwa, I'm going to teach now; ekwa piyis ki kaskittân, here you are, come to the end at last.
+EKWEYÂK, (ad.) The first time; v.g., ekweyâk ki wâbamitin, it is the first time that I see you; namawjya ekweyâk ikkin, this is not the first time that it has happened; ekweyâk tchi ​​totam eoko? (irony.) is this the first time that he's done that? ekweyâk ni wissa keyitten, this is the first time that I have suffered so much; ekweyâk takusin, it's just happening. One also says pitcheyâk.
+
+EKA
+
+« EKAYUTCH, (ad.) idem.
+EMÂNIS, (ad.) A little, apisis, (rarely used.)
+x EMIKKWÂN, ak, (n. r.) spoon.
+x ESEKAY, ak, (n. r.) woodlouse.
+« ENS, ak, (n. r.) Shell.
+« ENSIS, ak, (n. f.) small shell.
+x ENSKEW, ok, (v. n.) he breaks the beaver dam or rat's den to kill them. This word is used only for hunting in winter.
+« ENSKÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he breaks the beaver dam (he works on it).
+« ENSKÂGAN, a, (n. f.) Instrument for breaking down the dams, lodges, etc.
+x ESKAN, ak, (n. r.) horn, breading, head horn; ot eskaniw, he has a breading.
+x ESIGAN, a, (n. r.) a part, or a half; v. g., ësiganegin, a half of skin; esigan niyaw ka mojittâyân, it is in a half of, or, one side of my body that I feel it.
+x ESIKKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he annoys him, he tires him, he is always after him; v. g., ponih, ekawiya takki esikkaw, leave him alone, don't bother him all the time; kakike matchi manito esikkawew ayisiyiniwa, the demon is always among Man to torment him; kekwây oma ka esikkaman? what are you doing here? or, what are you doing? One also says this word of a man, v. g., who is pestering a woman to make her consent to evil.
+
+337
+
+ETC
+
+« ESIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he is always bothering him, tiring him out with his words; v. g., tāneki takki k'otchi esimiyan? why are you still bothering me?
+x ESIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he waits for her, he alters his walking pace to catch up with him
+ESKWA. (ad.) This word is rarely used alone. We say: nam'eskwa, or, namawiya eskwa, not yet; v. g. , nam'eskwa kakiyawiyiniwok ayamihâwok, the Indians are not all praying yet. This expression also means: during which, while; v. g., eskwa ota ayâtwaw, while they are still here; eskwa eyâbitch e pimâtisiyek, kakwe kesinâteyimisuk, while you live, try to repent.
+x ESÂHAMÂN, ak, (n. f.) seashell spoon.
+« ESAHAMÂWEW, (v. a.) he feeds him with a seashell spoon.
+ETCHIKA! (ex.) therefore; v. g., sipwettew etchika-ni, (ergo) it is so very true that he is gone! But so he's gone! etchikani namawiya ki wi-ayamihân! so you do not want to pray! Note. This ni is for ani, which joins itself with the word; v. g., etchikani, or, etchika ani namawiya nika ki wâbamaw! so I will not be able to see it!
+
+338
+
+« ETCHIKA AWÂH! (ex. and pro.) so it's him! v. g., etchikawâh ka matwe-nipit! so it's him that's said to be dead!
+« ETCHIKA OMA! (ex. and pro. in) so that's it! v. g., etchika oma ka ki wanittâyân! so that's it, or, it's true, that's what I had lost!
+x ET, (rac.) make a mark by knocking on it, or touching it in some way, to print on, etc., etc.
+« ETÂHWEW, (v. a.) HAM, HUWEW, HIKEW, he makes a mark, an incision on him by hitting him, by touching, v. g., with a stamp, a seal; etâham masinahigan, he prints a mark on the paper, ayetahwew.
+« ETÂNEHWEW, (v. a.) HAM, HUWEW, HIKEW, it makes a mark, etc., on wood, ayetânehwew, (redup.)
+ETISIW, ok, (a. a.) it is marked (according to the sense given by the root), ayetisiw, (redup.)
+« ETAN, wa, (a. in.) Idem, ayetan, (redup.)
+« ETISKIW, ok, (a. a.) There is his track, he prints the mark of his foot on, etc. This word is more often used with reduplication, ayetiskiw; v. g., mistahi ayetiskiw mahiganak, there are many wolf tracks; namawiya mwâsi ayetiskiwok wâbistânissak, there are few signs of martens.
+
+338
+
+EYI
+
+ETATO, (ad.) voy. akâwâtch, painfully, with difficulty, with reluctance; v. g., pakakkam etato ki miyin, it's likely with loathing, that you give it to me; etato takusin, it's wih difficulty that it may have happened; etato mitjisuwok, they barely have enough to eat.
+« ETATOWISIW, ok, (a. a.) He barely exists, he barely lives, he is near his end, or, etato pimâtisiw; ekawiya pehu kitchi etatowisiyan, kita âtjimisuyan, do not wait until you are at the end of your life to confess; etato yeyew, he barely breathes.
+« ETATOWEYIMEW, (v. a.) Tt, miwew, tchikew, he thinks so to the end, or, etattweyimew.
+EYÂBITCH, (ad.) See. keyâbitch again, again, more; v. g., eyâbitch ni wi-mitjisun, I want to eat again; eyâbitch tchi kit âkkusin? are you sick again? eyâbitch tchi? again? eyâbitch tchi ​​Jesus-Christ kita pe-ituttew waskitaskamik? Will Jesus Christ come to Earth again? eyâbitch ituke, without doubt, again; eyâbitch peyakwan kit ayân, you are at the same place again.
+EYIGOK, (ad.) When; v. g., eyigok wâbamatji, when you see it; eyigok miyoskamiki, when it is spring; more than, v. g. , eyigok kakiyaw iskwewok kit iteyittâkusin, you are more worthy than all women; nawatch ki kinosin eyigok niya, you are taller than me; nawatch anotch kissin eyigok otâkusik, it is colder today than yesterday; as much as, also as; v. g., namawiya ekoyigok ayâwok aka yasiw otayamihâwok eyigok katolik ot ayamihâwok. There are not as many Protestants as there are Catholics; namawiya ekoyigok ki maskawisin eyigok wiya, you are not as strong as him; eyigok kejewâtisit, he is so charitable!
+
+EYI
+
+« EYIGOKKWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he encourages him, he urges him, v. g. kit eyigokkweyimitinâwaw kita kanaweyittamek manitowi-pikiskwewin, I encourage you to keep to the divine word.
+« EYIGOKKWEYIMOTOTAWEW,(v. a.) tam, takew, tatchikew, idem
+« EYIGOKKWEYIMOW, ok, he has courage, he is courageous, v. g. eyigokkweyimuk ayiwâk kita sâkihâyek Kijemanito, have courage in, or, try to love God more, kayâs akayâsiwok mistahi ki eyigokkweyimowok e wi-paskewitâtjik Katolik ayamihâwin, in the olden days, the English did their best to abandon the Catholic religion, eyigokkweyimuk anotch kitchi kijittâyek, strive to end it today.
+
+339
+
+EZA
+
+EYIWEK, or, keyiwek, (ad.) (the most used word in the Cree language, and which has a host of rather difficult to understand meanings, however usage should soon make these clear) It doesn't matter, it is not so bad, nevertheless one can find better, yet it is not so bad, v. g. eyiwek ki ka miyitin I'll give it to you anyway (as long as I don't want to) mistahi kissin anotch, maka eyiwek ni ka sipwettân, it is very cold today, but it doesn't matter, I'm going to leave anyway, eyiwek tchi ​​ni ka ki ayamihân? can i pray?, with the assumption that I think myself incapable of doing so. Answer: eyiwek mana maka, certainly; eyiwek ki miyo ayâsin tchi? are you a little better though? enh, enh, eyiwek, yes, a little, eyiwek apisis ni kiskeyitten ekwa ayamihâwin, all the same I know a little religion now, see wiyatte, or, oyatte, which have almost the same meaning.
+É! É! EY! expression of discouragement, regret, v. g. é! é! ey! ki pistahutin! How can it be! I inadvertently injured him! é! é! ey! kakiyaw ki nipinânow! I don't believe it, we're all dead!
+EZA, (ad.) it seems that, etc., one says, one relates, etc., v. g. kiya eza ka kimotiyan, it seems that it was you who stole (it), nama eza ayiman, it doesn't seem too difficult, nama eza kisopwew anotch, it is not very hot today; one also says, weza, for eza. This expression is also used in narration, v. g. Jesus, eza omisi itew owitjewâgana, Jesus said so to his disciples, nipiw eza, it seems that he is dead, mitchetiwok eza mustuswok, one says there are a lot of buffaloes.
+
+Remarks.
+
+1 ° The G and II are not found
+to have place in this dictionary, by
+alphabetical order, because the sound
+idu k merges with the g at the com-
+start of words, and the sound of
+this last letter is always the
+more sensitive. Very often in the middle
+place of the word, and especially at the end,
+the sound of the g is very pronounced, and then
+we use it, v. vs. masina-
+higan, 'pound, tchikahigan, ax,
+the same goes for H.
+
+2 ° The letter I which will follow is the
+beginning, we could say,
+from the same root, which gives little
+almost everywhere the same idea, iji as well,
+is, ik, it, which mean so, of
+this way, this species, doing,
+or acting in such a way. We
+could join almost all
+endings of verbs and 'ad-
+jective to this general root, i, and
+form as many words as would be
+formed only of those we
+we just indicate.
+
+3 ° In Cree there is no word which
+begins with the letter J, but
+wind I use it in the body of the
+word, when I think it's the sound
+of this letter which dominates there.
+
+340
+
+IKK
+
+IH! (ex.) hey! see! when one wants to show an object, .v. g. ih! wâbatta eji-miwâsik! see how beautiful it is!
+x IKK, (rac.) lower, lessen.
+« IKKÂPASK, wa, (n. f.) Fern.
+« IKKIPAYIW, ok, .a, (a. a. and in.) it decreases, it becomes less, flows to disappear, v. g. swelling, ikkipayiw, it loosens, ki ikkipayik waskitaskami; when it was dried up on the land.
+« IKKIPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it flow out, he makes it decrease, he deflates it, v. g. pitane ikkipayittây eoko sipïy! Oh how I cannot dry up this river! sâsay ni ki ikkipayihaw ni sikkipim, I already loosened my nail.
+« IKKASTEW, a, (a. in.) it is dried; this is generally understood the water is falling, v. g. kakiyaw sâkahigana ikkastewa, all are lakes are low, ati-ikkastew sipïy, the (water of the) river begins to lower.
+« IKKAHWEW, (v. a.) ham, huwe, hikew, he lowers it by removing water, v. g. nama awiyak kita ki ikkaham kitchigami, nobody will be able to decrease or lower the sea.
+« IKKAHIKÂSUW, ok, (a. a.) he is diminished, v. g. a boiler, one can say, n't'ikkahwaw askik, I lower the water in the tank, ikkahikâsuw, the contents of the tank lower, lessen.
+
+IKK
+
+« IKKAHIKÂTEW, a, (a. in.) it is lowered, decreased.
+« IKKINEW, (v. a.) NAM. NIWEW, NIKEW, like ikkahwew, only here does one indicate actions of the hand by new.
+« IKKÂTJIWASUW, ok, (a. a.) He has diminished by boiling, v. g. a boiler.
+« IKKÂTJIWATTEW, a, (a. in.) idem N. Âtjiwasuw endings, âtjiwattew, denote the action of fire on something boiling.
+« IKKÂTJIWASWEW, (v. a.) SAM, SUWEW, SIKEW, he makes it decrease by boiling it.
+« IKKATAWAW, a, (n. f.) small meadow surrounded by woods, or rather, swamp reeds, where there is sometimes water, a place where, formerly, there was a lot of water, and which at present is either dried out or almost dried out.
+« IKKATAWASKAW, a, (n. f. and a. in.) where water has decreased, has disappeared, and where grasses appear.
+« IKKÂKUTTEW, (v. im.) Snow lowers by melting.
+« IKKWÂKUNEW, (v. im.) Idem.
+« IKKISIKUTTEW, (v. im.) The ice decreases while melting.
+« IKKISKAWEW, (v. a.) KAM, KÂKEW, TCHIKEW, like ikkahwew, except that here, an action of the foot is indicated.
+« IKKEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he languishes on his account, thinking of him, v. g. I see someone who is in great pain, watching him suffer this way makes the minutes seem to me hours, for this I would say n't'ikkeyimaw, I languish, I suffer for him, ikkeyittam eka mayo e takusiniyik, while he does not arrive, he finds the time long, ekawiya ikkeyimin, don't find me too long near you, ekawiya ikkeyittamokkan kinwes ki wi-ayamihitin, do not find the time too long, or, don't be bored, I want talk to you for a long time, ekawiya ikkeyittamuk eyamihâweku, don't find the time long when you pray, osâm e ikkeyittak, piyis kiwew, by boring him too much, he finally left.
+
+341
+
+ISA
+
+« IKKIMIW, ok, (a. a.) The water is going down, where it is placed, v. g. someone standing up in a pond or pool of water, if the water drops he can say n't'îkkimin.
+IKKIN, (v. im.) It happens, v. g. nama wikkâtch ekusi ikkin, it never happens like this, ikkiki kita ayiman, if that happens it will be troublesome, wi-ikkiki kiyârn kita ikkin, what will happen, pitane îkkik. May it happen! ayiwâk ikkin! terrible event, how terrible!
+IKKÂBAMEW, (v. a.) TTAM, KEW, TCHIKEW, he looks at him angrily.
+x IKKWA, ok, (n. r.) louse, vermin, n'otikkumin, I have louses, otikkumâtew, he destroys his lice, he kills his lice.
+x ISAWÂNAKEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he's jealous of him.
+
+ISA
+
+« ISAWÂNAKEYIMOTOtawew, (v. a.) TAM, TÂKEW, TATCHIKEW, idem
+« ISAWÂNAKEYIMOW, ok, (v. n.) he is jealous, see. sawânakeyimow.
+x ISA, (rac.) in spite of himself, with difficulty, do violence to oneself.
+« ISÂHUW,(v. r.) he moderates himself, he restrains himself, he corrects himself, but by doing violence to himself, v. g. namawiya ki isâhuw, it cannot be corrected, he can not overcome such a fault, ayis namawiya ni ki isâhun, what to do, I can not correct myself, I cannot help myself.
+« ISÂHEW, (v. a.) TTAW, HIWEW, HIKEW, he moderates it, he corrects it, he prevents him from doing such a thing, but only by doing some sort of violence.
+« ISÂTCH, or, IYISÂTCH, despite him, with pain, reluctantly, v.g. iyisâtchituttew, he goes there reluctantly , ekawiya iyisâtch tota, don't do this reluctantly.
+x ISAW, (rac.) square.
+« ISÂWESIW, ok, (a. a.) he is square, ayisâwesiw.
+« ISÂWEYAW, a, (a. in.) it is square, ayisâweyaw.
+« ISÂWEK, wok, square needle, or, asâwek, wok.
+« ISÂWESWEW, (v. a.) SAM, SUWEW, SIKEW, he cuts it square with a knife, or, a chisel.
+« ISAWENEW, (v. a.) NAM, NIWEW, NIKEW, he holds it with his hand by the square part, or, the cutting edge ,see the root asâwe, which is the same as this one in meaning.
+
+342
+
+ISI
+
+« ISAWEHEW, (v. a.) TTAW, HIWEW, HIKEW, it makes it square. N. B. All of these words are said more often with reduplication, ayis, etc. This is probably why one may equally say isâwe, or, ay-isâwe.
+x IS and IT, (rac.) as well, in this manner, of this form, in this way.
+« ISI, or, IJI, before the verb, like that, v. g. ekusi iji, it is thus, eji kijewâtisit, being so charitable, awâsis ka iji-miyosi, the child who is so beautiful, eji matchikijikâk, nama ni ka sipwettân, since it is such bad weather, I will not leave, eji-kâkebâtisit! how foolish he is! tchist! eji-pikupayik ni mokkumân! see how my knife is broken! ekusi piko n't'iji-kiskeyitten, I only know about this way, Jesus Christ ki pe-ittutew waskitaskamik eji-manitowit mina eji-ayisiyiniwit, Jesus Christ came to earth as God and as man, eji-atchâkowik mina eji-owiyawik, in soul and body.
+« IJITCHITCHEYIW, ok, (v. n.) extend your hand towards.
+« IJITCHITCHEYISTAWEW, (v. a.) TAM, TÂKEW, TÂTCHIKEW, he extends his hand towards him.
+« IJITGHITCHEYITOTAWEW, (v. a.) etc .. idem.
+« ISIW, ok, a kind of auxiliary, like, ittiw, ayaw, it is
+
+ISI
+
+« ISIWIN, a, (n. f.) To be, otisiwin, his being.
+« ISIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, it does so, in this way, v. g. ekusi iji kakwe isitta, try to do it that way, Kije-manito kakiyaw ayisiyiniwa ki ijihew kita naspitâkut, God has made all men to resemble him.
+« ISIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, (little used), he talks to him so.
+« ISISIMEW, (v. a.) TITAW, MIWEW, tchikew, he places it like that, he sets it down in such a way, v. g. ni ka kakwe ijittitân ni pikiskwewin kitchi miyottaman, I will try to direct my speech, so that you are happy with it.
+« IJISIN, wok, (a. a.) He is lying, he is lying on the ground in this way.
+« IJITTIN, wa, (a. in.) It is placed in such way, it goes, it leads itself in such a way, v. g. tanisi ejittik eoko pikiskwewin? How does this word go? or, how do you pronounce this word?
+« IJITTIN, wa, (a. in.) It's heading to this side, v. g. watercourse, kakiyaw sipiya ekute ijittinwa, all rivers flow from this side, tande ka ijittik eoko sipïy? where does this river flow?
+« IJISTIKWEYAW, a, idem, water which flows on this side.
+« ISIGAMAW, (v. im.) there is a lake of such form.
+« ISASTAW, ok, (v. n.) He has objects of superstition, it has objects in such a way. N. B. In some words it is is, and in others ij, according to pronunciation.
+
+343
+
+IJI
+
+« ISASTÂWIN, a, all the objects and forms of superstitions of the savages v. g. nama kekway n'ot'isastâwinin, I have no objects of superstition, kekway tchi ​​kit isastan? do you have, or, do you make superstitious things.
+« IJIHIKÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he calls it that, v. g. tanisi ka ijihikâsiyan? How? 'Or' What did you name me? One also says: iji-nikâtew.
+« IJIHIKÂSUW, ok, (a. a.) he is referred to as such.
+« IJIHIKÂTEW, a, it is called thus, v. g. tanisi ejihikâtek e nehiyâwek? what is that called in Cree?
+« IJINAWEW, (v. a.) NAM, NÂKEW, NÂTCHIKEW, he sees it that way, or, in such a way, v.g. somebody seeing a man and thinking he is a woman, he thus sees a woman, iskwewa ijinawew, I see an object in the distance, I think it's a bear, maskwa n't'ijinawaw. Tânisi ejinaman eoko? what view do you have of that? what do you think of that? mekwâtch e nipayân, ekusi n't 'ijinettày, while I was sleeping, he seemed to me to see thus, kekway ka ijinaman? what do you think you see?
+« IJINÂKUSIW, ok, (a. a.) He has such an appearance, he has such a resemblance, v. g. mwetchi ijinâkusiw, he is absolutely the same, tânisi ejinâkusit kit'em, what does your horse look like, or, what colour is your horse? ekusi ot ijinâkusi, he had this color, namawikkâtch ni wâbamaw ayisiyiniw ejinâkusit, I have never seen a man with such an appearance, tâbiskotch osima ijinâkusiw, he is similar to his younger sister.
+
+IJI
+
+« IJINÂKWAN, wa, (a. in.) it has such an appearance, v. g. ekusi ejmâkwanobani ni masinahigana, my books were similar to this, tâsisi ejinâkwak meskanaw? how is the path? namawiya peyakwan kakiyaw ijinâ kwanwa totamowina, all actions are not alike.
+« IJINÂKOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it look thus, v. g. Jesus Christ ki ijinâkuttaw o kijewâtisiwin e nipustamâwât ayisiyiniwa, Jesus Christ made his contribution by dying for men, tânisi ka ejinâkutchiket mekwâtch e ayât waskitaskamik? what did he make appear while he was on Earth?
+« IJINÂKOHUW, ok, (v. r.) he appears so, v. g. Jesus ki ijinâkohuwkitimâkisiwinik, Jesus appeared in poverty.
+« IJITTWAW, ok, (v. n.) he has such and such a way of acting; this is also for religion, v. g. tânisi ejittwâyan kiya? what religion are you? ni Katolik ijittwân, I am Catholic.
+« IJITTWÂWIN, a, (n. f.) way of acting; ayamihewijittwâwin, religion, v. g. peyak piko ki ojitaw ijittwâwin, eoko Katolik k'ejihikâteyik, He made only one religion, the one whose followers call themselves Catholic
+
+344
+
+ISP
+
+« IJIWIHEW, or better, IJIWIYEW (v. a.) TAW, YIWEW, OU, HIWI tchikew, he takes her in this way, v. g. wiya eza ka ijiwi ekute, it seems that he was the one who took him to that side, ijiwiyew otâbânâskok, he transports him thus by car, tandawik ka ijiwitâyan kit âbatjitjigana? how do you carry your tools?
+« IJIPUYEW, (v. a.) TAW, YIWEW, TCHIKEW, he saws it in such and such a way
+« IJIKKUTTEW, (v. a.) TTAM, TCHIKEW, he slices it thus, he cuts it well with a knife.
+« IJIKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he cuts it in this way with an ax.
+« ISPINEW, ok, (a. a.) He has such a disease. Note. The suffix new indicates disease, death; v.g., kakiyaw metchinewok, they are all destroyed by disease; tânisi ​​espineyan? what disease do you have? misiwe iji-n't'ispinân, I have all kinds of illnesses; ka kiyaw ekusi ispinewok, they all have this disease, or, they all die of this disease.
+« ISPINEMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he tells him all sorts of insults; misiwe iji ki mâmatchi ispinemaw, in this way, he overwhelmed him with insults, abuses.
+« ISPITEYIMEW, (v. a.) TTAM, WEW, TCHIKEW, he makes such an estimate; v. g., ka iji-ispiteyimak n'ottâwïy kit iji-sâkihitin, I love you as much as I esteem my father; Kije manito ki ispite yimew ayisiyiniwa pâskatch e mekit opeyakosâna, God esteemed man so highly, He gave them his only Son; n't'ispiteyitten ki pâskisigan, I make an estimate of your rifle; (this is also a kind of oath); v. g., espiteyimak Kije manito, I take God as a witness, or, as long as I esteem God, kit aso tamâtin, I promise you this.
+
+ISP
+
+« ISPITEYITTÂKUSIW, ok, (a. a.) it is estimable at such a value; tâneyigok espiteyittâkusit ki mustusum? what is the value of your beef? namawiya mistahi ispiteyittâkusiw, he is not of great value.
+« ISPITEYITTÂKWAN, wa, (a. in.) it is of such value; v. g., pâstâhawina namawiya kakiyaw peyakwan ispiteyittâkwanwa, not all sins have have the same degree of malice, they are not all the idem
+« ISPISIW, ok (a. a.) it is of a value, of such a character, of such a capacity; v. g., nama ayiwâk ni ki ispisin, I can do no more; eyigok espisiyan, as much as you are able; eyigok e ispisit eoko askik, as much as this boiler can contain; n't'ispisin, I still go; v. g., ispisi, still go, continue; n't'ispisin ata e wi-ayamihâyân, I try to always advance a little while wanting to be of religion
+
+345
+
+ISP
+
+« ISPITCHAW, a, (a. in.) It is of such a magnitude, of such a capacity; v.g., tàneyigok espitchâk ki wâskâhigan, what is the greatness of your house? espitchâk askîy, as long as the Earth is great; newonisk ispitchaw, it is four fathoms (6.4m); ayâtit ayiwâkes ispitchâwa, there are others which contain more.
+« ISPITCHOTEHIW, ok} (a. a.) as long as he has a heart; v. g., espitchotehiyek sâkihik Jesus; love Jesus with all your heart
+« ISPITCHOTATCHÂKUW, ok; (a. a.) as much as he has soul; v. g., espitchotatchâkuyân ki sakihitin, I love you with all my soul.
+« ISPISIW, ok, (a. a.) he is high, elevated; v. g., namawiya ispisiw kit askikum, your boiler is not high; mistahi ispisiw kitem, your horse is very high, tall.
+« ISPAW, a, (a. in.) It is high, elevated; v. g., wâskâhigan ka ispâk, a house that is high.
+« ISPAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he raises it, he places it higher.
+« ISPAPIW, ok, (a. a.) He's sitting high up, in a high place; ispapiwok they are piled up very high on top of each other.
+« ISPAPIWIN, a, (n. f.) High seat.
+« ISPASTEW, a, (a. in.) it is high, v. g., something piled up in such a way as to be elevated.
+« ISPATINAW, a, (n. f.) There is a high hill, high mountain.
+
+ISP
+
+« ISPATCHAW, a, (n. f.) High ground.
+« ISPATASKAMIKAW, a, (a. in.) idem.
+« ISPATAWOKKAW, (n. in.) idem.
+« ISPASKAW, a, (n. f. and a. in.) tall grass, tall hay.
+« ISPÂSKWEYAW, a, (n. f. and a. in.) high timber edges.
+« ISPI, (ad.) As soon as, then, when; v. g., ispi e wâbamât, mâtuw, as soon as he saw him, he cried; ispi Jesus ka tchistâhâskwâtit, when Jesus had been crucified; ispi Mary ka âtamiskâkut okijikowa, when Marie was greeted by the angel; ispi e ponipayik, when it's been over. Note. This expression seems to apply only to the past tense.
+« ISPITCH, or, ISPITCHI, (ad.) see. eyigok, meanwhile, as much as; v. g., nawatch kisopwew anotch ispitchi otâkusik, it is hotter today than yesterday; ispitchi pimutte, missawâtch ki ka atamittin, keep walking, I will catch up to you all the same, espitchi maskawisiyân, as long as I have strength, all of my strength, Kijemanito espitchi kitimâkeyimât ayisiyiniwa ki mekiw okosissa, God loved men so much that he gave (them) his son, nawatch kitchi nipiyek ispitchi ekusi kita totamek, you must prefer die than to do that, ispitch eka kita mitjisuyân, kiyâm nama ni ka pittwân, I'd rather not smoke than not eat, ispitchi ayamihâsi, kiyipa ni ka pe-kiwân, pray a little in the meantime, I will soon come back, ispitchi mitjisu kiya, niya wiya ni wi-atuskân, you're always eating, you, and I'm always working; one also says: ispisi, v.g, ispisi nipâsi, while waiting, sleep a bit.
+
+346
+
+ISP
+
+« ISPAYIW, ok, a, (v. im.) it happens, it goes like that, see. ikkin, v.g., kispin ekusi ispayiki, if it happens that way, ispayiyiw nista kitchi nipit, his time is also coming to an end, to death, tânisi ​​espayiyan, what do you have? what happened to you? nama nando n't'ispayin, nothing happened to me, kekway ka ispayik? what happened? N. B. This word also means to go on horseback in a certain way, as it bears the suffix payiw, as well as many other meanings, indicating the action of travelling on horseback, v. g., tande wa-ispayiyan? where do you want to ride on horseback? ispatinâk ni wi-ispayin, I want to go on the hill
+« ISPAYIWIN, a, (n. f.) the event of, or the action of, going on horseback.
+« ISPAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he leads him, he leads him, v. g. wâyo ni ki ispahâwok mistatimwok, I led the horses far away.
+« ISPATTAW, ok, (v. n.) he runs in such a direction, v. g. wâbaki maskutek ni ka ispattân, tomorrow I will go running to the meadow, wâyo ki ispâttâwok e wi-atimâtjik, They ran away to join them, tande espattâyan? where are you running?
+
+ISP
+
+« ISPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it go a certain way, he makes a certain thing happen this way, v. g. tânisi ​​espayittâyan eoko, eka ka kijittâyan? How do you deal with what you cannot finish? tânisi espayittâyan kit'eyaniy, eka e ki itweyan? how do you turn your tongue so as not to be able to say it? N. B. The following is the same root, it, in lieu of is and ij.
+x IT, (rac.) Thus, in this manner.
+« ITÂBAMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he looks at it like that. This word is most often used for imaginary things, and dreams, v. g. tânisi ​​etâbattaman tibiskok, what did you see last night? nama nando n't'itâbatten? I did not see anything, tânisi ​​etâbamiyan? how do you find me?
+« ITÂBAMINÂKUSIW, ok, (a. a.) it has such an appearance, v. g. misiwe itâbaminâkusiwok mustuswok, buffaloes appear on all sides.
+« ITÂBAMINÂKWAN, wa, (a. in.) it has such an appearance, v. g. eyigok itâbaminâkwak maskutek misiwe ayâwok, as far as the eye can see in the prairie, it is everywhere.
+« ITÂBISKAW, a, (a. in.) the rock is of such a type, v.g. wâyottâbiskaw assinïy watjiy, The Rocky Mountains stretch far, tânisi ​​etâbiskâk eoko piwâbisk? How is this iron made.
+
+347
+
+ITÂ
+
+« ITATCHAW, a, (a, in.) The earth/ground is of such a form; v. g., tânisi etatchâk ekute? how is the ground over there?
+« ITÂSKWEYAW ia, (a. in.) edges of the forest, arranged in such a way; v. g., Maskutek ekusi mana itâskweyaw, in the meadow, the forest appears thus, or, this is how the trees are arranged.
+« ITÂB, (ad.) Voy. tcheskwa, wait a little, in another time, still another moment, the time will come; v. g., itâb ki ka miyitin, wait a little, I will give it to you; itâb nama ekusi ki ka iteyitten, a time will come when you will not think like that; tcheskwa itâb, ni wi-ituttân, wait a little longer, I want to go.
+« ITÂTJIHUW, ok, (v. r.) He conducts himself thus; v. g., kwayask itâtjihuwok, they behave well.
+« ITÂTJIHUWIN, a, (n. f.) conduct: v. g., miyo itâtjihuwin, good conduct; matchi itâtjihuwin, misbehavior.
+« ITÂTISIW, ok, (a. a.) Like ijâtiihuw.
+« ITÂTISIWIN, a, (n. f.) like itâtjihuwin.
+« ITATJIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he raises him like this, he trains him in this way.
+« ITÂTJIMOW, ok, (v. n.) he tells it thus, he reports thus; v. g. tânisi etâtjimoyan? what did you say?,
+« ITÂTJIMOWIN, a, (n. f.) such a report.
+
+ITÂ
+
+« ITATJIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he tells it like this, he tells the story like so.
+« ITASINAHWEW, HAM, HUWEW, HIKEW, he describes it that way, he portrays it that way. 
+« ITASINAHIKÂSUW, ok, (a. a.) it is thus marked, written, or painted.
+« ITASINAHIKÂTEW, a, (a. in.) it is written like this, it is painted this way.
+« ITAKKAMIKISIW, ok, (a. a.) he is busy with such and such a thing; (but this indicates that he is making a lot of noise, or commotion) tānisi etakkamikisiyan? what are you doing?, or, what do you have to trade?
+« ITAKKAMIKAN, wa, (a. in.) there is such commotion, trouble; v. g., nama ni kiskeyitten tânisi ke itak kamikanokwè, I don't really know what will happen; tânisi etakkamikak? what is there? what's new? nametchi ki kiskeyitten etakkamikak? don't you know what's happening?
+« ITASIKKAWEW, kkam, he is busy with him.
+« ITASSIW, ok, (a. a.) it is of a such number; v. g., nijitano itassiwok, there are twenty of them; tantatto etassiyan? how many of you are there? (implied) including those who are with you, v. g., a father with their children; tantatto itassitwaw awâssimissak kit? how many children do you have? etassik waskitaskamik, K. Marie ka mâmawiyes kitchitwâwisit, as long as we are on Earth, it is the Sacred Virgin Mary who is the holiest.
+
+348
+
+ITA
+
+« ITATTIN, wa, (a. in.) is of a certain number; v. g., mîfâtat itattiniyiwa Kijemanito ot itâsowewina, the commandments of God are ten in number; tantatto etatti-ki ayamihewinanâtâwihuwina? how many sacraments are there? tepakuk itattinwa, there are seven
+« ITASI, (prepo.) Before the verb, a synonym of otami, he is busy with, v. g., itasi-kiyukew, he is busy visiting; itasi-metawew, he is at play; itasi-kiskinohamâkew, he is to be taught.
+« ITAKIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he esteems it at such a price, v.g., tâneyigok itakimat kit'em. what price would you set your horse? or nijwattây n't'itakitten oma, I value it at two more (furs).
+« ITÂMUW, ok, (v. n.) he runs away, he escapes thus. The suffix indicates a frightening, dreadful escape; v. g., tande ke itâmuyan ekuspi? where will you run away then. tabasiyâmuwok kakiyaw, they all escape in terror.
+« ITÂMUWIN, a, (n. f.) Escape
+« ITÂMUHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes him run away like this, in fright.
+« ITAMOW, ok, a, (a. a. and in.) it is fixed as such.
+« ITAMOHEW, (v. a.) TTSiw, hiwew, tchikew, he sets it like this, he makes it go thus; v. g., tânisi ​​etamotâyan eoko? how did you set that? kwayask itamotchikew meskanaw, he makes a straight, correct path
+
+ITA
+
+« ITAMUW, a, (v. im.) Path that goes in such and such a direction; v. g., eoko meskanaw sipik itamuw, this path goes to the river; kitchi kijikok ka itamuk, path that leads to the sky; tandè etamuk? where does this way lead?
+« ITASIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, see itasi, to which one adds mew, he is maintaining it with importunity.
+« ITASUWEW, ok, (v. n.) Or, itasiwew, ok, he judges so, he decides so.
+« ITASUWEWIN, a, (n. f.) or, itasiwewin, a, judgment, laws, decision; Kijemanito ot itasuwewin, the law of God.
+« ITASUWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he decides on his fate thus; v. g., kitchi kosâwepitit ki itasuwâtaw, he was judged to be hanged.
+« ITATÂMUW, ok, (v. n.) he speaks such language; v. g., tānisi etatâmuyan? what language do you speak? misiwe iji n't'itatâmun, I speak all languages.
+« ITATEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks it there; v. g, misiwe kitchi itateyimâyak Kijemanito, we have to think of God everywhere; ota itateyimâtâk, let us put ourselves in his presence; ekute n't'itateyimaw, I think it there.
+« ITAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he places it like that; v. g., ayamihewiyiniwok ki itahyikwok Kijemanitowa kitchi kâssinamâketjik, the priests have been placed by God to forgive.
+
+349
+
+ITE
+
+« ITAHYISUW, ok, (v. r.) he places himself well, he sets himself well. This is said of someone who believes himself to be great, who esteem himself highly.
+« ITAPIW, ok, (a. a.) he is seated so.
+« ITASTEW, a, (a. in.) It is placed thus, there it is.
+« ITÂTAWIW, ok, (v. n.) Or, itâtawew, ok, he's walking on a wood thus, eg. someone who would walk on a rope. N. B. The suffix âttawiw, or, âttawew, indicate that one is walking on an object raised in the air; v. g., pimâttawiw, he walks on, for example, the scaffolding of a building.
+« ITÂSKUNEW, (v. a.) NAM, NIWEW, NIKEW, he offers it; v. g., itâskunew ospwâgana, he offers, he presents the pipe. This refers to the superstitious custom of savages of presenting pipes to their spirits, this is where the word itâskunikew, ok, comes from.
+« ITÂSKUNAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he offers him, he presents (it) to him, (as above).
+« ITATJIKANIKEW, ok, (v. n.) He fires a blank. But one says more often kutahâskwew.
+« ITASEW, ok, (v. n.) she keeps her eggs, she broods.
+x ITA, (ad.) here; v. g., ita ka wâbamak, where I saw it.
+« ITE, (ad.) There; v. g., ite ka wâbamit Kijemanito, where one sees God.
+
+ITE
+
+« ITEKKE, (ad.) On that side; v. g., tande itekke ituttew? what side has he gone to?
+« ITEKKESKAWEW, (v. a.) KAM, KÂKEW, TCHIKEW, he follows it from this side; v. g., tānisi ki ki itekkeskawaw? on which side (direction) did you follow?
+« ITAKÂM, (ad.) Of such a bank of the river or lake; v.g., tande itakâm ki pimuttân? which side of the river did you pass on? sakak itekke, in the direction of the woods; paskwâk itekke, in the direction of the meadow.
+« ITAWEW, ok, (a. a.) he has such pellage, such color; v. g., tânisi ​​etawet kit'em? what color is your horse?
+« ITOWEW, ok, (v. n.) He's speaking such a language; v. #., ka itoweyek, pitane nista itoweyân! what, can I not speak your language!
+« ITATEW, (v. a.) TAM, SIWEW, TCHIKEW, he carries it like this, he transports in such a way; v. g., ni kwitate itaten, I do not know exactly how to carry this; tânisi ​​ituke ke itatamân n't'ayânissa, I don't know how I will place my belongings in order to transport them.
+« ITTAW, ok, (v. n.) He exists, he is; v. g., takki ki ittaw Kijemanito, God did not have a beginning; namawiya ittâwok, they do not exist anymore, they are dead; sâsày nama ittaw, he is no longer, or, namatew; ittâtwâwi mustuswok, if there are buffaloes.
+« ITTÂWIN, a, (n. f.) Existence.
+
+350
+
+ITE
+
+« ITTAKUN, wa, (a. in.) There are, v. g. ittakunwa tchi ​​mitta? is there wood? namawiya ittakun, or, namatakun, there is none. eyâbitch nijo kijikâwa ittakunwa, two more days ago.
+« ITOWA, (pro.) Voy. ekotowa, this type, of the same kind, v. g. miyin itowa ka ki miyiyan, give me the same type that you already gave me.
+« ITOWIKKÂN, ak, (pro.) Of the same kind of people.
+« ITEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks it so, he wants it so, v. g. ni ka witjewa kit iteyimitin, I think I will go with you, or, I will go with him, I think of you, ekawiya ekusi iteyim, don't think that of him, tânisi ​​iteyittamek? what do you think, nama nando n't'eyitten, I think nothing, kispin kit iteyitten, or, iteyittamani, if you want, wâbakki ni ka sipwettân n't'eyitten, I am thinking of leaving tomorrow, nama ekusi iteyittamok, they don't think so, ki iteyittamoguban ekuspi, without doubt he must have thought it so, nametchi ekwa kit iteyitten tchi ​​ayamihâyan, don't you think of praying now? tâpwe, ekusi n't'eyitten, it is true, I think about it.
+« ITEYIMOWIN, a, (n. f.) desire, will
+« ITEYITCHIGAN, a (n. f.) Idem
+« ITEYITCHIKÂSUW, ok, (a. a.) he is thought (of), one think so of him.
+« ITEYITCHIKÂTEW, a, (a. in.) it is thought, it is wanted.
+
+ITE
+
+« ITEYIMOW, ok, (v. n.) he thinks through, etc., he sighs for, etc. e.g. kitchi kijikok iteyimotân, let us lead our thoughts to Heaven, tande iteyimoyek? where do you intend to go? wâyo n't'iteyimonân, we intend to go far
+« ITEGAMIW, ok, a, (v. im.) e.g. the tea that is beginning to be made, namawâtch itegamiw, this liquid is not made, or, is not what it needs to be
+« ITEW, (v. a.) TAM, SIWEW, he tells him. Note. I know only these three forms for this verb, which is irregular, it has the imperative, isi, tell him, isik, tell them, itik, you all, tell him, e.g. eoko ka ki itamân, it is what I said
+« ITCHIKÂSUW, (adj. ani.) it (animate) is said
+« ITCHIKÂTEW, (adj. ina.) it (inanimate) is said
+« IWEWESIN, wok, (a. a.) one hears him coming noisily
+« IWEWETTIN, wa, (a. in.) idem, for example, wind which one hears coming
+« ITWENAM, ok, (v. n.) one hears him walking with a clatter
+« ITWEWEHEW,(v. a.) TTAW, HIWEW, TCHIKEW, he makes a noise with him by his means, e.g. tânisi etwewettâyan ekute? what noise are you making over there?
+« ITEHWEW, (v. a.) HAM, HUWEW, HIKEW, he brews it, e.g. iteha  mitjimâbuiy, brew the broth
+« ITINEW, (v. a.) NAM, NIWEW, NIKEW, he holds it with his hand in this way, e.g. ekusi itina ki mokkumân, hold your knife this way
+
+351
+
+   
+
+« ITWEW, ok, (v. n.) he says, e.g. kekway k'etweyan? what are you saying?
+« ITWEWIN, a, (n. f.) speech, talking
+« ITWEHEW, (v. a.) TTAW, HIWEW, HIKEW, he makes him say it
+« ITWEWIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he tells him without ceasing, to annoy him
+« ITWÂSUW, ok, (a. a.) he imagines himself (irony) e.g. n't'ayamihân itwâsuw, he imagines himself praying, implied to mean, while he does not actually pray, ni kaskittân itwâsuw, he imagines himself to be capable, kit itwâsun, you imagine that
+« ITWÂTEW, a, (a. in.) it is counted for that, to that end, e.g. eoko tchi tchikahigan e itwâtek? is this what you call an axe? 
+« ITWÂTEW, (v. a.) HAM, HUWEW, HIKEW, he counts it to that end, e.g. otâbânâsk tchi e itwâtat? do you count that as a sled? tânisi etwâtaman eoko? for what reason are you counting that?
+« ITISAHWEW, (v. a.) HAM, HUWEW, HIKEW, he makes him leave, he sends him, e.g. ke itisahut n'ottâwiy, ekusi nista kit itisahutinâwaw, like my father sent me, I send you, ki ki itisahen tchi? have you sent this?
+« ITISAHAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he sends him, e.g. peyak masinahigan kit itisahamâtin, I am sending you a letter
+
+ITI
+
+« ITISAHAMÂKEWIN, a, (n. f.) a thing that is sent
+« ITISAHAMÂTUWIN, a, mutual sending, rapport, correspondence
+« ITITTAWEW, (v. a.) TTAM, TTÂKEW, TTÂTCHIKEW, he hears it that way, he understands it that way, e.g. kwayask tchi kititittawaw? do you understand it well? tânisi itittawiyan? how do you hear what I am saying? tânisi itittaman eoko? how do you understand this? how do you hear this?
+« ITITTÂKUSIW, ok, (a. a.) he is understood in this way, he is grasped in this fashion
+« ITITTÂKWAN, (a. in.) it is understood in this way, e.g. kekway ka itittâkwak? what is it that you understand?
+« ITUTTEW, ok, (v. n.) he goes there, e.g. tande etutteyan? where are you going?
+« ITUTTEWIN, a, (n. f.) the action of going
+« ITUTTAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he brings it there
+« ITUTTATWÂWEW, (V. a.) he brings it for him, or rather, he brings it for him, or, ituttatowew
+« ITUTTATESTAMÂWEW, (v. a.) he brings it for him
+« ITTIKITIW, ok, (a. a.) he is of such a size, dimension, e.g. kakiyaw peyakwan ittikitiwok, they are all the same size
+« ITOWÂN, (pro.) see. itowa, e.g. nama itowân, is is not this type. N.B. In this way a multitude of other words can be formed by these roots, is, ij, it
+
+352
+
+ISK
+
+« ITISKÂKEW, ok, he causes such an effect on his body, e.g. from food
+x ISKA, (ad.) response to eza, one says, it appears that; but this word is only typically used in the narration of dreams, which one believes to have while sleeping, e.g. iska ekusi n'tikwa, it seems to me that he spoke to me in this way; this adverb influences the form of the verb, and necessitates an a at the end to provide a dubitative form, e.g. iska ni wâbamâwa, he seems to me to see it
+« ISKÂNI, (ad.) this is close to the same meaning as iska above, and expresses a type of doubt, with the letter a at the end of the verb, iskani tâpwewa, apparently he said the truth, it must therefore be this way, iskâni nakiskawewa, we must believe that apparently he met him, iskâni âkkusiwa, eka k'ope-ituttet, apparently he is sick, since he is not coming
+« ISKÂWÂTCH, (ad.) idem
+ISKÂYIWÂK, (ex.) it is terrible! it is frightening!
+x ISK, (rac.) to lose hold, to lose courage, to be weary
+« ISKIW, ok, (v. n.) he loses grip, not being able to hold any longer, e.g. piyis Moise iskiw kinwes ospituna ispimik e itinak, in the end Moses became weary of holding his arms up for so long
+« ISKAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he tires him, he makes him weary
+
+« ISKASTWAW, ok, (v. n.) he loses courage, he loses patience, he cannot hold it any longer, e.g. kwetakittâyeku, ekawiya iskastwâk, when you suffer, do not lose courage
+« ISKISIN, wok, (a. a.) he is tired of lying down
+« ISKITTIN, wa, (a. in.) idem
+« ISKAKUSIW, ok, (a. a.) he is tired of being perched there, of being placed up high from something
+« ISKAPIW, ok, (a. a.) he is tired of being seated, e.g. someone who is on a horse
+« ISKIKÂBAWIW, ok, (a. a.) he is tired of staying standing
+« ISKÂBIW, ok, (a. a.) he is tired of watching
+« ISKÂBAMEW, (v. a.) TTAM, KEW, TCHIKEW, he is tired of watching it
+« ISKÂGANEW, ok, (a. a.) he is tired in his bones
+« ISKÂBÂWEW, ok, (a. a.) he is tired of being in the water
+« ISKÂKUNEW, ok, he is tired of being in the snow
+« ISKIMIW, ok, (v. n.) he loses ground (in the water), or, iyâwaskenam
+« ISKÂMWÂNISIN, wok, (a. a.) he barely appears on the other side of the hill
+« ISKÂMWÂTINAW, a, (n. f. and a. in.) hill which barely appears, while seems to lower out
+« ISKANAPIW, ok, (v. n.) he does not walk for this day, e.g., someone who is on a journey. and who stops to rest for a day or more; e.g. ayamihewikijikâki iskanapik, stop your walk on Sunday; anotch nama ni wi-pitchinân, ni wi-iskanapinân, today we do not want to move camp, rather we want to stop
+
+353
+
+ISK
+
+« ISKANAPIWIN, a, (n. f.) rest, a day or more of rest from walking
+« ISKANAPIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he stops his walking to rest for a day or more
+« ISKITCHEW, ok, (a. a.) his heart does him harm, his heart is falling, he has a pain in his heart
+« ISKIKEPIW, ok, (a. a.) he is weary in all of his limbs
+« ISKAKUTTEW, a, (a. in.) it finishes by falling, because it has been attached for too long
+« ISKAKUTTIN, wa, (a. in.) idem
+« ISKIPEW, ok, a, (v. im.) the water rises. One says: n't'iskipân, the water rises where I am; e.g., kakiyaw ayisiyiniwok ki iskipewok, all men were submerged; ekuspi misiwe ki iskipew askiy, so the whole Earth was covered with water
+« ISKIPEWIN, a, (n. f.) deluge, water which rises
+« ISKIPETTAW, ok, (v. n.) he makes the water rise; e.g. Kijemanito ki iskipettaw askiy, God submerged the Earth
+x ISK, (rac.) until there, until a certain point
+« ISKO, (ad.) up to, while; e.g., isko pâskwâk, up to the prairies; isko anotch, until today; isko pimâtisiyeku, while you are alive; isko kitchi wâbamitân, until I see you; isko kita poni-askiwik, until the end of the world; isko iskweyâtch, until the end, until the last
+
+ISK
+
+« ISKUPEW, ok, (a. a.) he is in the water up to a certain height; e.g., nitchikwanik n't'iskupân, I have water up to my knees
+« ISKUNEW, (v. a.) NAM, NIWEW, NIKEW, there are some left; e.g. nama kekway iskunam, there was nothing elft; nama kekway iskunikew, he spends it all; nama awiyak kita iskunaw, nobody was spared, everybody passed; tantatto eyâbitch kit iskunâwok ayamihewiminak? how many do you still have on your rosary? tâneyiyok ka iskunaman? how many do you have left?
+« ISKUPAYIW, ok, a, (a. a. and in.) there is a surplus, which is left over; e.g., mitchet iskupayiw, ok, there is plenty of surplus; nama kekway iskupayiw, there is none left over, no surplus
+« ISKWAMEW, (v. a.) STAM, MIWEW, TCHIKEW, he has some surplus (which he eats); e.g., nama kekway iskwastam, he has eaten everything; pakki iskwamew kinosewa, he leaves part of the fish that he is eating
+« ISKWÂSTCHIGAN, a, (n. f.) the rest of the foot; e.g. eyiwek mâna atimusissak, mitjiwok tebeyimikutwaw ot iskwâstchiganiyiwa, yes, but the little dogs are eating their master's leftovers
+
+354
+
+ISK
+
+« ISKWÂSTAMEW, see. Iskwamew
+x ISKW, (rac.) the last, at the end, in last place, in the last row
+« ISKWEYÂTCH, (ad.) at the end, in last place, the last time; e.g., iskweyâtch ka ki wâbattuyak, the last time that we saw each other; aspin iskweyâtch, since the last time; iskweyâtch ka ayamihewikijikâk, the last time that it was Sunday; iskweyâtch ekwa ki miyitin, this is the last time that I am giving you thisl iskweyâtch ka takusik, the last arrival
+« ISKWEYÂNIK, (ad.) in the last row, at the end; e.g. iskweyânik mitjisuwinâttikok, at the end of the table; iskweyânik iteyittâkusiw, it's the last of the men; iskweyânik n'tawi api, go sit in the last row
+« ISKWATÂM, (ad.) immediately, no sooner, (with or without negation); e.g. iskwatâm ke takusik, it will not happen any sooner, or, namawiya iskwatâm kita takusin; nametchi iskwatâm o ka ki kijitta? would he not have been able to finish it immediately? ata iskwatâm o ka ki kaskitta, however, he could have done it right away
+« ISKWATAMUW, ok, (v. n.) he breathes his last
+« ISKWATÂMISIW, ok, (a. a.) he is ardent for bad things, like someone who would take anything that he can get his hands on
+
+ISK
+
+« ISKWÂHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he annihilates it, he destroys it to the very last. One also says in a more general manner: he kills a large number; e.g. iskwâhew mustuswa, he kills many buffalo; iskwâttaw mitjima, he makes lots of provisions; Kijemanito ki wi-iskwâhew ayisiyiniwa, God wished to annihilate man
+« ISKWETCHITCHÂNIS, a, (n. f.) the small finger of the hand, the last finger
+« ISKWEW, ok, (n. f.) woman, the being in the last place. As where there is no Christian religion, the woman is always the last, she accepts her condition as a slave, which this word indicates, having such a meaning. Sometimes, one uses this word to refer to female animals, as one uses the word nâbew, or, ayâbew, for male beasts; e.g. iskwewi-mustus, cow, etc., though the true word ought be onitjâniw, the female buffalo
+« ISKWEWIW, ok, (a. a.) she is a woman, it is female
+« ISKWEWIN, a, (n. f.) femininity. But this word it almost alway used badly (genitalia mulieris (woman's genitals)), the feminine sex; ot iskwewin, her female sex
+« ISKWESIS, ak, (n. f.) small woman, little girl
+« ISKWESISSSIWIW, ok, (a. a.) it is a little girl
+« ISKWESIS, ak, (n. f.) or, iskwesissikkân, ak, barley
+
+355
+
+IYI
+
+« ISPOKUSIW, ok, (a. a.) he has such a taste
+« ISPOKWAN, wa (a. in.) it has such a taste
+IYÂMITTAW, (ad.) many, in great numbers
+x IYASKUTCH, (ad.) following, one after the other, in turn; e.g., niyaskutch, in my turn; kiyaskutch, in your turn; wiyaskutch, in his turn; plur. niyaskutchinân, kiyaskutchinow, kiyaskutchiwaw, wiyaskutchiwaw, or, niyaskwatam, kiyaskwatam, wiyaskwatam; plur. niyaskwataminân, kiyaskwataminow, kiyaskwatamiwaw, wiyaskwatamiwaw
+IYÂWASKENAM, wok, (v. n.) see. Iskimiw, he loses ground in the water
+x IYEKAW, a, (n. r.) sand
+« IYEKÂWISKAW, a, (n. f. and a. in.) place where there is sand
+IYEKAMÂ, (ad. irony) denial, negation, is this to be believed! it is not, e.g. one asks someone: kiya tchi ka totaman, was it you who did this? he shall respond in denial: iyekama, how can you believe that it is me; iyekama ke miyitân, how can you believe that I am going to give it to you; iyekama ekusi etwet, he did not say that; iyekama mâtuyân, I am not crying; iyekama watjekkam, it will not happen so quickly; iyekama kissin, how can you believe that it's cold outside, it's not cold outside
+x IYIK, (rac.) apart, throw to the side, walk away (from)
+
+IYI
+
+« IYIKATETTEW, ok, (v. n.) he withdraws a bit
+« IYIKAW, ok, (v. n.) he moves away momentarily, he goes a little far
+« IYIKÂTTEW, ok, (v. n.) idem; e.g., iyikâttewok mistatimwok, the horses are far away, they move a bit farther off
+« IYIKÂWIN, a, (n. f.) moving away, moving a bit farther
+« IYIKÂTTEWIN, a, (n. f.) idem
+« IYIKÂPAYIW, ok, a, (v. n.) he moves away momentarily on horseback
+« IYIKÂTENEW, (v. a.) NAM, NIWEW, NIKEW, he moves it away, he puts it to the side
+« IYIKÂTETISAHWEW, (v. a.) HAM, HUWEW, HIKEW, he sends it farther away, to the side
+« IYIKÂTENAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he moves it away from him; e.g. iyikâtenamâwinân ka mayâtak, move away from us that which is evil, deliver us from evil
+x IYIKITCHIKÂWIW, ok, (a. a.) or, yikitchikâwiw, he is non-chalant, lazy
+« ITIKITCHIKÂWIWIN, a, (n. f.) non-chalance, laziness
+« IYIKITCHIKAWOKEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he believes him to be lazy
+x IYIPE, (rac.) to go on a slope, inclination
+« IYIPEPIW, ok, (a. a.) he is on a slope, he leans
+« IYIPEYAW, a, (a. in.) it goes on a slope
+« IYIPESKANAW, a, (n. f.) sloping path
+« IYIPEMUW, a, (a. in.) idem
+
+356
+
+IYI
+
+« IYIPETINAW, (v. im.) there is a sloping hill, mountain
+« IYIPETINAW, a, (n. f.) sloping hill, mountain
+« IYIPETINEW, (v. a.) NAM, NIWEW, NIKEW, he puts it on an incline, he leans it with his hand
+« IYIPEPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he leans it by using his arms
+« IYIPESKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he leans it by means of his foot
+« IYIPESIMEW, (v. a.) TITAW, MIWEW, TCHIKEW, he plants it on the ground in a sloping fashion
+« IYIPESIN, wok, (a. a.) he is on the ground, he is lying down, leaning
+« IYIPETTIN, wa, (a. in.) idem
+« IYIPESKWEYIW, ok, a, (v. n.) he leans his head
+« IYIPATTAW, ok, (v. n.) he goes trotting, or, he goes ambling
+IYAWIS, (ad.) all, entirely, at the same time; e.g. iyawis n'otinen, I take all of it; iyawis sipwettewok, they have all left; iyawis kijitew, it is all burned; iyawis, it is finised; iyawis miyew; he gives him everything; iyawis takusin, it happens at a certain place without stopping, all at once
+IYIPPIW, ok, (a. a.) he is agile, prompt in doing something
+IYIPPINÊ, (ad.)  very, many, absolutely, certainly, principally; e.g. iyippinê miyo-pimâtisiw, he lives very well; iyippinê kitimâkisiw, he has plenty of mercy (This expression is one more than superlative); e.g. iyippinê kissin, it couldn't possibly be colder outside; iyipinê kisiwâsiw, he couldn't possibly be angrier
+
+x IYE, (rac.) dirt, unclean
+« IYEPÂHAN, wa, (a. in.) or better: pakâttahan, it is exposed to the wind
+« IYEKWASKWAN, (v. im.) the weather is overcast, nebulous (cloudy)
+« IYEPÂTISIW, ok, (a. a.) he is dirty, unclean
+« IYEPÂTAN, wa, (a. in.) it is dirty, unclean
+« IYEPÂTAKKAMIKISIW, ok, (a. a.) he does all sorts of dirty things
+« IYEPÂTAKKAMIKAN, wa, (a. in.) there is, etc.
+« IYEPÂTCHIHEW, (v. a.) TTAW, HIWEW, HIKEW, he dirties it
+« IYEPÂTEYIMEW, (v. a.) he finds it, he thinks it dirty, unclean
+« IYEPÂTISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he dirties it by touching it with his feet
+« IYEPÂTINEW, (v. a.) NAM, NIWEW, NIKEW, he dirties it by touching it
+x IYEWANISIW, ok, (a. a.) he is in a famine, he suffers from a famine
+« IYEWANISIWIN, a, (n. f.) famine, drought
+« IYEWANISIHEW, (v. a.) TTAW, HIWEW, HIKEW, he places it in a famine
+« IYEWANISIHISUW, ok, (v. r.) he fasts, he makes penitence, or, kihikusimow
+« IYEWANISIHISUWIN, a, (n. f.) fasting
+x IYEWAHWEW, (v. a.) HAM, HUWEW, HIKEW, he grinds it, he crushes it, he reduces it to a powder
+
+357
+
+IYI
+
+« IYEWAHIKEW, ok, (v. n.) he crushes. One says this word when one grinds dried meat to make crushed meat
+« IYEWAHIGAN, ak, (n. f.) crushed meat
+IYEKÂMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he argues it
+IYIKÂWAN, (v. im.) there is frost
+IYIKWAWAN, (v. im.) idem
+IYIKOPIWIW, (v. im.) there is fog, (kaskawan)
+IYIKOPIWIPISIM, (n. f.) Frost Moon, November
+IYIKEWATEW, (v. a.) TAM, SIWEW, TCHIKEW, he leaves him nothing to eat
+x IYIMOW, ok, (v. n.) he is discouraged
+« IYIMOWIN, a, (n. f.) discouragement
+« IYIMOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he discourages him
+« « IYIMOMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he discourages him by what he says to him
+« IYIMOTOTAWEW, (v. a.) TAM, TÂKEW, TÂTCHIKEW, he is discouraged by him, on account of him; e.g. kit iyimototâtin, osâm nama kekway ki ki kiskeyitten, I am discouraged with you, you do not want to learn
+IYIKWOK, (n. r.) glands in the throat
+x IYIN, (rac.) principal, first, pure
+
+IYI
+
+« IYINATO, or, N'TOK, (ad.) really, absolutely, much. This is the root iyin, farther; e.g. n'tok kissin anotch, it is really cold (weather) today, iyenato ayamihewiyiniw, the true priest; iyenato ayamihâwin, the true religion; iyinato naspitâtuwok, they look like how we no longer can; iyenato wemistikosiw, a pure Frenchman, a Frenchman from France; iyenato osâwa soniyaw, pure gold; iyenato pimâtisiwin, true life; ni wiyas iyenato mitjiwiniwiw, mina ni mikkum iyenato minikkwewiniwiw, my flesh is truly a food, and truly a beverage; iyenato nipiy, true water, iyenato sominâbuiy, real wine
+« IYINIW, ok, (n. f.) man, vir. According to its root, this means the principal being, the natural being, the true being. The savages refer to themselves as iyiniwok, not claiming to be the first men, but the natural men, who are still in a state of nature. As one sees above in the word iyenato, which comes from the same root, we said: iyenato nipiy, true water, pure water, natural water; thus one says iyenato ayisiyiniw, or iyiniw, a true man, a natural man; iyenato iyiniw, a true Indian, a pure Indian. Such is the only explanation that I think to be the truth, for the root iyin, or, iyen, where iyenato iyiniw, etc.; iyiniwok, the savages, the Indians
+
+IYI
+
+358
+
+« IYINIAYAW, ak, (n. f.) black bear, the principal species of bear
+« IYINISIW, ok, (a. a.) he is wise. From the root iyiniw, man, because that is not wise, does not act like a man, is not a man
+« IYINISIWIN, a, (n. f.) wisdom
+« IYINISIHEW, (v. a.) TTAW, HIWEW, HIKEW, he makes him wise
+« IYINISIKKATTEW, (V. a. )TTAM, LIWEW, HIKEW, he acts with wisdom, with finesse over him, to bring to something, for example, I want to hire someone to do something, and coming to an end in that, I say: ni ki iyinisikkataw; kit iyinisikkatten eoko, k'o kaskittâyan, you know how to do it, that is why you came here in the end; iyinisikkattew k'o tâpwettâkut, he knows how to obtain it from him
+« IYINIWIW, ok, (a. a.) he is healed, thatis to say, he is a man, he is put back to this natural state
+« IYINIWIWIN, a, (n. f.) healing
+« IYINIKKAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he heals him, that is to say, he puts him back to his initial state
+« IYINISKÂTÂSK, wok, (n. f.) type of sweet root, which we call rat-tail
+« IYINIKINUSEW, ok, (n. f.) pike, first fish
+« IYINISIB, ak, (n. f.) French duck, first species of duck. And so on, there are other words and suffixes that would have the root iyin
+
+IYI
+
+IYISÂTCH, (ad.) see. Akâwâtch, despite him, with difficulty, unwillingly; e.g. iyisâtch atuskew, he works despite him; ekawiya iyisâtch tota, do not do it unwillingly; namawiya iyisâtch ki wi-ayamihâhitin, I don't want to make you pray despite you; namawiya iyisâtch atuskew, he works willingly
+IYITTEW, (v. im.) the earth begins to uncover itself, to be 'undressed' from the snow
+x IYIWE, (ad.) on purpose, pertinently, deliberately, but with a contradictory spirit, e.g., for example, someone unhappy, because he did not want to do something, yet did it as a pleasantry; v.g. iyiwe mitjisuw, he eats out of the normal time; iyiwe ni totâk, he deliberately does this for me, he treats me like this on purpose; iyiwe sipwettewok, they leave as a pleasantry, though they do not wish to leave
+« IYIWEHUW, ok, (v. r.) he ventures, he abandons himself to evil, or, to danger, he throws his body,  e.g. e ki kikkâmikut ottâwiya, n'tawi-iyiwehuw, having been arguing with his father, he had been thrown into danger
+« IYIWEHUWIN, a, (n. f.) abandoning oneself
+« IYIWEHEW, (v. a.) TTAW, HIWEW, MIKEW, he makes him throw (himself) into danger
+« IYIWETOTAWEW, (v. a.) TAM, TÂKEW, TCHIKEW, he does it do him on purpose to contradict him, to upset him
+
+359
+
+KÂH
+
++ IYIWEKUTCHIN, wok, (a. a.) he hangs next to, e.g. fish which are suspended outside of a barrel
+« IYIWEKUTTEW, a, (a. in.) it is suspended, it hands, e.g. a piece of clothing torn into hanging shreds
+« IYIWEKUSIMEW, (v. a.) TITAW, MIWEW, TCHIKEW, he drags him by hanging him, or suspending him
+ISTCH, (ex.) look! stop! e.g. I see someone who is walking, and I cry out to stop him, I say, istch! hey, stop
+KÂ! (ex.) indicates that one hears, or that one understands which is being said, yes! quite! exactly! e.g. I say to someone, tande itutteyan? where are you going? he responds to me: sipiy, to the river; I say: kâ! yes! alright. It is only through usage that one can properly grasp this manner of speaking, like the others which follow. In addition, when one is recounting something, and from time to time (the others) say kâ, it is to encourage the person who is speaking
+KÂH! (ex.) pronounced very long, and as if dragging, this indicates that one understands well what is being said or told; it is banal way of letting the person who is speaking know that you are paying attention to what he is saying. This corresponds slightly to the Canadian expression, why yes! e.g. your horse has already died, sâsay nipiw kit'em, I respond, kâh! namawiya ekusi n'iteyittetay, why yes! I didn't think of that. This expression may appear to mean the same thing as the first, but there is a great difference between the two
+
+KA
+
+KA, (pro.) who, that, before the subjunctive, e.g. mistatim ka kiyosit, the horse that is beautiful, mokkumân ka takkunaman, the knife that you are holding in your hand, ka kanâtâtchâkwet Marie, Mary, who is pure
+KA, sign of the future, e.g. ni ka itwân, I will say, ki ka nipinâwaw, you will die. One must note that in the first person, one pronounces this as ga, though I have written ka to follow regularity, in the third person,  ka changes to kita, or kata
+KA, sign of the conditional, e.g. o ka wittamawâttay, he should have confessed to him, o ka sipwettâttâwaw, they should well leave, o ka ki ayamihâttâwaw semâk, they would have done quite better to have prayed immediately
++ KÂKÂKIW, ok, (n. r.) thus named for its cry, kâ, kâ, kâ, crow
+« KÂKÂKISIB, ak, (n. f.) cormorant, duck-crow
+KÂKAYE, (prep) thus, it is for that reason, see. anisikis, e.g. kâkaye miyo-ayaw k'o atusket, it must therefore be the case that he is better, since he works; someone says to another person before me, kit ayamihân etchi kâni ekwa? so do you pray at the moment? I say, kâkaye pe-kiski nohamâkusit, it is clear that he comes to be educated, Kijemanito mistahi sâkihew ayisiyiniwa, kakaye ki nipustamâwew, God loves mankind very much, since he died for them
+
+360
+
+KAY
+
+KÂKAYÂNI, (prep) like kâkaye
+x KÂKK, (rac.) rough, rugged, hard to the touch
+« KÂKKISIW, ok, (a. a.) he is rough
+« KÂKKASEW, ok, (a. a.) he has rough skin
+« KÂKITCHIKISIW, ok, (a. a.) idem
+« KÂKITCHIKAW, a, (a. in.) idem
+« KÂKKEWOK, wa, (n. f.) sun-dried meat, meat that is rough to the touch. N.B. The suffix wok indicates flesh, meat
+« KÂKKINEW, (v. a.) NAM, NIWEW, NIKEW, he touches it roughly
+« KÂKKEYIMEW, (v. a.) TAM, MIWEW, TCHIKEW, he finds it rough to the touch
+« KÂKWA, k, (n. p.) case with various compartments, vase made with birch bark. N. kway indicates birch
+« KÂKOMIN, a, (n. f.) black seed, covered in small points, porcupine seed
+x KAYA, (rac.) hard-working, that which succeeds well, expeditive, N.B. These words which belong to this root, are best said with reduplication, this is why I have written them so here
+
+KÂK
+
+« KÂKAYÂWISIW, ok, (a. a.) he is hard-working, active
+« KÂKAYÂWAN, wa, it is expeditive, it succeeds, e.g. kâkayâwan ni pâskisigan, my rifle is just right, it carries well
+« KÂKAYÂWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he finds him hard-working
+« KÂKAYÂWÂTISIW, ok, (a. a.) he has a hard-working character
+« KÂKAYÂWÂTAN, wa, (a. in.) idem
+« KÂKAYÂWÂTEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he finds him to have a hard-working character
+« KÂKAYÂHUTTEW, ok, (a. a.) he is a good walker
+« KÂKAYATUSKEW, ok, (a. a.) he is a good worker
+« KÂKAYÂWIPAYIW, ok , a, (a. a. and in.) it is expeditive, it goes well
+« KÂKAYÂWIMOW, ok, (a. a.) he is a big talker
+« KÂKAYÂTCHIMEW, ok, (a. a.) he is a good rower
+x KAYE, (rac.) to trick, to be deceitful. N.B. The words which derive from this root are better said with reduplication, as follows:
+« KÂKAYEHISIW, ok, (ad.) he is deceitful, a hypocrite. The syllable hi is barely perceptible, and changes sometimes to a yi
+« KÂKEYESIHEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he believes it to be deceitful
+
+361
+
+KÂK
+
+« KÂKAYESIHEYITTÂKUSIW, ok, (a. a.) he is seen as deceitful
+« KÂKAYESIHEYITTÂKWAN, wa, (a. in.) it is misleading, e.g. kâkayesiheyittâkwan pisikwâtisiwin, debauchery is a misleading thing
+« KÂKAYEHISIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he tricks him
+« KÂKAYEHISIMEW, (v. a.) TTA, MIWEW, TCHIKEW, he deceives him with his words
+« KÂKAYEYIPAYIW, ok, (a. a. and in.) it is misleading. N.N. The root kakayesi joined with a noun or a verb, or an adjective, indicates that one says that one does something with deception, hypocrisy, e.g.
+« KÂKAYESI-AYAMIHAW, ok, (v. n.) he does not really pray, he plays the hypocrite
+« KÂKAYESI-TIPIHIGAN, a, (n. f.) false measurement
+« KÂKAYESI-MASINAHIGAN, a, bad book
+« KÂKAYESITTWÂWIN, a, deceiful behaviour
+« KÂKAYESITTWAW, ok, (a. a.) he behaves deceitfully
+« KÂKAYESPIKISKWEW, ok, (v. n.) he speaks a ruse
+« KÂKAYESINEHWEW, (v. a.) HAM, HUWEW, HIKEW, he cheats him in a transaction, or, wayesinehwew
+« KÂKAYESI-TOTAWEW, (v. a.) TAM, TÂKEW, TCHIKEW, see. kâkayesihew
+
+KAK
+
+x KAKEBÂTISIW, ok, (a. a.) he has no spirit, he has a stuffy character. This word probably comes from the root kepa, or, kippaw, which means blocked, closed, with the reduplicative ka
+« KAKEBÂTEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he finds him mad, insane
+« KAKEBÂTISIKKEW, ok, (v. n.) he acts out of insanity
+« KAKEBÂTCHITTWAW, ok, idem
+« KAKEBÂTISIKKEWIN, a, (n. f.) madness
+« KAKEBÂTCHITTWÂWIN, a, (n. f.) idem
+« KAKEBÂTISIKKATTEW, (v. a.) TTAM, SIWEW, TCHIKEW, he drives himself insane by acting with him, he goes sick in order to win it
+« KAKEPITTEW, ok, (a. a.) he is deaf, he has blocked ears
++ KAKESKIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he gives him counsel, he advises him, he warns him
+« KAKESKIMIWEWIN, a, (n. f.) counsel, advice, see. the root kiski
+« KAKESKIMOW, ok, or, kakeskikkemow, ok, (v. n.) he gives instructions, he gives advice; this is the word that is used to say: he preaches
+« KAKESKIMOWIN, a, or, kakeskikkemowin, a, (n. f.), instruction, sermon
+« KAKESKWEW, ok, (v. n.) like kakeskikkemow
+« KAKESKWEWIN, a, (n. f.) like kakeskikkemowin
+
+362
+
+KÂK
+
+« KAKESKWEWIYINIW, ok, (n. f.) a preacher
+« KAKETTÂWEW, ok, (v. n.) like nittâwew, he has the use of speech, he has words in his mouth, e.g. a child who already has the use of speech, one says: kakettâwew
+KAKETTÂWEYIMEW, TTAM, he finds it prudent, ingenious
+KAKETTÂWÂTISIW, or, kakettâweyittam, he is prudent, a genius
+x KÂKI, (rac.) to beg, to humble onself in the presence of, etc., etc.
+« KÂKISIMOWIN, a, (n. f.) humble supplication
+« KÂKISIMOW, ok, (v. n.) he begs with tears, with humility
+« KÂKISIMOTOTAWEW, (v. a.) TAM TÂKEW, TCHIKEW, he begs him by lowering himself, e.g. n'otta ki pe-kâ-kisimototâtin kitchi kitimâkeyimiyan, my father, I come to beg you to have mercy on me
+« KÂKITOKKAWEW, (v. a.) KKAM, KÂKEW, TCHIKEW, he humbles himself before him, by lowering himself, (this last word must be used in the way of a country) e.g. e ki kisiwâhât onâbema, ekwa pe-kâkitokkawew, having angered her husband, she game to lower herself before him
+« KÂKITOKKÂSUW, ok, (v. n.) he lowers himself, he recognises his fault
+« KÂKITOKKÂSUWIN, a, (n. f.) lowering, humbling, submission
+« KÂKITJIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he consoles him, he begs to console himself. Sometimes one also uses this word in religion to say, he appeases him, e.g. Kijemanitowokosissân ki kâkitjihew ottâwiya, the son of God has appeased his father, kâkitjih ki'simis ka mâtut, console your little brother, who is crying
+
+KÂK
+
+« KÂKITJIHIWEWIN, a, (n. f.) the action of consoling somebody who is crying
+« KÂKITJIHISUW, ok, (v. r.) he consoles himself, he stops crying
+« KÂKITJIHISUWIN, a, (n. f.) the action consoling oneself when in tears
+« KÂKITJIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he speaks to him to console him (rarely used)
+« KÂKITISIW, ok, (a. a.) he is sensitive e.g. someone who has an injury, which, if one touches it slightly, causes (him to) cry
+« KÂKITISIWIN, a, (n. f.) sensitivity. See. the root kit
+« KÂKITJIMOW, ok, (v. n.) he only speaks of his illness/injury (he wants to make everybody experience it)
+x KAKISTIW, ok, (a. a.) he is brazen, impudent, coarse, to grab everything that one can get one's hands on
+« KAKISTIWIN, a, (n. f.) brazenness, impudence
+« KAKISTWEW, ok, (v. n.) he speaks insolently
+« KAKISTWEWIN, a, (n. f.) insolent speech. See. the root kist
+x KAKI, (rac.) with pride, vanity
+
+363
+
+KAK
+
+« KAKITCH, (ad.) by pride, e.g. kakitch ayitew, he says it to him by pride, he praises it, kakitch kit ayitoten, or, kit ayittin, you act for vain glory
+« KAKITJIMOW, ok, (v. n.) he praises himself, he glorifies himself. This also means, he is a talker, a braggart: one also says this of a child who gossips a lot, kakitjimoskiw
+« KAKITJIMOWIN, a, (n. f.) vain glory, babbling
+« KAKITJIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes him swagger
+« KAKITJIMEW, (v. a.) (v. a.) etc., idem, by his words
+x KÂKIKE, (ad.) always, without end, e.g. kâkike ki ittaw Kijemanito, God has always been, kâkike kita pîmâtisinâniwan, one will always live
+« KÂKIKEKKAMIK, (n. f.) (always earth) name of the first man, in the accounts of the Indians
+x KAKK, (rac.) all, entire, that which has all of its parts
+« KAKKIYAW, (adj.) all, every. This word does not change in the plural, e.g. kakkiyaw ayisiyiniw, any/every man, kakkiyaw iyiniwok, all of the savages, kakkiyaw ki sâkihitinâwaw, I love all of you, kakkiyaw ki miyitin, I give you everything
+« KAKKISIW, ok, (a. a.) he is whole, he has not been deteriorated, e.g., mitoni kakkisiw awah mistatim, this horse has no defects, no injuries, oki ayamiheminak, miyâmaw namawiya kakkisiwok, it is probable that this rosary is not complete
+
+KAK
+
+« KAKKAN, wa, (a. in.) entire, complete, that which is not sick, bad, e.g. eyâbitch kakkan eoko wâskâhigan, this house is still good, she is not hurt, nama kakkan ki masinahigan, your book is not complete anymore, it is broken
+« KAKKIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it whole, he places all of its parts on him
+« KAKKEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks it complete, uninjured
+« KAKKÂTISIW, ok, (a. a.) he indeed still keeps his character, his behaviour is still whole, dignified
+« KAKKÂTISIWIN, a, (n. f.) well-kept character
+« KAKKÂTAN, wa, (.n) idem
+x KAKEK, (ad.) with choice, e.g. kakek otina, he takes the best that there is 
+« KAKEKINEW, (v. a.) NAM, NIWEW, NIKEW, he makes a choice in it, e.g. kakekinew tatto ka miyosiyit, he takes all of the best ones, kakekinam tatto ka misâyik, he choses all of the biggest ones, but the word nawasunew appears to most closely mean, to make somebody's choice for an office
+« KAKEKÂBAMEW, (v. a.) TTAM, KEW, TCHIKEW, he makes a choice on it while watching
+« KAKEKEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he makes a choice on it in his thoughts
+
+364
+
+KAK
+
+« KAKEKEYITTÂKUSIW, ok, (a. a.) he is chosen, one makes a choice on him
+« KAKEKEYITTÂKWAN, wa, (a. in.) idem
+x KAKWE, (ad.) to try to, etc., before or after the verb, e.g. ni kakwe toten, or, ni ka toten kakwe, I'm going to try to do it, kita kâkwe ikkin, it must happen (something must be tried to make it happen), kita kakwe sipwettâniwiw, we are going to try to leave. It is also used as a response and as a questoon; e.g. I say to someone, kakwe miyin eoko, try giving me that; he responds; kakwe, I will try, implied; ni ka toten kakwe tchi? aren't you going to try?
+« KAKWEYÂHUW, ok, (v. r.) he hurries to, kakwe, to try, and, yâhuw, to prevail over oneself
+« KAKWEYÂHUW, a, (n. f.) haste
+« KAKWEYÂHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he finishes before him, from kakwe, to strive, and yâhew, to prevail over him, that is to say, he makes him hurry, kakweyâhituwok, he strives to surpass himself, trying to finish one thing before another
+« KAKWEYAKUNEW, (v. a.) NAM, NIWEW, NIKEW, he tries to empty it by shaking it, e.g. a back or baril, using one's hands
+« KAKWEYAKAHWEW, HAM, HUWEW, HIKEW, he tries to empty it by shaking it forcefully, or by hitting it
+
+KAK
+
+x KAKITJITISIW, ok, (a. a.) he is slow, he takes his time
++ KAKWÂYAK, (rac.) to be horrified, to find (something) terrible, to dread
+« KAKWÂYAKEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he is horrified of it, he finds it frightening, he experiences great repulsion by thinking about it, e.g. tattwaw miyâmitoneyittamâni ni kakwâyakeyitten, every time I think of it, I am horrified
+« KAKWÂYAKÂBAMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he is frightened by seeing it
+« KAKWÂYAKINAWEW, (v. a.) NAM, NÂKEW, NÂTCHIKEW, idem
+« KAKWÂYAKIHEW, (v. a.) he repulses him, or, he is repulsed by him
+« KAKWÂYAKINEW, (v. a.) NAM, NIWEW, NIKEW, he tickles him, he causes him an irritating sensation
+« KAKWÂYAKISIW, ok, (a. a.) he is ticklish
+« KAKWÂYAKAN, wa, (a. in.) it is repulsive
+« KAKWÂYAKISIWIN, a, (n. f.) tickling
+« KAKWÂYAKEYITTÂKUSIW, ok, (a. a.) he is worthy of horror
+« KAKWÂYAKEYITTÂKWAN, wa, (a. in.) idem
+« KAKWÂYAKEYITTÂKUSIWIN, a, (n. f.) horrible thing
+« KAKWÂTAKISIW, ok, (a. a.) he is suffering, languishing; from the root kwatak
+
+365
+
+KAK
+
+« KAKWESÂPPEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he dreads it
+x KÂKWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he is jealous of him. This word must only be used to describe jealousy that one experiences for someone in relation to their spouse; e.g. konata ki kâkweyimin, you are jealous of me for no reason
+« KÂKWEYITTAM, wok, (v. n.) they are jealous of one another
+« KÂKWEYITTUWIN, (v. m.) mutually jealousy in marriage
+« KÂKWEYITTAMOWIN, a, (n. f.) jealousy in marriage
+x KAKWETJIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he questions him, he asks him. See. the root kutji, to test/try; I test him with my words, ni kutjimaw, or, ni ka-kwetjimaw, (which is reduplicated); ni kakwetjipattân, or, ni kutjipattân, I try to run; kekway ka pe-kakwetjimiyek? what are you coming to question me about?
+« KAKWETJIKKEMOW, ok, (v. n.) he asks, he questions, he makes inquiries; e.g. ni pe-kakwetjikkemon kispin namawiya ki ki wâbamâwaw, I've come to ask you whether or not you have seen him
+« KAKWETJIKKEMOWIN, a, (n. f.) request, question
+« KAKWETJIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he tries it, see. kutjihew
+
+KAK
+
+« KAKWETJIPAYIW, ok, a, (a. a. and in.) it asks
+« KAKWETJISIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he deceives him by his speech, he tricks him; e.g., namawiya ki ka ki kakwetjisimaw Kijemanito, you are not able to trick God. See. tchisimew
+KÂKIKEJIK, wa, (n. f.) ice which never melts, in the savannahs; I believe the savages refer to the North Pole in this way, the place where there is always ice
+KÂMÂTJIWAHAM, wok, (v. n.) he sings his victory. This is only used when returning from a battle, after having taken one or several locks of hair (from their enemies), the Indians dance and sing while holding these trophies in their hands
+« KÂMÂTJIWAHIGAN, a, (n. f.) song of victory
+« KÂMÂTJIWISIMOW, ok, (v. n.) he sings of victory while dancing
+« KÂMÂTJIWISIMOWIN, a, (n. f.) song of victory with a dance
+« KÂMÂTJIWISIMOWINIKEW, ok, (n. f.) he does a victory dance with a song
+x KÂMÂMAK, wok, (n. r.) butterfly
+x KANAK, (ad.) an instant, a moment; see. atchiyaw; e.g., kanak piko nipaw, he only slept for a moment; kanak n't'ayamihaw, I am speaking to him for the moment; kanak piko âkkusiw, he is sick only for a moment
+
+366
+
+KAN
+
+« KANAKA, (ad.) see. iyekama; e.g. kanaka wiya ojittât, as if it was him who would have done it (ironically, in denial)
+« KANAKÂNI, (ad.) idem; kanakâni ke miskak, there is no danger that he will find it; kanakâni ke miyât, don't be afraid that he'll give it to him, he won't give it to him
+« KANAKOMA, (ad. in.) e.g. kanakoma kissin, it seems that it's cold (weather)
+« KANAKE, (ad.) see. seyâkes, tebiyâk, at least, if at least; e.g. kanake abittaw miyiyan, if you would at least give me half; kanake apisis kakwe-mitjisu, at least try to eat a bit; kanake eka ekusi totak, if he at least wasn't doing this
+« KANAKEKA, (ad.) see. wâwâtch, again, and then again, and then unfortunately; e.g. kissin, kanakeka kimiwan, it is cold (wearher), and furthermore, it is raining; kissin kanakeka piwan, it is cold (weather), and it is also blowing snow; kimotiskiw kanakeka kiyâskiskiw, he is a thief, and above all he is a liar; kanakeka kisiwâsiskiw, and what is even worse is anger; kanakeka nama manâtjimew okâwiya, and yet again he does not respect his mother. It appears that this word is most commonly used in a negative sense, though one could say; Kijemanito kakiyaw kekway kaskittaw, kanakeka kakiyaw wâbattam, God can do anything, not to mention that also he sees everything
+
+KAN
+
+« KANAKENÂ, (ad.) idem, but ironically, as negation; e.g., kanakenâ kita wi-ayamihaw, one mustn't wait to see him pray; kanakenâ kejewâtisit, it doesn't have to be charitable. See. iyekama
+« KANAKEKKANÂ! (ex.) word used to give thanks in superstitious feasts
+« KANIKA, or, KANIKANISI, (ad.) if yet, certainly, see. tâpika; e.g., kanika wâbamât ottâwiya pa-miweyittam, oh how happy he would be if he saw his father! kanika nisi ki ka miyawâtenânow kitchi kijikok! oh how happy we will be in Heaven! kanika tâpwe kita ayiman! without doubt it will be painful!
+« KANI, (ad.) indeed, quite, yes, quite right; e.g., kani tâpwe anotch ayamihewikijikaw, indeed, it's true, today is Sunday; kani ni wi itutta, indeed, or, quite right, I wanted to go there; kani tâpwe, yes, indeed
++ KÂMWÂT, (rac.) to be sad, melancholic
+« KÂMWÂTISIW, ok, (a. a.) he is sad, melancholic
+« KÂMWÂTAN, wa, (a. in.) it is boring, melancholic
+« KÂMWÂTISIWIN, a, (n. f.) melancholy
+« KÂMWÂTEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks it, he finds it melancholic
+
+367
+
+KAN
+
+« KÂMWÂTEYITTÂKUSIW, ok, (a. a.) one finds it melancholic
+« KÂMWÂTEYITTÂKWAN, wa, (a. in.) it is melancholic
+« KÂMWÂTEYITTÂKUSIWIN, a, (n. f.) melancholy
+« KÂMWÂTAPIW, ok, (a. a.), he is quiet, sad
+« KÂMWÂTAPIWIN, a, (n. f.) silence
+« KÂMWÂTJIWINÂKUSIW, ok, (a. a.) he seems melancholic
+« KÂMWÂTJIWINÂKWAN, wa, (a. in.) idem
+« KÂMWÂTJITTÂKUSIW, ok, (a. a.) it is sad, melancholic to hear
+« KÂMWÂTJITTÂKWAN, wa, (a. in.) idem, e.g. a melancholic song
+« KÂMWÂTJIMOW, ok, (v. n.) he speaks manner so as to incite sadness, melancholy
+« KÂMWÂTJIMOWIN, a, (n. f.) speech, word(s), news, which provokes melancholy. N.B. And so on, in using the root kâmwâtji, one can form a multitude of words following these circumstances
+x KAN, (rac.) pure, immaculate, clean, neat, that which one keeps with care, which one conserves well
+« KANÂTISIW, ok, (a. a.) he is pure, clean, he is has a character free of any stains
+« KANÂTAN, wam (a. in.) it is clean, neat; e.g. namawiya kanâtan eoko wâskâhigan, this house is not clean
+« KANÂTISIWIN, a, (n. f.) purity
+
+KAN
+
+« KANÂTJIHUW, ok, (v. r.) he dresses himself cleanly, he clothes himself in clean garments; also he cleans his whole body, he purifies himself
+« KANÂTJIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he purifies him with care
+« KANÂTEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he believes him to be pure, without any stain(s)
+« KANÂTEYITTÂKUSIW, ok, (a. a.) he is wortht of being considered pure
+« KANÂTEYITTÂKWAN, wa, (a. in.) idem
+« KANÂTEYITTÂKUSIWIN, a, (n. f.) the dignity of purity. N.B. By placing kanâtch, or, kanâtji, before a noun, or an adjective, or a verb, or a suffix, one creates a word which has the meaning of the root kan, e.g.:
+« KANÂTJIPIMÂTISIWIN, a, (n. f.) pure life
+« KANÂTJIPIMÂTISIW, ok, (v. n.) he lives purely, cleanly
+« KANÂTÂTCHÂKWEW, ok, (a. a.) he has a pure soul, without stain(s). This is the word adopted to express the Immaculate COnception of Mary
+« KANÂTÂTCHÂKWEWIN, a, (n. f.) soul without stain(s), e.g. kanâtâtchâkwewin ki pe-kiki nittanikiw kitchitwa Marie, Mary came to the world with an immaculate soul
+« KANÂWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he keeps it, he takes care of it, he conserves it
+« KANÂWEYITTAMÂWEW, (v. a.) TTAM, KEW, TCHIKEW, he conserves it for him, he keeps it for another
+
+368
+
+KAN
+
+« KANÂWEYITTAMÂKEWIN, a, (a. f.) care for a something in favour of someone
+« KANÂWEYITTAMÂSUW, ok, (v. r.) he keeps it, he conserves it
+« KANÂWEYITTAMÂSUWIN, a, (n. f.) the action of conserving something
+« KANÂWEYITTAMOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he entrusts it in his care, he gives it to him to keep
+« KANÂWISKOTTEHEW, or, YEW, idem, e.g. Jesus Christ ki kanâwiskottehew ot ayamihewiyinima ot ayamihâwin, Jesus Christ entrusted his religion to the care of his priests, le Pape ki kanaweyittamohikowisiw kakiyaw kitchiayamihewiyiniwa mina ayamihewiyiniwa, he has divinely confided in the Pope the care of all of the bishops and all of the priests
+« KANÂWÂBAMEW, (v. a.) TTAM, KEW, TCHIKEW, he considers it, he looks at it attentively, e.g. ata ni ki wâbamaw eoko iskwew, maka namawiya ni ki kanawâbamaw, I have indeed seen this woman, but I have not looked at her (attentively)
+« KANOTIBISKWEW, ok, (v. n.) ok, (v. n.) or, kanâwetibiskwew, he watches, he keeps guard during the night, okanotibiskwew, the night watchman
+« KANOKIJIKKWEW, ok, (v. n.) he guards (it) during the day
+
+KAN
+
+KANOKIJIKKWEWIN, a, (n. f.) day guarding
+KANÂWASTIMWEW, ok, (v. n.) he keeps the horses, okanâwastimwew, ok, the horse keeper
+KANÂWASTIMWEWIN, a, (n. f.) keeping horses
+KANÂWASTIMWÂN, a, (n. f.) place where one keeps horses
+KANÂWIMUSTUSWEW, ok, (v. n.) he keeps cows, etc.
+KANÂWIPIJISKIWEW, ok, (v. n.) he keeps beasts, okanâwipijiskiwew, ok, shepherd
+KANÂWIPIJISKIWÂN, a, (n. f.) place where one keeps beasts
+KANÂWI-PIJISKIWIKAMIK, wa, (n. f.) bestiary
+KANÂWÂBÂGAN, a, or, kanâwâbâtchigan, a, (n. f.) that which one uses to look, telescope
+KANÂWÂPUKEW, ok, (v. n.) he guards the house, the residence, e.g., peyakuw e kanâwâpuket, he is alone to guard the residence, tâna ka wi-kanâwâpuket eyamihewikijikâyik, kata kakwe pe-withihiwew Lamessikkewitji kekijebâyik, he who must keep the house on Sundays should try to come to the mass which is held in the morning
+KANAWÂPUKEWIN, a, (n. f.) the action of guarding a place of residence while one is absent. N.B. The suffix ukew, or, okew, indicates a residence, a lodge, e.g. mânokew, he fixes the lodge (in place)
+KANÂWISKWÂTEMIWEW, ok, porter
+
+369
+
+KAN
+
+KANÂWIWÂSKÂHIGANEW, ok, guard/keeper of a house
+KANONEW, (v. a.) NAM, NIWEW, NIKEW, he pursues him everywhere, not wishing to abandon him, being extremely attached to him
+KANOSKAWEW, (v. a.) he attaches himself to his entourage, he pursues him everywhere, with care, e.g. ki wi-konoskâtin ekwa, I want to attach myself to your entourage at the moment, ki ka wi-kanoskâk meyosit manito! I wish that the Holy Spirit accompanies you! kâkike kanoskâkuw o kaskeyittamowin, his grief still pursues him, takki kanoskâkuwok okisiwâsiwiniwaw, their anger does not abandon them, okanoskâke-wikijikow, ok, guardian angel
+KANOSIMOW, ok, (v. n.) to become bored, e.g. someone who is very attached to a friend or to an object who becomes bored with it, e.g. ni kanosimon e witjewok ni simis, I am becoming bored with the company of my little sister, ni kanosimon ayamihewâttik, the cross makes my boredom my consolation, or, I am attched to the cross
+KANOSIMOWIN, a, (n. f.) boredom
+KANOSIMOWINIWIW, ok, (a. a. and in.) this is used for boredom (as well as) of defense, e.g. ayamihewâbuiy kanosimowiniwiw, holy water is a guard, defense, consolation, masinahigana mistahi kanosimowiniwiwa, books are a great boredom, okanosimowiniw, he has it for boredom, for consolation, e.g. n't'ayamihewiminimak n'okanosimowinin, I have my rosary for my boredom, for my consolation, manitowimasinahigan okanosimowiniwok, they have the holy books for their vade mecum (their handbook, their manual)
+
+KAP
+
+x KAPA, (rac.) to pull to shore, to reach the shore, to the edge
+« KAPAW, ok, (v. n.) he touches ground, he grounds, he disembarks from the canoe
+« KAPÂTENEW, (v. a.) NAM, NIWEW, NIKEW, he disembarks from the vessel. One also says the same thing for pulling an object from the fire or the water, e.g. sâsay osuw, kapaten askik, the boiler is already boiling, pull it from the fire, kapâtena eokoni mistikwa, take these pieces of wood out of the water
+« KAPATESKWEW, ok, (v. n.) he takes the food out of the boiler; but this word is said only when one makes foot and takes the food from the boiler in order to eat it, once it is cooked, e.g. sâsay tchi ki kapateskwân? have you already taken the food out of the boiler? He soaks the soup, or, he serves the table
+« KAPÂTEHWEW, (v. a.) HAM, HUWEW, HIKEW, someone who took the soup or the meat from the boiler, he places it, ready to eat
+« KAPÂTEYÂSKWAHWEW, (v. a.) HAM, HUWEW, HIKEW, he takes it from the water with the help of a piece of wood
+
+370
+
+KAP
+
+« KAPÂTETISAHWEW, (v. a.) HAM, HUWEW, HIKEW, he drives it out of the water, he sends it towards the shore
+« KAPÂWIN, a, (n. f.) whorf, place where one disembarks onto the shore
+KÂBAWIW, ok, is a suffix which indicates: to stand upright, e.g. asikâbawiwok, they stand upright in a pile, itasikâbâwistawew, he remains upright around him
+KAMIK, is a suffix which indicates a house, a residence, habitation, e.g. ayamihewikamik, house of prayer, church, assiniwikamik, stone dwelling, papakiweyânikamik, tent
+KAMAW, pronounced gamaw, suffix which indicates: lake, e.g. kinokamaw, long lake
+x KAPE, (ad.) all, entirely. This word is never used alone, e.g. kape-kijik, the whole day, kape-tibisk, the whole night, kape-pipn, the whole winter, etc. I do not know that one can use this expression in any other sense, for example, he has been sick all his life, for this one could not sayk, ape opimâtisiwin, rather, misakâme opimâtisiwin ki âkkusiw
+« KAPE AYI, (ad.) all of the time, e.g. kape-ayi metawew, he is always playing, kape-ayik, all of the time
+« KAPESIW, ok, (v. n.) he camps, he stops to stay the night, witji-kapesimew, he camps together with him
+« KAPESIWIN, a, camp, the action of stopping to spend the night
+
+KAP
+
+« KAPESIWINIKKEW, ok, (v. n.) he prepares the place for the camp
+« KAPESIWINIKKEWIN, a, (n. f.) the action of preparing the place for the camp
+KÂKAPEPAYIW, ok, a, (a. a. and in.) he falls by sliding, having his limbs spread out
+KÂSAKEW, ok, (a. a.) he is gluttonous. One also says: kâsakew ittiw, he is ardent to acquire something. One also says: okâsakimiw, ok, it is voracious, unable to be satiated; okâsakim, ak, a species of worm which lives in the body and eats the food that one takes on
+x KASK, (rac.) sometimes means: to cut, to break, to cut short, and other times it means: to close, to obscure
+« KASKAM, (ad.) or taskam, straight ahead; kaskamuttew, he makes a straight path; kaskamiskuttew, he makes a straight path on the ice; kaskam wittamâwew, he tells him without any preamble; kaskam kiskisam ni pikiskwewin, he cuts me off (while speaking). See. soskwâtch
+« KASKAMUTTEW, ok, (v. n.) he makes a straight path
+« KASKAMUTTEWIN, a, (n. f.) the action of making a straight path
+« KASKAMUW, (v. im.) path straight ahead, which cuts straight ahead
+« KASKAMAN, wa, (v. im.) that which cuts straight ahead, the shortest distance, by the shortest path, e.g. tânima mâmawiyes e kaskamak, ekute tchi ituttek? what is the straightest direction to go there?
+
+371
+
+KAS
+
+« KASKAMISKUTTEW, ok, (v. n.) he makes a straight path on the ice
+« KASKEWEW, ok, (v. n.) he portages, in order to make a straight path, e.g. someone who goes from one lake to another, or from one river to another, so as not to make a curved path. One also says kaskewew, that which would go from one sea to the other, crossing the continent
+« KASKEWEWIN, a, (n. f.) the action of portaging
+« KASKAMAHAM, wok, (n. n.) he makes a straight path on the water. Also, taskamaham, to split the water straight
+« KASKÂBASWEW, (v. a.) SAM, SIWEW, SIKEW, he smokes it, he smoke-dries it
+« KASKÂBASUW, ok, (a. a.) he is smoked, smoke-dried, he is in the smoke
+« KASKÂBASUWIN, a, (n. f.) the action of being in the smoke
+« KASKÂBATTEW, a, (a. in.) it is smoked, smoke-dried. This adjective is also a noun, and means: the smoke, like the following word
+« KASKÂBATTEWIN, a, (n. f.) smoke
+« KASKIKASWEW, (v. a.) SAM, SIWEW, SIKEW, he makes it brittle, fragile, by cooking it for too long
+« KASKIKKASUW, ok, (a. a.) he has become fragile by cooking, e.g. an overcooked duck, it is dry
+
+KAS
+
+« KASKIKKATTEW, a, (a. in.) idem
+« KASKATISIN, wok, (a. a.) he breaks himself by falling
+« KASKATCHITTIN, wa, (a. in.) idem
+« KASKÂPITESIN, wok, (v. n.) he breaks his own teeth
+« KASKÂTCHIKÂTESIN, wok, (v. n.) he breaks his own leg
+« KASKATCHIPITUNESIN, wok, (v. n.) he breaks his own arm
+« KASKIKWESIN, wok, (v. n.) he breaks his own neck
+« KASKIKWENEW, (v. a.) NAM, NIWEW, NIKEW, he breaks his neck with his hand
+« KASKIKWEPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he breaks his neck with his arm(s)
+« KASKINEW, (v. a.) NAM, NIWEW, NIKEW, he breaks it; e.g. mistikussa kaskina, break the little pieces of wood
+« KASKIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, or, kaskatchipitew, idem, with the arm
+« KASKASKATCHIGAN, a, (n. f.) the inside of the nose
+« KASKATIN, wa, (a. in.) it is closed by the cold, it is frozen all over; e.g., kakiyaw sâkahigana kaskatinwa, all of the lakes are frozen
+« KASKATISIMEW, (v. a.) TITAW, MIWEW, TCHIKEW, he makes it freeze, hardens it with the cold
+« KASKATINOWIPISIM, wok, (n. f.) october, month where everything is closed by the cold
+« KASKAWAN, (v. im.) it is foggy/misty
+
+372
+
+KAS
+
+« KASKAWÂKAMIW, (v. im.) idem, as if the atmosphere closed itself off and became dark with fog
+« KASKAWANIPESTAW, (v. im.) there is fog
+« KASKITIBISKAW, (v. im.) dark night, murky night
+« KASKEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he is bored compared to him, or, more often, he finds him boring. N.B. This verb is seldom used in the active, one does not use it as a neutral verb in saying:
+« KASKEYITTAM, wok, (v. n.) he is in grief, he is weary, it is as if there is a darkness in his spirit
+« KASKIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he comes to the end, he reaches it
+« KASKIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he earns it with his words
+« KASKITTAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he earns it for him, he deserves him; e.g. J.C. ki ki kaskittamâkonow kâkike pimâtisiwin, J.C. has earned us eternal life
+« KASKIKWÂSUW, ok, (v. a. and a. a.) he sews, he plugs, he closes an opening with a needle. Also: he is sewn
+« KASKIKWÂSUWIN, a, (n. f.) the action of sewing
+« KASKIKWÂSUWIYINIW, ok, (n. f.) tailor
+« KASKIKWÂTEW, a, (a. in.) it is sewn
+« KASKIKWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he sews it. One also says this word for: he sews his clothes, he mends them
+
+KAS
+
+« KASKIKWÂTTAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he sews it for him; e.g. kaskikwâttamâwin ni maskisin, sew me my shoes
+« KASKIKUTTEW, e.g., TTAM, SIWEW, TCHIKEW, he chops it, he cuts it up; e.g. tobacco
+« KASKIKUTCHIGAN, a, (n. f.) (hash) prepared tobacco (being cut)
+« KASKIKUTAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he chops it, he cuts it for him
+« KASKIKWÂSUNÂBISK, wa, (n. f.) thimble for sewing
+« KASKIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he hermetically seals it; e.g. a bag, by tightening the opening with a rope; from which,
+« KASKIPITÂGAN, a, (n. f.) medicine bag, charm bag. These are bags made of bearskin or other animal (pelts), which the savages use to perform their sorceries
+« KASKIPITÂGAN, a, (n. f.) Is also a metal box, in which one places tobacco
+« KASKITAKAHWEW, (v. a.) HAM, HUWEW, TCHIKEW, he locks it
+« KASKITESIN, ok, (a. a.) he is black, dark, murky
+« KASKITEWAW, a, (a. in.) it is black
+« KASKITENEW, (v. a.) NAM, NIWEW, NIKEW, he blackens it
+
+373
+
+KÂS
+
+« KASKITEWIKKWEW, ok, (a. a.) he has a black face
+« KASKITEWASTIM, wok, (n. f.) black horse
+« KASKITEW, (n. f.) powder (plural point) (Translator's Note: Although not explicitly stated, this is presumed to mean 'gunpowder' specifically)
+« KASKITEWIYÂS, ak, (n. f.) Negro, black meat
+« KASKITEWISTIKWÂN, a, (n. f.) black head. And so on, placing kaskite before (the word)
+x KÂSK, (rac.) to scrape, to rub strongly to remove something
+« KÂSKINEW, (v. a.) NAM, NIWEW, NIKEW, he removes it with his hand by rubbing it, by scraping it
+« KÂSKIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he scratches it, he rubs it hard
+« KÂSKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he scrapes it, he forcefully removes what is attached; e.g., kâskâskaha ki maskisina: remove, by forcefully scraping that which is attached to your shoes
+« KÂSKIPÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he shaves him, he gives him a shaves
+x KASKIPASUN, a, razor
+« KASKIPÂSUW, ok, (v. n.) he shaves himself
+« KÂSKIPÂSUWIN, a, (n. f.) the action of shaving oneself
+« KÂSKIPÂSIWEWIYINIW, ok, (n. f.) barber
+« KÂSKISKINEW, NAM, NIWEW, NIKEW, he undoes it, he unstitches it
+« KÂSKISKIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he undoes it, he unstitches it with some effort, almost ripping it
+
+KÂS
+
+x KÂSP, (rac.) fragile, frail, etc.
+« KÂSPISIW, ok, (a. a.) he is fragile, he does not bend; e.g. mistik e âkwatchit kâspisiw mâna: a frozen piece of wood is usually easy to break, (as it) does not bend
+« KÂSPAW, a, (a. in.) idem; e.g., mokkumân ka kâspâk, fragile knife, because it is too dry and hardened
+« KÂSPINEW, (v. a.) NAM, NIWEW, NIKEW, he breaks it easily with his hand
+« KÂSPIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he breaks it easily with his arm(s)
+« KÂSPAMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he breaks it with his teeth, e.g. a nut
+« KÂSPIKKASWEW, (v. a.) SAM, SIWEW, SIKEW, he cooks or roasts it, in a way which really dries it out, kâspikkasam nîpiya, he dries out the leaves by passing them through the fire
+« KÂSPÂKATOSUW, ok, (a. a.) he collapses from being too dry, e.g. bread that is too dry collapsing into crumbs
+« KÂSPÂKATOTEW, a, (a. in.) it collapses from being too dry, e.g. a parchment that is too dry ends up breaking up like bark
+« KÂSPAHWEW, (v. a.) HAM, HUWEW, HIKEW, he breaks him easy by hitting him
+« KÂSPAWEPAHWEW, (v. a.) HAM, HUWEW, HIKEW, he breaks him easily by subjecting him to a shock
+x KÂS, (rac.) sharp, pointed, prickly
+
+374
+
+KÂS
+
+« KÂSISIW, (a. a.) he is sharp, pointed
+« KÂSISIN, wa, (a. in.) it is sharp, pointed, e.g. kâsisin ni mokkumân, my knife cuts
+« KÂSÂKKATOSUW, ok, (a. a.) rough, harsh, being too dried out
+« KÂSÂKKATOTEW, a, (a. in.) idem
+« KÂSISIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he sharpens it, see. kâwisiw, kinisiw
+x KÂSISP, (rac.) that which exceeds, which is more
+« KÂSISPOSIW, ok, (a. a.) he is too long, he exceeds
+« KÂSISPOTTIN, wa, (a. in.) idem
+« KÂSISPOMOW, ok, a, (a. a. and in.) idem, e.g. eoko mistik kâsispomow, this piece of wood sticks out too much
+« KÂSISPOHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he makes it overtake, exceed, e.g. ni kâssispohyik, he escapes me, I lose sight of him; one also says: nijo piko nit'emak ni kâsispohyâwok, I'm saving only two of my horses
+« KÂSISPOMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he cuts off his speech, e.g. ekusi ni wi-itwa maka sâsay ki kâsispomin, I wanted to say so, but you already passed by what I was saying, you spoke too quickly, too soon
+« KÂSISPOW, ok, (v. n.) he passes straight, he cuts a straight path, he exceeds the marked place, or, kâsispopimuttew, this means someone who is escaping an obvious danger, e.g. wiya piko kâsispow, he is the only one who escaped, etato ni ki kâsispon, n't'aka e kâsispohyit, it is with difficult that I ran away, luckily I got away from him
+
+KÂS
+
+KÂSISPOPAYIW, ok, (a. a. and in.) he passes completely straight, being on a horse, it exceeds, it happens too quickly
+x KÂSS, (rac.) wipe, purify, etc. erase
+« KÂSSIHWEW, (v. a.) HAM, HUWEW, HIKEW, he wipes it, he purifies it
+« KÂSSIKKWEW, ok, (v. n.) he wipes his face, though this word is taken to mean: he washes his face
+« KÂSSIKKWEWIN, a, (n. f.) the action of washing one's face
+« KÂSSITCHITCHEW, ok, (v. n.) he washes, he wipes his hands
+« KÂSSITCHITCHEWIN, a, (n. f.) washing of the hands
+« KÂSSIKKWÂGAN, a, (n. f.) handtowel, napkin
+« KÂSSITCHITCHÂGAN, a, (n. f.) handtowel, cloth for cleaning dishes
+« KÂSSIKWENEW, (v. a.) NAM, NIWEW, NIKEW, he wipes him, or, he washes his face
+« KÂSSIPAYIW, ok, a, (a. a. and in.) it erases itself, it wipes itself
+« KÂSSINAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he erases him. This word is taken as meaning, he pardons his faults, e.g. ayamihewikâssikamâwew, he gives him absolution, ayamihewikâssinamâkewin, the sacrament of penitence
+
+375
+
+KÂT
+
+« KÂSSIHAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, idem
+« KÂSSINAMÂSUW, ok, (b. r.) he does deeds which grant him indulgence, he erases his own sins
+« KÂSSINAMÂSUWIN, (n. f.) indulgence, pardon
+« KÂSSINEW, (v. a.) NAM, NIWEW, NIKEW, he erases it, he wipes it with his hand
+x KÂTTAP, (ad.) of different proportions, in different places, e.g. kâttap iskusiwok, they are of different lengths, kâkâttap iskwâwa mokkumâna, knifes of different lengths, kâkâttap nakatam, he leaves them in different places, see. nanâhway
+« KÂTTAPIPAYIW, a, (ad.) sometimes in one way and sometimes in another
+« KÂTTAPAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he places it in different ways
+x KATÂTCH, (ad.) there is no need, it is not necessary, also, interrogation, e.g. katâtch kitchi pe-ittutet? what did he need to come? katâtch wiya tibiyawe n'tawâbamew, he absolutely wants to go see it himself, katâtch Kijemanito okosissa wi-mekiw, it was his son that God wanted, and no other, katâtch tchi kiya kitchi itutteyan? must it absolutely be you who goes there? namawiya atawiya katâtch niya, though it is not absolutely necessary that it be me, katâtch ituke, it is not need, it is not pain, katâtch ekusi ki wi-totâkonow Jesus, it is thus that Jesus wanted to act with us, and that is the only way that he wanted it
+
+KAT
+
+x KATAWA, (ad. and rac.) well, beautifully, correctly, see. mitoni kwayask, e.g. katawa totam, he does it well, e.g. katawa otâni itwew, he says (it) correctly, katawa atuskew, he works well, nama katawa pimâtisiw, he does not live well
+« KATAWÂSISIW, ok, (a. a.) he is beautiful, cheerful
+« KATAWÂSISIN, wa, (a. in.) it is beautiful, well done
+« KATAWÂTEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he finds it beautiful, cheerful
+x KÂTEW, (v. a.) SIWEW, TCHIKEW, he hides it. This verb is irregular, taking taw in the active inanimate form, even though according to rule, it should be tam, e.g. ni kâtân ni tchikahigan, I hide my axe
+« KÂTCHIKÂSUW, ok, (a. a.) he is hidden
+« KÂTCHIKÂTEW, a, (a. in.) it is hidden
+« KÂSUW, ok, (v. r.) he hides himself
+« KÂSUSTAWEW, (v. a.) TAM, TÂKEW, TÂTCHIKEW, he hides himself from him, e.g. Kijemanito namawiya kita ki kâsustawew, one cannot hide oneself from God
+« KÂTAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he hides it for him, e.g. kiya tchi ka kâtamâwiyan ni masinahigan? are you the one who hid my book from me?
+
+376
+
+« KÂTOWEW, etc., idem, e.g. ekawiya kekway kâtowin, do not hide anything from me, oma ka ki itisk Tebeyitchiket, of everything that the Lord has said to you
+KATOPPINEW, ok, (a. a.) he has a sickness on the inside, like those who have blood clots in their body
+x KÂTCH, (rac.) to reach with pain, with difficulty
+« KÂTCHITCHI, (ad.) idem
+« KÂTCHITINEW, (v. a.) NAM, NIWEW, NIKEW, he reaches it with difficulty with his hand, e.g. piyis ni kâtchitinen, in the end I reached it with my hand
+« KÂTCHIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he reaches it with his arm, by pulling with great effort
+« KÂTCHITAHWEW, (o. a.) HAM, HUWEW, HIKEW, he reaches it by hitting it
+« KÂTCHITISKAWEW, (v. a.) he reaches it with his foot
+x KAYÂS, (ad.) a long time ago, in olden days, for quite a long time, e.g. kayâs ka askiwik, the Earth has existed for a long time, kayâs otchi ka pehitân, I have waited for you for a long time
+« KAYÂSIWIW, ok, (a. a.) or, kayâsotjiw, ok, he is ancient, aged
+« KAYÂSIWAN, wa, (a. in.) or, kayâsotjipayiw, it is ancient
+« KAYÂSESKAMIK, (ad.) since a long time ago
+« KAYATTE, (ad.) formerly, at first, e.g. kayatte ekusi ijinâkwanoban, at first, it was like this, it has always been this way, kayatte namawiya ekusi opimâtisi, he did not live like this at first, kayatte Kijemanito ki peyakwaniyiw ot ittâwin, the being of God has always been the same, kayatte ekusi itastew, it is so there, since time immemorial, kayatte ekusi ni ki iteyitten, I thought like so at first
+
+KAY
+
+x KAYEWOK, (ad.) at the same location, in the same place; e.g. kayewok otaskiwok, they remain in the same country, kayewok mitjisuwok, they eat in the same place, kayewok ayâwok, they are in the same place
+« KATIKONIW, ok, (v. n.) he goes to bed, he spends the night away from his place
+x KAW, (rac.) to succumb, to throw to the ground, to tear down
+« KAWIPAYIW, ok, a, (a. a. and in.) it collapses
+« KAWINEW, (v. a.) NAM, NIWEW, NIKEW, he tears it down with his hand
+« KAWIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he tears it down with his arms
+« KAWAHWEW, (v. a.) HAM, HUWEW, HIKEW, he tears it down, e.g. a tree; e.g. tande itekke ke kawahuwitte mistik, nâspitchi kita ayapiw, on the side where the tree falls, he will rest
+« KAWIWEPAHWEW, (V. a.) HAM, HUWEW, HIKEW, he knocks it down by hitting it, or causing him shocking 
+« KAWÂSIW, ok, (a. a.) he is knocked down by the wind
+
+377
+
+KAW
+
+« KAWÂSTAN, wa, (a. in.) it is knocked over by the wind
+« KAWATCHIW, ok, (a. a.) he succumbs to the cold, he is cold; mistahi ni kawatchin, I am very cold
+« KAWATIN, wa, (a. in.) it succumbs to the cold, it is frozen
+« KAWATINEW, (v. a.) TAM, MIWEW, TCHIKEW, he makes him suffer from the cold, he makes him freeze
+« KAWATCHISITEWATCHIW, ok, (a. a.) his feet are cold
+« KAWATCHITCHITCHEWATCHIW, ok, (a. a.) he has cold hands. In this way, one may interpose other parts of the body which are cold
+« KAWÂKKATOSUW, ok, (a. a.) he succumbs to hunger, to malnutrition, he starves
+« KAWÂKKATOSUHEW, (v. a.) TTAM, HIWEW, TCHIKEW, he makes him starve, also, he makes him suffer from hunger
+« KAWÂKKATOTEW, a, (a. in.) it becomes arid, dry, meager
+« KAWIKKWASIW, ok, he succumbs to fatigue
+« KAWISSIMOW, ok, (v. n.) he goes to sleep, he goes to bed
+« KAWISSIMOWIN, a, (n. f.) going to sleep
+« KAWISSIMOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he puts him to sleep, he puts him to bed
+
+KAW
+
+« KAWISSIMONAHEW, etc. idem
+« KAWISKOHYEW, (v. a.) TTAW, YIMEW, TCHIKEW, he is overwhelmed by his burden, or, he collapses under the weight of what he is carrying
+« KAWISKOSUW, ok, (a. a.) he succumbs to his burden; e.g. Jesus nistwaw ki kawiskosuw e nayât ayamihewâttikwa, Jesus succumbed three times under his burden while carrying the cross
+« KAWISKOTEW, a, (a. in.) it crushes under the weight
+KAWI, (ad.) once more, again, see. kittwâm; e.g. kâwi itwe, say (it) again; kâwi pe-kiwew, he comes back once more; ki miyew, ekusi kâwi nantotamâwew, he had given it to him, and he asked him for it back. Kâwi is used very well for translating French verbs which begin with re, and which indicate a new action, e.g. refaire, kâwi ojittaw, he leaves again, kâwi sipwettew
+x KÂWIY, ak, (n. r.) pointed spines of a porcupine
+KÂWIYOSANEW, ok, sterile
+x KÂWEYOTEHIW, ok, (a. a.) he does not have heart
+« KÂWEYOKIJEWÂTISIW, ok, (a. a.) he has no charity. It appears that this root kâweyo is a type of negation
+KÂWISIW, ok, (a. a.) he is rough to the touch, e.g. a file
+KÂWAW, a, (a. in.) idem
+x KWÂKKUNEW, (v. a.) NAM, NIKEW, NIKEW, he pushes with his hand to knock it over
+
+378
+
+KWA
+
+KWÂKKWASUW, ok, (v. n.) he perches, such as, being ina  canoe or a barge, one uses a long piece of wood to embark
+x KWÂKKWASWEW, (v. a.) SAM, SIWEW, SIKEW, he makes it pass by the flame
+« KWÂKKUSUW, ok, (a. a.) he is in flames
+« KWÂKKUTEW, a, (a. in.) it is in flames
+x KWÂPAHWEW, (v. a.) HAM, HUWEW, HIKEW, he draws it e.g. nipiy kwâpaham, he draws water
+« KWÂPAHAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he draws (it) for him
+« KWÂPAHIGAN, a, (n. f.) vessel used for drawing (e.g. water)
+« KWÂPIKEW, ok, (v. n.) he draws water, he goes looking for water
+« KWÂPIKEWIN, a, (n. f.) the action of drawing water
+« KWÂPIKAWEW, (v. a.) KAM, KÂKEW, TCHIKEW, he goes drawing water for him, he goes seeking out water for him
+x KWÂSIHEW, (v. a.) he takes it away, he pilfers it. This is especially used of someone who takes away a woman to marry her
+« KWÂSIHIWEWIN, a, (n. f.) removal, abduction
+« KWÂSIHISKWEWEW, ok, (v. n.) he takes away a woman (rapit mulierem (he snatches away a woman))
+« KWÂSIHISKWEWEWIN, a, (n. f.)removal
+x KWATAK, (rac.) suffer, languish
+« KWATAKIHEW, (v. a.)TTAW, HIWEW, TCHIKEW, he makes him suffer, he martyrs him
+
+« KWATAKITTAW, a, (v. n.) he suffers
+« KWATAKITTÂWIN, a, (n. f.) suffering, pain
+« KWATAKISIW, ok, (a. a.) he is in suffering
+« KWATAKISIWIN, a, (n. f.) suffering
+« KWATAKIKKASWEW, (v. a.) SAM, SIWEW, SIKEW, he makes him suffer by burning him
+« KWATAKIHISUW, ok, (v. r.) he makes himself suffer, he makes penitence; e.g. ayiwak piko e kwatakihisut, kijikok kita ituttew, there are only those who will do violence, or those who while make penitence, who will go to Heaven; eka kwatakihisuyekukakiyaw ki ka wanihunâwaw, if you do not make penitence, you will all perish
+« KWATAKIHISUWIN, a, (n. f.) voluntary suffering, penitence. For penitence of the heart, compunction, one would rather say: kesinâteyimisuwin, a
+« KWATAKIHESTAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he suffers for him, in his place; e.g. Jesus-Christ ki ki pe-kakwatakihestamâkonow e wi-kaskittamâkoyak kâkike pimâtisiwin, Jesus Christ came to suffer for us, so as to earn us eternal life
+« KWATAKIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he makes him suffer by his words, he makes him pitiable, he insults him, he says painful things to him, which he does not like to remember
+
+379
+
+KWÂ
+
+« KWATAKIMOW, ok, (v. n.) he speaks of suffering. But this word more often means: he speaks of things without good sense, he does not know what he is saying
+« KWATAKEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks him to be suffering, or, he reflects painfully on him
+« KWATAKEYITTAM, wok, (V. n.) he suffers in his heart, in his soul
+« KWATAKEYITTAMOWIN, a, (n. f.) suffering in the soul, pain of the spirit
+« KWATAKEYITTAMOW, ok, (v. n.) he speaks of his sufferings in his spirit
+« KWATAKIKKASUW, ok, (a. a.) he suffers in the fire; e.g. ni kwatakikkasun ota, crucior in hac flamma (I am crucified in these flames)
+« KWATAKÂTCH! misfortune! excl.
+« KWATAKIKKATTEW, a, (a. in.) idem, it is a misfortune
+x KWÂSK, (rac.) to jump, to make an explosion, to rebound
+« KWÂSKWEPAYIW, ok, a, (a. a. and in.) it rebounds, it bounces back
+« KWÂSKUSIN, wok, (a. a.) he rebounds by falling
+« KWÂSKUTTIN, wa, (a. in.) idem
+« KWÂSKWENEW, (v. a.) NAM, NIWEW, NIKEW, he makes it rebound
+« KWÂSKWEYÂSKWAHWEW, (v. a.) he makes it rebound, jump using a piece of wood
+« KWÂSKWEYÂSKWAHUSUW, ok, (v. r.) someone who walks with crutches, he makes himself jump with help from a piece of wood
+
+KWÂ
+
+« KWÂSKWEYÂSKWAHIGAN, a, (n. f.) crutch
+« KWÂSKUTTISIS, ak, (n. f.) grasshopper
++ KWAYASK, a, (ad. and rac.) right, just, justly, without fraud
+« KWAYASKUMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he tells it to him the way it is, without disguising it, e.g. ki ka kwayaskumitin, I am going to tell you correctly, without beating around the bush
+« KWAYASKUMIWEW, ok, (v. ind.) he says it without beating around the bush
+« KWAYASKUMIWEWIN, a, (n. f.) the action of informing (somebody), speaking without disguising (what you are saying)
+« KWAYASKUTTUWOK, (v. m.) they get along, they convene with such an arrangement
+« KWAYASKUTTUWIN, a, (n. f.) mutual agreement
+« KWAYASKWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he has the right idea of him, e.g. awiyak eka eyamihât, namawiya kita ki kwayaskweyimew Kijemanitowa, he who is not a Christian cannot have the right idea about God
+« KWAYASKWEYITTAM, wok, (v. n.) he understands, he has intelligence about it
+« KWAYASKWEYITTAMOWIN, a, (n. f.) intelligence, the right idea
+« KWAKASKWEYITTAMOHEW, (a. a.) TTAW, HIWEW, TCHIKEW, he makes him understand, he gives him intelligence
+
+380
+
+KWA
+
+« KWAYASKÂTISIW, ok, (a. a.) he has a just, right character
+« KWAYASKÂTISIWIN, a, (n. f.) justice
+« KWAYASKWEYITTAMOYITCHIKÂSUW, ok, (a. a.) one has made him understand
+« KWAYASKWEYITTAMOYITCHIKÂTEW, a, (a. in.) it is made intelligible, understandable
+« KWAYASKWEYITCHIKÂSUW, ok, (a. a.) he is understandable, e.g. Kijemanito namawiya kwayaskweyitchikâsuw, God is not understandable
+« KWAYASKWEYITCHIKÂTEW, a, (a. in.) it is understandable, e.g. Manito nistweyakihuwin, namawiya kwayaskweyitchikâtew, the Trinity is not understandable
+« KWAYASKUTTAWEW, (v. a.) TTAM, TÂKEW, TCHIKEW, (v. a.) he understands it well, he hears it correctly, he grasps well what he is saying
+« KWAYASK, (ad.) right, with justice, straight, e.g. kwayask ni wi-nâtaw, I want to go straight towards him, awiyak e ka-nâtâchâkwet, kwayask nâtew Kijemanitowa, he who has a pure soul goes straight to God, kwayask ki wittamâtin, I confess to you without circumlocution, namawiya kwayask ki totawin, you do not act well to me, kwayask kakwe-tota, try to act properly, nama kwayask aya mihâwok, they do not pray well, eoko kwayask meskanaw, it is the right path, namawiya kwayask kitotew, he does not speak to him like he must, kwayask kit itwân, you say (it) well
+
+KWA
+
+« KWAYASKOPAYIW, ok, a, (a. a. and in.) it goes straight, it is arranged well, it goes well, e.g. takki âniskâtch ki pe-kwayaskkopayiw Katolik ayamihâwin aspin Jesus Christ otchi, the Catholic religion has come from a direct line since Jesus Christ
+« KWAYASKOPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it go correctly
+« KWAYASKAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he places it corretly. In this way, one can form a multitude of words with the root kwayask, which would be useless to list here
+x KWAYASITEW, ok, (v. n.) he enters into a hole, or, into any opening, but one does not say this for entering a door, etc.
+« KWAYASITEYÂMOW, ok, (v. n.) he flees into his hole
+x KWATAPIW, ok, (a. a.) he capsizes, he turns, he flips
+« KWATASTEW, a, (a. in.) it is flipped upside down
+« KWATAPIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he capsizes it
+« KWATAPINEW, (v. a.) NAM, NIWEW, NIKEW, he turns it the other way
+« KWATAPIWEPISKAWEW, (v. a.)KAM, KÂKEW, KÂTCHIKEW, he capsizes it, turns it, e.g. by putting a foot on the side of a canoe or a car
+
+381
+
+KEK
+
+« KWATAPAHUYEW, (v. a.) TAW, YIWEW, TCHIKEW, idem
+x KEPPAW, (rac.) closed, blocked, tightened. This is probably the same root as Kipp
+« KEBÂTISIW, ok, (a. a.) rarely used, he has a blocked character, he is senseless. See kakebâtisiw, etc.
+« KEBÂTAN, wa, (a. in.) idem
+x KÂKWESPAN, (ad.) it is dangerous; e.g. kâkwespan kispin e kitottwaw piyesiwok, it is dangerous when thunder rumbles
+« KÂKWESPANEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks it dangerous
+« KÂKWESPANEYITTÂKUSIW, ok, (a. a.) he is regarded as dangerous
+« KÂKWESPANETITTÂKUSIWIN, a, (n. f.) danger
+« KÂKWESPANEYITTÂKWAN, wa, (a. in.) it is seen as dangerous
+« KÂKWESPANEYITTÂKWANOK, (ad.) in a dangerous place
+x KEKWESÂPPINAWEW, (v. a.) NAM, NÂKEW, NÂTCHIKEW, he finds it quite weak, without strength, by seeing it
+« KEKWESÂPPEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, idem, in his thoughts
+KE, sign of the subjuntive future, e.g. ke kikkâmak, that I will argue, interpreted as, it is needed that, etc., tânisi ituke ke ayikkinokwe, I do not know very well what will happen, tâneyigok ke nipiyak, when will we die? N.B. When the verb begins with e or i, there is elision, e.g. tânisi k'etwet? what will he say? nama ni kiskeyitten k'etak, I don't know what to say to him, tânisi ituke k'eteyittamowâkwenik, I do not know just what they will think, ke pikok, or, pikoki, last winter, kittwâm ke miyoskamik, last springtime
+
+KEK
+
+KEKASK, (ad.) quickly, a little bit too promptly, e.g. osâm kekask pe-kiwân, you come back a little bit too quickly, kekask ki sipwettân, you leave a little bit too quickly, osâm kekask pittukewok, they entry a little bit too soon
+KEKÂTCH, (ad.) almost, e.g. kekâtch nipiw, he is almost dead, kekâtch namawiya ni wâbamaw, I almost didn't see it, kekâtch ki miyitin, I will not give it to you, kekâtch ki nistâbâwew, little comes from (the fact) that he was drowned, kekâtch tâbiskotch, it is almost similar
+KEKA-PIKO, (ad.) it got to the point, one says ... etc., e.g. keka-piko namawiya pisiskeyittam ayamihâwin, it's gotten to the point that he no longer cares about religion, keka-piko ekwa ayiwâkes ati-matchipimâtisiw, he is at a point where he has been getting crueller and crueller, keka-piko ni ka ki mâtun eyigok e kesinâteyittamân, I would cry about it, for I regret it so much, keka-piko ni kiwân eyigok eka e miweyittamân, I am almost at the point of going back, for I am not satisfied
+x KEKKEK, wok, (n. r.) hawk
+
+382
+
+KEK
+
+KEKO? (pro. inter.) e.g. keko ayiwiyan? who are you? or, awenâwiyan? or awena kiya? keko mukkumân eoko? what sort of knife is this? kek'watim ka miskawâyek? what sort of horse have you found? kekoyikkân? what sort of being is it? keko iyiniwok? which kind of people are they?
+KEKUTCH, (ad.) as a way, at least, in place of, etc., e.g. I ask someone for a good horse, which they do not want to give me, so I say to them, kispin eoko osâm ki sâkihaw, kekutch kutak miyin, if you like this one too much, at least give me the other one, kekutch eka ekusi pimâtisitji, if he at least wouldn't act like that, see. n't'awâtch; kekutch wayawi eka ka wi-kiyâm apiyan, get out, since you don't want to be calm, kekutch ekawiya mâtu, don't cry, at least, kekutch wâbiyan, if I had at least seen it
+KEKWASK, (ad.) come and go, e.g. kekwask pimuttew, he comes and goes, kekwask ispayiw, ok, a, it comes and goes, and he comes and goes on a horse, tattwaw kijikâki kekwask ni n'tawâbamaw, every day and come and go in order to see it
+x KEKWAY, a, (n. r.) thing, something, e.g. mitchet kekwa ya ni wanittân, I lost many things, kakiya kekway, all of (the) things, piko kekway, any thing, nama kekway, nothing, no thing, kekway ituke, I don't know what there is
+ 
+« KEKWAY? (pro. inter.) what? which? who? e.g. kekway ka n'tâweyittaman? what do you desire? kekwayi ka miskaman? which type of thing have you found? kekwayikkân? what sort of being? kekwayikkânak? which sort of people are they? kekwayak? what are these?
+« KEKWANOK? (ad.) in which place? e.g. kekwanok ka nittâwikit Jesus? in which place was Jesus born? kekwanok ka wi-ki-wettatâyan? how do you want to carry it? kekwanok ka wissakeyittaman? where are you suffering? nama kekwanok ni ki apin, I can't sit down anywhere, nama kekwanok miyottwaw, he is not acting well in any way, kekwanok ituke ke nipiwâné, I do not know the place I wil die
+KESÂ, mark of shock, of surprise, of admiration, e.g. it is strange! it's quite shocking! e.g. kesâ eyâbitch e pimâtisiyan, it is quite strange that you are still alive, heard alongside another sentence, for example, e ki iji-âkkusiyan, after having been so sick; kesa eka tcheskwa e pittuket, wiya takki e pe ituttet, it is quite shocking that it has gone so long without entering, the one who comes nonstop; kesa eka e ki âkwatchiyan, e ki iji-kissik, it is quite strange that you are not frozen, by such a cold
+KESÂOTI, (idem); e.g., kesâoti eka e kisiwâsit! it is still quite shocking that he didn't get angry! kesâoti Kijemanito eyâbitch e kitimâkeyimât ayisiyiniwa, eji matchi-ayiwiyit, it is all quite admirable, that God still takes mercy on men, though they be so cruel! kesâoti eka ayiwâkes matchittwât, (it is) still quite fortunate, that he does not behave worse
+
+383
+
+KES
+
+x KESINA, (rac.) to have regret, grief
+« KESINÂTCH, (ad.) it is regrettable, it is painful; e.g. kesinâtch wanihew otema, opeyakuyittay, it is regrettable that he had lost his horse, he had only the one
+« KESINÂTEYIMISUW, ok, (v. r.) he has regret, repents, mitjiyâwesiw, ok
+« KESINÂTEYIMISUWIN, a, (n. f.) repenting, compunction of the heart, mitjiyâwesiwin, abandon
+« KESINÂTEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he has regret, grief about him, he regrets it
+« KESINÂTEYITTAM, wok, (v. n.) he regrets; e.g. ni kesinâteyitten ekusi e ki ispayik, I regret that the way that this has happened
+« KESINÂTEYITTAMOWIN, a, (n. f.) regret, grief, pain
+« KESINÂTJIHEW, (v. a.) TTAW, MIWEW, TCHIKEW, he causes him misfortune, he causes him pain, grief
+« KESINÂTJIHUW, ok, (v. r.) he causes himself misfortune
+« KESINÂTJIHUWIN, a, (n. f.) misfortune, poor fortune
+
+KES
+
+« KESINÂTAKKAMIKISIW, ok, (a. a.) by his actions or his way of acting, he causes a misfortune, an accident
+« KESINÂTAKKAMIKISIWIN, a, (n. f.) misfortune, or an accident caused by someone
+« KESINÂTAKKAMIGAN, wa, (a. in.) he befalls an accident, a misfortune
+x KEKUTEWIAKAM, (ad.) to attempt, and to try to do something; e.g. kekutewiakam ni ka toten, or, ni ka kutchi toten, I will nonetheless try to do it; kekutewiakam ni ka kakeskikkemon, nevertheless I am still going to try to preach, implied, though I do not think myself able
+x KESISKOW, (prep.) immediately, without delay; e.g. kesiskow mitjisu, eat immediately. N.B. This expression is used when one is made to do something, but first one would like to do something else which requires less time; e.g. kesiskow apisis pittuke, itâb ki ka kiwân, come a bit earlier, you will go back to your place in a moment; kesiskow n'tawâbam ayamihewiyiniw mayowes sipwetteyan. go see the priest's residence before leaving; kesiskow e ki atamikawit, ekusi aspin, having bid me farewell, he disappeared
+x KESISKUTÂTUWOK, (v. m.) they come forward together, they thrust through together, they run to the assault
+
+384
+
+KEP
+
+« KESISKUTÂTUWIN, a, (n. f.) assault, the action of rushing towards, etc.
+« KESISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he arrives on time to see him, or to meet him; e.g., namawiya ni ki kesiskawaw, sâsay nipiw, I could not arrive in time to see him, he was already dead; kesiskawew osima, mayowes sipwetteyit, he arrived enough on time to see his little brother before his departure; ki kesisken ki masinahigan, I arrive on time to come across your letter
+KESWÂN, (ad.) see. miskawi; nahitâk, by fluke, by chance, e.g. keswân nakiskutâtuwok, they meet by chance; keswân takusin, by chance, he arrived; tâpwe mitoni keswân ispayiw, in truth, it happened quite by chance; keswân tâbiskotch iteyittamok, it happens by chance that they are thinking the same thing; namawiya keswân ki ka ki miskawaw, you will not have a chance to find it
+x KEPIW, ok, (v. n.) he staggers, he flips over, e.g. someone who is seated and who falls from tiredness. One also says: he goes to bed
+« KEPINEW, (v. a.) NAM, NIWEW, NIKEW, he flips it with his hand
+« KEKIPITEW, (v. a.)TAM, SIWEW, TCHIKEW, he flips it by using his arms
+« KIPISIN, wok, (a. a.) he goes to sleep as if by falling
+« KEPITTIN, wa, (a. in.) idem
+« KEPIKKWASIW, ok, (a. a.) he succumbs to sleep
+
+KEK
+
+KEKIKKOHUW, ok, (v. n.) he flaps his wings. One says this word of partridges, in the woods, which flap their wings and make a great noise
+KETCHIWÂK, (ad.) voy. tchiki; mitjim, with, capable of, something which is in the hand; e. g. ketchiwâk ekute ni miskawaw, I find it there immediately, it lies in the hand, so that I find it; askik ketchiwâk ni minikwân, I can even drink from the boiler; ketchiwâk ekute ni misken mistikwa kitchi wâskâhiganikkeyân, I find it at this place, wood in the hand for building
+« KETINEW, (v. a.) NAM, NIWEW, NIKEW, he harms him, he causes him pain by touch
+« KETISIN, wok, (a. a.) he harms himself by falling
+« KETISIMEW, (v. a.) TITAW, MIWEW, TCHIKEW, he harms him by dropping him to the ground, or by throwing him on the ground
+« KETCHIKOMOW, ok, (v. n.) he designates a time or place, see kiskimow; e. g. ekuta ka kiketchikomoyâan kita wikiyân, I had designated that my place dwelling is there, ke miyoskamik ka ki ketchikomoyân kita pe-kiweyân, it is during spring that I designate my return
+x KETCHINA, (ad.) assuredly, certainly, e.g. ketchina kiya ka otinaman, it is certainly you that took it, ketchina ki wanittân, I am certain that you lost it
+
+385
+
+KET
+
+« KETCHINÂHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it certain
+« KETCHINÂHUW, ok, (a. a.) he is certain, assured
+« KETCHINÂHUWIN, a, (n. f.) certainty
+« KETCHINÂMEW, TTAM, MIWEW, TCHIKEW, he assures it, he assures him
++ KET (rac.) to remove, detach, tear off
+« KETCHITCHITCHEPITEW, he snatches him from his hands
+« KETAHWEW, (v. a.) HAM, HUWEW, HIKEW, he tears it off, e.g. removing the round from a rifle
+« KETAHIGAN, a, (n. f.) screwdriver
+« KETCHIW, ok, (v. n.) he removes his clothes, he undresses himself
+« KETCHIWIN, a, (n. f.) undressing
+« KETCHITÂSEW, ok, (v. n.) he removes his pants, or, his mitasse (Translator's note: A type of removable pant-sleeve made from hides)
+« KETCHITÂSEPITEW, (v. a.) TAM, SIWEW, TCHIKEW, idem, by pulling strongly
+« KETASKÂKEW, ok, (v. n.) he removes his garments, his hood
+« KETAYONISEPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he takes his clothes off of him, e.g. Jesus-Christ ki ketayonisepitaw, Jesus Christ was derobed of his clothing
+
+KET
+
+« KETASÂMEW, ok, (v. n.) he takes off his snowshoes
+« KETASKISINEW, ok, (v. n.) he removes his shoes
+« KETASTISEW, ok, he takes off his gloves, his mittens
+« KETASTOTINEW, ok, (v. n.) he removes his hat, his cap
+« KETCHIPIPAKIWEYÂNEW, ok, (v. n.) he takes off his shirt
+« KETCHIKUNEW, (v. a.) NAM, NIWEW, NIKEW, he takes it out, he tears it off of, e.g. ni ketchikunâwok kinusewok, ayapik otchi, I take the fish out of the net
+« KETCHIKUW, ok, (v. r.) he takes himself out, he tears himself out of where he is taken and attached
+« KETCHIKUPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he rips it by tearing it off
+« KITCHIKUPAYIW, ok, a, (a. a. and in.) it tears itself off, it rips itself
+KETCHITAHWEW, (v. a.) HAM, HUWEW, HIKEW, he positions him in a corner, he plants it, he presses it in by hitting it
+« KETCHISTÂBISKAHWEW, (v. a.) HAM, HUWEW, HIKEW, e.g. someone who cleans his rifle, one says: ketchistâbiskahikew, he inserts something into his rifle by hitting it
+KETCHIK, (ad.) e.g. eyiwek ketchik miyin, give it to me, with the implication, though it revolts you; it also means; âtjipiko, e.g. eyiwek ata e kitahamâwok ketchik ka totak, what I am preventing him from doing, he is doing more and more
+
+386
+
+KWE
+
+KETCHIWÂK, (ad.) itself, e.g. wiyawaw ketchiwâk, themselves, nipik ketchiwâk, at the water itself, ketchiwâk sipik, at the river itself, or, right on the river
+KETOKKÂN, in that way, of this type, e.g. ketokkânesiw, he appears to be the same type, the same tribe, nama ketokkân n't'ijipimâtisin, I do not live like that
+KETTOK, (ad.) see. kisâtch
+KEYÂBITCH, (ad.) again, see eyâbitch
+KEYIWEK, (ad.) despite everything, in any case, see. eyiwek
+x KWE, (rac.) to return to the opposite side, to turn around
+« KWESKINEW, (v. a.) NAM, NIWEW, NIKEW, he turns it to the other side with his hand
+« KWESKIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, idem, by using his arms
+« KWESK'APIW, ok, (v. a.) he sits on the opposite side
+« KWESK'ASTEW, a, (a. in.) placed on the reverse, or, put on the other side
+« KWESKI, (ad.) of the other side, the reverse, e.g. kweski otchi nibâwi, hold on to the other side, kweski itina, hold it by the opposite side, kweski asta, put it on the other side
+« KWESKÂYIK, (ad.) on the other side, e.g. kweskâyik wâskâhiganik, on the other side of the house, kweskâyik oskutâkâk, on the reverse (side) of his clothes
+
+KWE
+
+« KWESKAKÂM, (ad.) on the other side of the river or lake
+« KWESKÂTTIK, (ad.) on the other side of the woods, or of the forest
+« KWESKÂBISK, (ad.) on the other side of the rock, or of the iron
+« KWESÂMATIN, (ad.) on the other side of the mountain, or of the hill
+« KWESKISIN, wok, (a. a.) he turns around, while lying down
+« KWESKISTAWEW, he returns towards him
+« KWESKITTIN, wa, (a. in.) it changes sides, e.g. kweskittin yotin, the wind changes
+« KWESKISIMOW, ok, (v. n.) he turns around while lying down
+« KWESKISIMEW, (v. a.) TITAW, MIWEW, TCHIKEW, he turns it around, while lying down, e.g. sâsay ni kijikkasun napate, ekwa kweskisimin, I am already roasted on one side, turn me around to the other
+« KWESKIPAYIW, ok, a, (a. a. and in.) it changes, it turns around
+« KWESKIMITONEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he changes the idea on his account
+« KWESKEYIMEW, (v. a.) etc., idem
+« KWESKOWEW, ok, (v. n.) he changes the language, or, kweski pikiskwew, kweskatâmow
+« KWESKISKWEYIW, ok, (v. n.) he turns his head
+« KESKIKÂBAWIW, ok, (v. n.) he turns while standing
+« KWESKAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he changes its side while placing it
+
+387
+
+KET
+
+« KWESKINISKEW, ok, (v. n.) he changes hands, in this way, other words with the root kweski are formed
+KETATAWE, (ad.) all of the sudden, e.g. ketatawe namawiya pimâtisiw, all of the sudden he stopped living, ketatawe takusin, he arrives without being expected, see. sesikutch
++ KETISK, (ad.) just what is necessary, e.g. ketisk tebipayiw, there is just enough, ketisk takusin kitchi wâbamât, he arrived just to see it, see. ekuyigok
+« KETISKISPAYIW, ok, a, (a. a. and in.) there is enough, that is enough
+« KETISKISPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it enough, it is enough
+« KETISKOMOW, ok, a, (a. a. and in.) he adjusts himself, he joins well
+« KETISKOMOWIN, a, (n. f.) adjustment
+« KETISKOMOHEW, or, YEW, (v. a.) TTAW, HIWEW, TCHIKEW, he adjusts it, he makes it join well
+« KETISKINEW, (v. a.) NAM, NIWEW, NIKEW, he lets it escape from his hand, he lets it go, he can no longer hold it
+« KETISPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he lets go of him, no longer being able to hold him with his arms
+« KETISKIPAYIW, ok, a, (a. a. and in.) it comes undone, it comes off, e.g. a beam which comes off of its tenon, and ends up coming off, falling
+« KETISKIPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it come off, removing one from the other, e.g. two pieces of wood which were joined together
+
+KWESKUSIW, ok, (v. n.) he whistles. The Indians, who believe in ghosts, think that they whistle during the night
+KWESKUSIMEW, (v. a.) TTAW, MIWEW, TCHIKEW, he whistles it
+KWETIPIW, ok, (v. n.) he returns
+KWETIPINEW, (v. a.) NAM, NIWEW, NIKEW, he turns it on the opposite side, also, he turns it upside down
+KWETIPI, (ad.) wâwiyak, e.g. osâm kisopwew kwetipi, it is a little too hot (in terms of weather), osâm kwetipi misaw, it is a little bit too big, kwetipi nama ni pisiskeyimik, he doesn't care about me too much anymore, kwetipi osâm ekwa kitimahisuw, he makes himself suffer a bit too much at the moment, kwetipi kusikwan maskutch nama ni ka ki oppinen, it is a little bit too heavy, I will probably not be able to lift it
+KWEYÂT, (rac.) all ready, all prepared, arranged in advance
+KWEYÂTJI, (ad.) beforehand, in advance, all prepared; e.g. kweyâtji miyin, give it to me right now, or, in advance; kweyâtji-mâmitoneyimisu kitchi nipiyan, beforehand, think of dying, kweyâtji-ayamiha mayowes nottekwasiyan, do your prayer before going to sleep; kweyâtjiwâweyi kitchi sipwetteyan, prepare yourself before leaving, see. kisâtch
+
+388
+
+KI
+
+KWEYÂTEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks of it beforehand, or, he thinks it to be prepared; e.g. meyâkwâm, kweyâteyimisuk, mayowes nipiyek, I beg of you, think well in advance of yourself, before dying; sâsay tchi ki kweyâteyitten ka we-itweyan?, have you already reflected beforehand on what you want to say?
+KWEYÂTINEW, (v. a.) NAM, NIWEW, NIKEW, he readies it all, prepares it
+KWEYÂTAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he arranges everything to be ready, he prepares it in advance
+KWEYÂTISIW, ok, (a. a.) he is ready, prepared
+KWEYÂTAN, wa, (a. in.) it is prepared
+KWEYÂTISIWIN, a, (n. f.) preparation
+KWEYÂTJIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he prepares it in advance; e.g. wi-kweyâtjihin kita miyo-nipiyân, prepare me to die well
+KWEYÂTEYITTÂKUSIW, ok, (a. a.) he is prepared, one has prepared it
+KWEYÂTEYITTÂKWAN, wa, (a. in.) it is prepared
+KWETCH! expression of thanks, of satisfaction (rarely used), there is enough, it is sufficient, it is very well, tâpwe
+KIM sign of the second person, and of the first second person plural; e.g. ki miyosin, you are beautiful; ki miweyittenâwaw, you (pl.) are happy; ki mitjisunânow, we (incl.) eat, N.B. Sometimes it becomes kit before a vowel, and k'o before an o; e.g. kit astân, you place it; k'otinenânow, we (incl.) take it
+
+KI
+
+KI, sign of the second and the first second person in the posessive pronoun; e.g. ki t'em, your (sg.) horse; ki mustusuminow, our (incl.) cow; ki wâaskâhiganiwaw, your (pl.) house. It becomes kit before a vowel, and k' before an o, and other words which one learns from usage; e.g. kit ayamihewiminimak, your (sg.) rosary; k'ottâwinow, our (incl.) father; k'istesiwaw, your (pl.) older brother; kit ânis, your (sg.) daughter 
+KI, sign of the past tense; e.g. ni ki sikâtchikâsun, I have been baptised. Note. Whenever ki is preceded by the pronoun ni, it must be pronounced gi, but I always write it as ki, for regularity; ki ki miyitin, I have given it to you; ki wâbamak, if I had seen it; oka ki ayamiha, mayowes kitimâkisit, he would have to become Christian before dying; ki ki wâbamaw tchi? have you seen it? ki takusiniyani, when you arrive
+KI, sign of possibility, of a capacity to do something; e.g. namawiya ni ki toten, I cannot do it; ki totamâni, if I could do it; namawiya ni ka ki ituttânân, we cannot go; ki ispayiki, kita miwâsin, if this could happen, it would be good; nista ni pa ki toten, I could also do it; kakiyaw awiyak kita ki totam, everybody can do it
+
+389
+
+KIH
+
+KIHEW, (v. a.) TTAW, HIWEW, HIKEW, he loses it, he has it slip from his hands; e.g. moswa ni kihik, the moose (that I was preparing to kill) escapes me, flees. Note. The animate form of this verb is not used, one always hears it said: ni kihikun maskwa, the bear escapes me; ni kihikun makkesis, the fox flees from me
+KIHIKKEW, ok, (v. n.) he leads a team of dogs on the hunt
+« KIHIKKEWIN, a, (n. f.) hunting with dogs
+« KIHIKKAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he brings it with him for the hunt
+x KIHKIW, ok, (a. a.) he is healed, his wound being closed
+« KIHKIWIN, a, (n. f.) healing a wound, an injury
+« KIHKIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he heals his wound, his injury
+« KIHKEW, ok, (a. a.) like kihkiw
+« KIHKAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, like kihkihew
+« KIHIKUSIMOW, ok, (v. n.) he fasts, he deprives himself of food; see. iyewanisihisuw. N.B. This is also the expression which one uses to describe the fasting of food and drink which the infidels impose upon themselves, spending two or three days on a high hill without eating, trying to sleep there, so as to obtain their genius from mysterious dreams
+« KIJIKUSIMOWIN, a, (n. f.) fasting
+
+KIH
+
+« KIHIKUSIMOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes him fast
+« KIHISKWEW, ok, (a. a.) he is mad, insane, his head, his reasoning escapes him
+« KIHISKWEYÂTISIW, ok, (a. a.) he has a mad/crazy character
+« KISISKWEYÂTISIWIN, a, (n. f.) insane character
+« KIHISKWEYÂBAMOW, ok, (a. a.) he is dizzy, his head is spinning
+« KIHISKWEYÂBAMOWIN, a, (n. f.) dizziness
+« KIHISKWEYEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks it mad
+« KIHISKWEYEYITTAM, wok, (v. n.) he is as if mad, he does not know which way to turn
+« KIHISKWEYEYITTÂKUSIW, ok, (a. a.) he is seen as mad, he deserves to be seen as insane
+« KIHISKWEYEYITTÂKWAN, wa, (a. in.) it is madness
+« KIHISKWEYAKKAMIKISIW, ok, (a. a.) he does crazy things
+« KIHISKWEYAKKAMIKISIWIN, a, (n. f.) the action of doing crazy things
+« KIHISKWEYAKKAMIKAN, wa, (a. in.) there are crazy things; e.g., eoko wâskâhigan pesissik kihiskweyakkamikan mana, in this house, there is nothing but madness
+« KIHISKWEMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he drives him mad with his speech; e.g. kakwe-ponimin, ki kihiskmewin, try to leave me alone, you are making my head spin
+
+390
+
+KIH
+
+« KIHISKWEHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he drives him mad; e.g. kihiskwehikuw o matchâtisiwin, his bad character drives him mad; ni kihiskwehikun n'istikwân, my head takes away all of my ideas
+« KIHISKWESUW, ok, (a. a.) the fire or the smoke makes him dizzy, takes away his spirit
+« KIHISKWEMOW, ok, (v. n.) he speaks like a madman
+« KIHISKWEMOWIN, a, (n. f.) insane speech
+« KIHISKWEBEW, ok, (a. a.) he is mad from drink, that is to say, he is drunk
+« KIHISKWEBEWIN, a, (n. f.) drunkenness
+« KIHISKWEBAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he intoxicates him
+« KIHISKWEKKÂN, ak, (n. f.) sort of madness; see. tchist oki kihiskwekkânak!, see this madness!
+« KIHISKWESIN, wok, (a. a.) he loses his head from a blow which he received from falling
+« KIHISKWETTIN, wa, (a. in.) idem
+« KIHISKWESIMEW, (v. a.) he dazes him by throwing him to the ground
+x KIHISPUW, ok, (a. a.) he is full, satiated
+« KIHISPUWIN, a, (n. f.) fullness, being satiated
+« KIHISPUSKUYUW, ok, (a. a.) he is very full, having eaten a lot
+
+KIH
+
+« KIHISPUSKUYUHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he satiates him by making him eat lots
+« KIHISPUYEW, (v. a.) TTAW, YIWEW, TCHIKEW, he satiates him
+x KIK, (rac.) to be attached to, etc., to hold on to something, put on, etc.
+« KIKAMOW, ok, a, (a. a. and in.) it holds, it is attached to, etc.; e.g., nama kekway kikamowok mikisissak, there are no more beads attached to it; nijo eyâbitch kikamowa mistikwa, there are still two pieces of wood which stick to it; nama tâpwe kikamow nipit, my tooth does not hold
+« KIKAMOHEW, or, YEW, (v. a.) MTAW, HIWEW, TCHIKEW, he fixes it to, etc., he attaches it to; e.g. sâsay ni kikamohâwok kit ayamihewiminimak, ka pikupayitjik, I have already put together your rosary, which was broken; mitoni kikamotta ajiskiy ita ka tawâk, put the earth (the mortar) in there well, where there is space
+« KIKÂBOWESIN, wok, (a. a.) he is covered with something which is attached to him
+« KIKÂBOWETTIN, wa, (a. in.) idem
+« KIKÂBOWISIMEW, (v. a.) TITAW, MIWEW, TCHIKEW, he fills it; e.g., opâskisigan kikâbowettitaw, he loads his rifle
+« KIKÂBOWITCHIKEW, ok, (v. n.) he fills his rifle
+« KIKÂBOWITCHIKEWIN, a, (n. f.) the action of filling one's rifle
+« KIKÂBOWÂN, a, (n. f.) rifle stuffing
+
+391
+
+KIK
+
+« KIKÂBOWEYEW, (v. a.) TTAW, YIWEW, TCHIKEW, like kikâbowisimew
+« KIKÂBOWENEW, (v. a.) NAM, NIWEW, NIKEW, idem
+« KIKASÂKEW, ok, (v. n.) he puts on his hood or his robe
+« KIKASÂMEW, ok, (v. n.) he puts on his snowshoes
+« KIKASKISINEW, ok, (v. n.) he puts on his shoes
+« KIKITÂSEW, ok, (v. n.) he puts on his pants or loincloth
+« KIKASTISEW, ok, (v. n.) he puts on his mittens, his gloves
+« KIKASTOTINEW, ok, (v. n.) he puts on his hat, his cap
+« KIKAYONISEW, ok, (v. n.) he puts on his clothes
+x KIKKA, (rac.) that which appears clearly, which is easily recognised, whose nature is easily understood
+« KIKKISIW, ok, (a. a.) he appears clearly
+« KIKKISIWIN, a, (n. f.) clear view of a thing
+« KIKKAW, a, (a. in.) it appears clearly
+« KIKKÂNÂKUSIW, ok, (a. a.) he appears clearly
+« KIKKÂNÂKWAN, wa, (a. in.) idem
+« KIKKÂNAWEW, (v. a.) NAM, NÂKEW, NÂTCHIKEW, he perceives it clearly
+« KIKKÂWITTAWEW, (v. a.) TTAM, TTÂKEW, TTÂTCHIKEW, he hears it clearly
+
+KIK
+
+« KIKKÂWITTÂKUSIW, ok, (a. a.) one hears it clearly
+« KIKKÂWITTÂKUSIWIN, a, (n. f.) clear voice
+« KIKKÂWITTÂKWAN, wa, (a. in.) one hears this clearly
+« KIKKÂMEW, (v. a.) TTAM (I know only thiese two forms) he disputes it, he quarrels (about) it
+« KIKKÂWIMEW, (v. a.) TTAM, idem
+« KIKKÂTUWOK they quarrel with one another, they argue with one another
+« KIKKÂTUWIN, a, (n. f.) quarrel, argument
+« KIKKÂTASKIW, ok, (a. a.) he is quarrelsome
+« KIKKÂWITAM, wok, (v. n.) he argues, he quarrels
+« KIKKÂWITASKIW, ok, (a. a.) he is quarrelsome
+« KIKKÂTOWEW, ok, (a. a.) idem
+« KIKKÂYÂSOWEW, ok, (a. a.) he is brilliant, shining
+« KIKKÂYÂSIW, ok, (a. a.) idem
+« KIKKÂYÂSTEW, (v. m.) there is beautiful moonlight
+« KIKKÂSPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he knows the taste easily
+« KIKKÂSPOKUSIW, ok, (a. a.) he has a very sensitive taste, one recognises the taste easily, (it smells strongly)
+« KIKKÂSPOKWAN, wa, (a. in.) so the taste is recognised, it has a strong taste
+« KIKKÂMÂTTEW, (v. a.) TTAM, SIWEW, SIKEW, he finds the odour very strong
+
+392
+
+KIK
+
+« KIKKÂMÂKUSIW, ok, (a. a.) one smells it very sensitively; e.g. wâyo otchi kikkâmâkusiw, he is smelled from afar
+« KIKKÂMÂKWAN, wa, (a. in.) it smells very strongly
+« KIKKÂMÂSUW, ok, (a. a.) he has a strong odour; e.g., tchistemaw ka kikkâmâsut, tobacco which has a strong odour
+« KIKKÂMÂSTEW, a, (a. in.) idem, e.g. meat which is cooking, kikkâmâstew wiyâs, meat which has a strong odour
+x KIKKÂTEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he venerates it, he honours it
+« KIKKÂTEYITTÂKUSIW, ok, (a. a.) he is venerable, deserves to be honoured
+x KIKI, (prep.) with, and; e.g. nâbew kiki wiwa, the man and his wife, or the man with his wife; sipwettataw o masinahigan kiki omasinahiganâttik, he carries his book with, or, and his pencil; ayamihewikijikâwa kiki kitchikijikâwa, Sundays and the holidays
+« KIKAKUTCHIN, wok, (a. a.) he immedaitely rushes forward, he leaves like the word
+« KIKAKUTTIN, wok, (a. in.) idem
+« KIKINEW, (v. a.) NAM, NIWEW, NIKEW, he takes it with, implied to mean, with other things; e.g. kikinew ospwâgana, he also takes his pipe with it
+« KIKISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, she also carries it, that is to say, she has someone in her bosom, she carries it. This word is also used to say: I carry with me, I have with me; e.g. nikikiskawâwok ayamiheminak, I carry my rosary on me; kâkike kikiskamokkan K. Marie oskutâkâs, carry the garment of Marie with you always; sâsay kikiskâkuw âkkusiwin, the sickness is already with him, he already carries the sickness; tâpwe miwâsin miskutâkay ka kikiskaman, truly, the outfit which you wear is beautiful, awâsis ka ki kiskawat, the child which you carry in your bosom
+
+KIS
+
+x KIS, (rac.) finished, perfect, well done, to the highest degree, to have attachment
+« KISÂSTEW, (v. im.) it is very hot (outside)
+« KISÂSIKEW, (v. im.) idem
+« KISÂSTEWIN, a, (n. f.) great heat
+« KISÂBEWIW, ok, (n. f.) he has reached a manly age, he is a made man
+« KISÂBEWIWIN, a, (n. f.) manly age, perfect
+« KISÂBEWOKEYIMEW, (v. a.) etc., idem
+« KISÂBEWÂTISIW, ok, (a. a.) he has the character of (a man of) manly age; e.g. eyigok ki otittamaki kisâbewâ tisîwin, when we reach the state of perfect age
+« KISAWEW, ok, (a. a.) he has finished shedding his skin, he moults
+« KISAWEWIN, a, (n. f.) moulting, changing skin
+« KISÂTCHI, (ad.) with amity, with charity; e.g. kisâtchi mekinawâtew, he distributes him something to eat, charitably, being amicable to him
+« KISÂPINE, (ad.) since, as long as, e.g. kisâspine e wi-itutteyan, kiyâm semâk sipwette, since you want to go, leave now
+
+KIK
+
+« KIKOSEW, ok, (v. n.) she carries a child, she is pregnant
+« KIKOSEWIN, a, (n. f.) the action of being pregnant
+« KIKISIN, wok, (a. a.) he is lying with; e.g., ni kikisinin ni maskisina; I lie down with my shoes on; nipiyani namawiya kekway ki ka kikisinin, when you die, you bring nothing with you
+« KIKITTIN, wa, (a. in.) it is placed with
+« KIKISIMEW, (v. a.) TITAW, MIWEW, TCHIKEW, he places it, he lies it down with; e.g., omasinahigan kikisimew, he lies him down (he buries him) with his book; âtit iyiniwok kikisimâwok ot ospwâganiwâwa, one buries certain savages with their pipes
+« KIKIYOWÂMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he sucks it
+KIKIYISINIKKE, still alive; e.g., kikiyinikke kisiswew, he burns him alive
+
+393
+
+KIK
+
+x KIKKIK, (ad.) at the end, (tandem, aliquando (at last, finally)), the time will come; e.g. kikkik ni ka kaskittân, I finally came to the end; kikkik takusin, it happens a lot. N.B. This word bears some resemblance to piyis, however, it does not in fact mean the same thing; kikkik ni pe-n'tawâbamik, he comes to see much often; piyis miweyittam, he was finally satisfied
+« KIKKIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he wants, forcefully, to earn it, to bring it on to him, he is stubborn against him, hoping that it will finally come to an end
+« KIKKIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he is stubborn around him by words, he wants to persuade him
+« KIKKITTUWOK, (v. m.) they are stubborn with one another in their arguments, etc.
+« KIKKITTUWIN, a, (n. f.) obstinancy, mutual stubbornness in words or opinions
+« KIKKIKISIW, ok, (a. a.) he is stubborn in wishing for his opinion to prevail
+x KIKISEB, (n. r.) the morning
+« KIKISEBÂYAW, (v. im.) it is morningl e.g. tattwaw kikisebâyâki, every morning
+« KIKISEBANISIW, ok, (a. a.) he sees the morning; e.g. wâbaki kikisebanisiyâni, tomorrow, if I see the morning
+x KIKKUSWEW, (v. a.) SAM, SUWEW, SIKEW, he shoots it, but the bullet only grazes the skin, without penetrating it
+
+« KIKKWAHWEW, (v. a.) HAM, HUWEW, HIKEW, the blow that he strikes only grazes
+« KIKKUSIN, wok, (a. a.) he only touches (it), grazes (it)
+« KIKKUTTIN, wa, (v. in.) idem
+« KIKKWÂHÂKES, ak, (n. f.) wolverine, wild beast, also, omiyâkes, ak, and, naweyimesis, ak
+x KIMANA, (n. r.) crush, rubbed hay, which one prepares for lighting fires in encampments, from which, manikimanew, he takes hay to make a fire
+x KIM, (rac.) in secret, in hiding
+« KIMWEW, ok, (v. n.) he speaks in secret, in a low tone
+« KIMWEWIN, a, (a. f.) speaking in secret
+« KIMOTOWEW, ok (v. n.) like kimwew, to speak in secret
+« KIMOTOWEWIN, a, (n. f.) like kimwewin, speech in secret
+« KIMOTOWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he speaks to him in secret
+« KIMAYAMIW, ok, (v. n.) see. Kimwew
+« KIMIPUW, ok, (v. n.) he eats, he satiates himself in secret
+« KIMIPUWIN, a, (n. f.) the action of eating in secret
+« KIMIPUYEW, (v. a.) yiwew, he satiates him in secret
+« KIMISKUYUW, ok, (v. n.) he eats a lot in secret
+« KIMISKUYUWIN, a, the action of eating furitively
+
+394
+
+KIM
+
+« KIMISKUYUHEW, or, YEW, (v. a.) he makes him eat a lot in secret
+« KIMIPEW, ok, (v. n.) he drinks secretly
+« KIMIPEWIN, a, (n. f.) the action of drinking secretly
+« KIMIPAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes him drink secretly
+« KIMINITCHÂGAN, ak, (n. f.) bastard
+« KIMINITCHÂGANIKKEW, ok, (v. n.) he, or, she has a bastard
+« KIMINITCHÂGANIKKEWIN, a, (n. f.) the action of having bastards
+« KIMINITCHÂGANIKKAWEW, (v. a.) KKÂKEW, he has a bastard with her
+« KIMISÂHUW, ok, (v. r.) he wipes his anus after having satisfied nature's call
+« KIMISÂHUWIN, a, the action of, etc.
+« KIMIW, ok, (v. n.) he deserts, he flees
+« KIMIWIN, a, (n. f.) desertion, fleeing
+« KIMISIW, ok, (a. a.) he acts in secret, without making noise, e.g. he walks without making noise, kimisiw, ok, or, kimâsiw, ok
+« KIMITTAW, ok, idem
+« KIMISIWIN, a, (n. f.) the action of acting in secret
+« KIMINEW, (v a.) NAM, NIWEW, NIKEW, he touches it in secret, N. This word is almost always used for bad touches
+« KIMINIKEW, ok, (v. n.) he is touching
+
+KIM
+
+« KIMINIKEWIN, a, (n. f.), dishonest touching
+« KIMINITUWOK, (v. m.) they mutually touch one another
+« KIMINITUWIN, a, (n. f.) mutual touching
+« KIMINISUW, ok, (v. r.) he touches himself shamelessly
+« KIMINISUWIN, a, (n. f.) touching oneself
+« KIMITTAWEW, (v. a.) TTAM, TTÂKEW, TTÂTCHIKEW, he listens to him in secret without being heard
+« KIMASKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he walks on him, or, he acts on him, in secret
+« KIMINAWEW, (v. e.) NAM, NÂKEW, NÂTCHIKEW, he sees it without being seen by him
+« KIMÂBAMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he watches it in secret
+« KIMINATEW, he torments him, he makes him perish in secret
+« KIMIWAN, (v. im.) it rains
+« KIMIWANÂBUIY, a, (n. f.) rainwater
+« KIMIWANITTAW, ok, (v. n.) he makes it rain
+« KIMOTCH, (ad.) in hiding, e.g. kimotch sipwettew, he leaves in secret, kimotch nama miweyittam, he is not happy on the inside
+« KIMOTISIW, ok, (a. a.) he acts in secret
+« KIMOTAN, (in.) it is secret
+« KIMOTISIWIN, a, (n. f.) the action of acting in secret, in hiding
+
+395
+
+KIN
+
+« KIMOTJIYÂWESIW, ok, (a. a.) he is angry in his heart
+« KIMOTJIYÂWESIWIN, a, (n. f.) secret, hidden anger
+« KIMOTJIYÂWEHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes him angry by acting in secret
+« KIMOTIW, ok, (v. n.) he steals, he takes (things) secretly
+« KIMOTAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he steals him, e.g. awiyak kimotamâwâtji witjâyisiyiniwa piko kitchi tipahamâwât, he who steals from his neighbour must reimburse him.
+« KIMOTIWIN, a, theft, larceny
+« KIMOTAMÂKEWIN, a, (n. f.) idem
+« KIMOT'ASTIMWEW, ok, (v. n.) he steals horses
+« KIMOT'ASTIMWEWIN, a, theft of horses
+« KIMOT'ASTIMWÂTEW, (v. a.) SIWEW, he steals horses from him
+« KIMOTAYAPEW, ok, (v. n.) he steals nets, that is to say, he steals the fish from them
+« KIMOTAYOWINISSEW, ok, he steals fabric, clothes, merchandise
+x KIN, (rac.) pointed, object which is long and pointed
+« KINIKISIW, ok, (a. a.) he is pointed, sharpened
+« KINIKAW, (a. in.) idem. Note, one also uses this word in this fashion, nama wikkâtch n'otinen e kinikâk ayamihewikijikanok, I never take objects with which one may kill on the day of Sunday, that is to say, I never use a gun, an axe, etc., etc. on Sunday, nawatch ki miweyittam Saul e kinikâyik kitchi otchinatit ispitchi kiki iyinikke kitchi otittinikut onotinâgana, Saul preferred to die by points of iron than be taken alive by his enemies
+
+KIN
+
+« KINEBIK, wok, (n. f.) grass-snake, misikinebik, snake
+« KINIKIKKUTEW, (v. a.) TAM, SIWEW, TCHIKEW, he makes it pointed with a knife, a plane, a carpenter's plane
+« KINIKKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he makes it pointed with an axe
+« KINIPUYEW, (v. a.) TAW, YIWEW, TCHIKEW, he files it, he sharpens it with a file, a stone, a grindstone
+« KINIPUTAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he sharpens it for him
+« KINIPUTCHIGAN, a, (n. f.) instrument for filing, file, or a stone. Note. The savages also refer (albeit incorrectly) in this manner to stones, though in the animate form, e.g. kiniputchiganak mitchetiwok, there are many stones
+« KINOSEW, ok, (n. f.) fish, e.g. notjikinosewew, he works the fish, he fishes. Note. The suffix amek indicates fish, e.g. wâbamek, fish which is white; but the actual whitefish is named attikamek, wok
+« KINOSIW, ok, (a. a.) he is long, big, e.g. witji iskusimew, he is as big as him
+
+396
+
+KIN
+
+« KINOWAW, a, (a. in.) it is long, e.g. e kinowâk pisâganâbiy, a long rope
+« KINOWÂBEGAN, wa, (a. in.) it is long, e.g. if it is something shaped like a rope, line, e.g. kinowâbeganiyiw oteyaniy, his tongue is long
+« KINOWÂBEKISIW, ok, (a. a.) he is long, rope-shaped
+« KINOWÂBEKIYÂWEW, ok, (a. a.) he has a long body
+« KINOKÂTEW, ok, (a. a.) he has long legs
+« KINOSIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he elongates it
+« KINOTTAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, idem
+« KINOTTAKISIW, ok, (a. a.) this piece of wood is long
+« KINOTTAKAW, a, (a. in.) this building is long
+« KINOWÂSKUSIW, ok, (a. a.) this tree is long
+« KINOWÂSKWAN, wa, (a. in.) e.g. a long pole
+« KINOWÂSKISUW, ok, (a. a.) he is long, being planted, e.g. a very high tree
+« KINOWÂSKITEW, a, (a. in.) it is long planted
+« KINOWÂBISKISIW, ok, (a. a.) he is long, a piece of metal, a stone
+« KINOWÂBISKAW, a, (a. in.) long piece of metal
+« KINOWEKISIW, ok, (a. a.) he is long, e.g. a sheet
+« KINWEGAN, wa, (a. in.) idem, e.g. Indian cloth
+
+KIN
+
+« KINWEYÂN, ak, a, idem, e.g. a buffalo robe
+« KINWENSH, (ad.) a long time, e.g. kinwensh âkkusiw, he has been sick a long time, nama kinwesh, not a long time
+« KINWENSESKAMIK, (ad.) a very long time
+x KIPIW, ok, (v. n.) he knocks it down
+« KIPIPAYIW, ok, a, (a. a. and in.) it falls over
+« KIPINEW, (v. a.) NAM, NIWEW, NIKEW, he knocks it over with his hand
+« KIPISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he knocks it over with his foot
+x KIPP, (rac.) to close, to block the passage, to place an obstacle. Note. I write this root with two p, but I deliberately write certain words derived from it with one p, for reasons of pronunciation
+« KIPPOKKWASWEW, a, (v. a.) SAM, SIWEW, SIKEW, he closes it, he stops the flow of blood
+« KIPOKKWESAMÂWEW, TAM, KEW, TCHIKEW, he stops his blood, he closes his injury
+« KIPPOKKWASIGAN, a, (n. f.) medicine for stopping blood
+« KIPPATÂTTAM, wok, (a. a) his breathing is blocked; he chokes, he loses his breath
+« KIPATÂTTAMOWIN, a, (n. f.) fainting, discomfort in breathing
+« KIPPWATÂMUW, ok, (a. a.) he chokes
+« KIPPWATÂMUWIN, a, (n. f.) choking
+
+397
+
+KIP
+
+« KIPPWATÂMUSTKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he chokes him, he stops his breathing
+« KIPPWATÂMÂBASWEW, (v. a.) SAM, SÂWEW, SIKEW, he chokes him in the smoke
+« KIPPWATÂMÂBASUW, ok, (a. a.) he chokes in the smoke
+« KIPPWATÂMÂBASUWIN, a, (n. f.) the action of choking in smoke
+« KIPPWATÂMÂBATTEW, a, (v. m.) there is thick smoke
+« KIPPWATÂMÂBATTEWIN, a, (n. f.) smothering smoke
+« KIPAHWEW, (v. a) HAM, HUWEW, HIKEW, he closes it, he blocks an opening, he closes it off, he imprisons him; e.g. kipaha iskwâtem, close the door; amiskwok nitta kipahamok sipiya, the beavers are skillful at blocking off the river
+« KIPAHIGAN, a, (n. f.) barrier. Note. One also hears this word to refer to a barrier placed in a river to catch fish
+« KIPAHAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he closes it for him, or he encloses it
+« KIPAHITUWIKAMIK, wa, (n. f.) prison
+« KIPAHIKÂSUWIKAMIK, wa, (n. f.) idem
+« KIPAHIKÂSUW, ok, (a. a.) he is closed in, imprisoned
+« KIPAHIKÂSUWIN, a, (n. f.) imprisonment
+« KIPAHIKÂTEW, a, (a. in.) it is closed in, it is closed, closed off; e.g. kipahikâtewa iskwâtema, the doors are closed; tâneki k'o kipahikâtek meskanaw? why is the path closed?
+
+KIP
+
+« KIPPISIW, ok, (a. a.) he is blocked, obstructed; e.g. kippisiw n'ospwâgan, my pipe is blocked
+« KIPPAW, a, (a. in.) it is blocked, closed off; e.g. oskitjiy ka kippâk, the stem of the pipe which is blocked
+« KIPPAPIW, ok, (a. a.) he is placed, seated, in a way which blocks the passage; e.g. opime n'tawi-aya ki kippapin ota, go put yourself somewhere else, you are embarrassing here
+« KIPPASTEW, a, (a. in.) it blocks the passage
+« KIPPISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he blocks the passage for him, he places an obstacle for him, he prevents him; e.g. nama ki pimuttewok ki kippiskawâwok, they cannot pass, you are blocking their path; nipiyâni pitane eka kippiskâkuyân ni matchi ittiwina, when I die, pray to God that my sins do not block my path; ki kippiskawin, you are in my way
+« KIPPISKÂKEWIN, a, (n. f.) something in the way, obstacle
+« KIPPISKAMOWIN, a, (n. f.) idem
+« KIPPUSKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he closes the passage for him; e.g. kippuskâk oki mistatimwok eka kita pimuttetjik, block the passage of those horses, so that they do not pass
+« KIPPITONEHWEW, (v. a.) HAM, HUWEW, HIKEW, he chokes him, by squeezing his throat
+« KIPPITONEMEW, (v. a.) he silences him, he closes his mouth
+
+398
+
+KIP
+
+« KIPPITONENEW, (v. a.) NAM, NIWEW, NIKEW, like kippitonehwew
+« KIPPITTOWEW, ok, (v. n.) he silences himself, he shuts his own mouth
+« KIPPITTOWEWIN, a, (n. f.) the action of silencing oneself
+« KIPPINEW, (v. a.) NAM, NIWEW, NIKEW, he closes it with his hand
+« KIPPITTAKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he locks it
+« KIPPITTAKAHIGAN, a, (n. f.) key, like abikkokahigan, a
+« KIPITTAKAHIKÂSUW, ok,(a. a.) he is locked
+« KIPPITTAKAHIKÂTEW, a, (a. in.) idem
+« KIPPITCHIW, ok, (v. n.) he ceases to act, he stops what he is doing. This word is used both physically and morally, e.g., ekawiya kippitchi ka atuskâtaman ayamihâwin, do not stop what you do for religion; ayiwak eka kippitchikwe isko iskweyâtch, eoko kita pikkohew ot atchâkwa, that which will persevere until the end is that which will save his soul; takki wi-kippitchiw, he is only seeking to stop
+« KIPPITCHIWIN, a, (n. f.) stop, cessation
+
+KIP
+
+« KIPPITCHIPAYIWIN, a, (n. f.) idem
+« KIPPITCHIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he stops what he is doing, he averts his actionsl e.g. Josué ki kippitchihew pisimwa, Joshua stop the sun; mina ki kippitchittaw sipiy Jourdain, atchiyaw eka kita pimitjiwaniyik, he also stopped the river Jordan from flowing for a time
+« KIPPITCHIMEW, (v. a.) he stops him from speaking
+« KIPISUW, ok, (a. a.) see. kippisiw, he is closed, blocked
+« KIPWAW, a, (a. in.) idem
+« KIPUTCH! term of scorn for someone, e.g. madness! that's crazy! raca! (idiot!)
+« KIPUTCHEYIMEW, (v. a.) TTAM, he finds him to be insane, mad
+« KIPUTCHÂTISIW, ok, (a. a.) he is of an insane character
+« KIPUTISAHWEW, (v. a.) HAM, HUWEW, HIKEW, he drives him out, he throws him outside, he puts it to the door; e.g. piweyimi-kiputisahwew, he drives him out with disdain; ata e wi nâtak ni kiputisahuk, despite wanting to go to him, he sent me away; n'otta ekawiya kiputisahun, my father does not reject me from your presence
+« KIPUTISAHUWEWIN, a, (n. f.) the action of sending (somebody) back, of driving somebody out of his presence
+KIPISTANIW, ok, (v. n.) he bleeds from the nose
+
+399
+
+« KIPISTANIWIN, a, (n. f.) nosebleed
+« KIPISTANEHWEW, (v. a.) he gives him a nosebleed
+KISÂTCH, (ad.) see. kweyâtchi, immediately, this instant, beforehand; e.g. kisâtch wâweyista kit itâtjihuwin mayowes nipiyan, immediately (while there is time) prepare your conduct before dying; ota askik kisâtch kwatakihisu, do penitence down here in advance; kisâtch miyin, give it to me right now; kisâtch ki ka wittamâtin, I will tell you immediately; tcheskwa, tcheskwa ekawiya itwek, maka kisâtch totamuk ayamihâwin, do not say: there is still time, rather, practice religion right away
+« KISÂTJIAYITTIW, ok, (a. a.) he acts in advance, he prepares himself in advance
+KISÂSTOW, (ad.) one says that, etc.,; see. miyâmay; e.g. kisâstow wimispun, one says that it is going to snow; kisâstow ekusi n't'eyitten, I almost think so; kisâstow abittaw tibiskaw, it seems that it must be midnight; kisâstow namawiya ki miyo-ayân, it seems as if you were not well; kisâstow mistikwok n't'ijinawâwok, I see them like trees; kisâstow wiya ka petchâstamuttet, it appears as if it was him he came forward
+« KISÂSTOWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks it so, it seems to him to be so
+
+KIS
+
+x KIS, (rac.) finished, perfect, well done, to the highest degree, to have affection
+« KISÂSTEW, (v. im.) it is very hot (weather)
+« KISÂSKIKEW, (v. im.) idem
+« KISÂSTEWIN, a, (n. f.) great heat
+« KISÂSIKEWIN, a, (n. f.) idem
+« KISÂBEWIW, ok, (a. a.) he has reached a manly age, he is a made man
+« KISÂBEWIWIN, a, (n. f.) manly, perfect age
+« KISÂBEWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks that he has reached a manly age
+« KISÂBEWOKEYIMEW, (v. a.) etc., idem
+« KIÂBEWÂTISIW, ok, (a. a.) he has the character of (a person at a) manly age; e.g., eyigok ki otittamaki kisabewâtisîwin, when we reach the state of perfect age
+« KISAWEW, ok, (a. a.) he sheds his skin, he moults
+« KISAWEWIN, a, (n. f.) moulting, changing one's skin
+« KISÂTCHI, (ad.) with attachment, with charity; e.g. kisâtchi mekinawâtew, he distributes him something to eat, charitably, with compassion for him
+« KISÂSPINE, (ad.) since, as long as, e.g. kisâspine e wi-itutteyan, kiyâm semâk sipwette, seeing as you want to leave, just go
+
+400
+
+KIS
+
+« KISÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he is always around him, he does not abandon him, e.g. ekawiya kisâtikuk omatchi-ayiwiwok, do not associate yourself with the wicked, ketimâkisiyani, kispin âtjipiko ki kisâtik, ekuta otchi ki ka kiskeyimaw, tâpwe e sâkihisk, if he remains around you in hardship, you know that he truly loves you, ni kisâten ayamihewikamik, I like to stay around the church, ata kakiyaw nakatikawiyani, niya ki ka kisâtitin, though we abandoned you entirely, I will never abandon you
+« KISÂTJIW, ok, he is attached to this place
+« KISÂTEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks to stay around him, he attaches himself to him, he thinks not to abandon him
+« KISÂTCHIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he keeps him, he prevents him from leaving, e.g. by paying him, etc., etc.
+« KISÂTCHIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, idem, by speech
+« KISEW, ok, (v. n.) she is charitable to her young, she defends them, she does not abandon them, e.g. a hen
+« KISEWIN, a, (n. f.) the action of protecting one's young
+« KISE-MANITO, (n. f.) the charitable spirit, the perfect spirit, the great spirit, God
+« KISE-MANITOWIW, ok, (a. a.) he is God
+
+KIS
+
+« KISE-MANITOWIWIN, a, (n. f.) divinity
+« KISEMANITOWEYIMEW, (a. a.) TTAM, MIWEW, TCHIKEW, he thinks it to be God, he recognises it as God
+« KISEMANITOKKÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, I love him like God
+« KISEMANTIOKKÂSIWEWIN, a, (n. f.) adoration of divinity
+« KISEMANITOWOKEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, see Kisemanitoweyimew
+« KISEMANITOWOKEYIMOW, ok, he thinks himself to be God
+« KISEMANITOWOKEYIMOWIN, a, (n. f.) the action of declaring oneself God
+« KISEMANITOWOKOSISÂNIWIW, ok, (a. a.) he is the son of God, e.g. kisemanitowikosisâniwiwane, if you are filius Dei (a son of God), etc., etc.
+« KISE-PISIM, wok, (n. f.) the great month, January
+« KISEWÂTISIW, ok, (a. a.), he is charitable, of a perfect character, he is compassionate
+« KISEWÂTISIWIN, ,a (n. f.) charity, principle virtue, perfect virtue, manitowi-kisewâtisiwin, charitas (the theological virtue)
+« KISEWÂTAN, wa, (a. in.) it is charitable, e.g. kisewâtan eoko wâskâhigan, this house is charitable, that is to say, that one is received compassionately there
+« KISEWÂTAYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he believes it, he finds it charitable
+
+401
+
+KIS
+
+« KISEWÂTISITOTAWEW, (v. a.) TAM, TÂKEW, TÂTCHIKEW, he does him charity
+« KISEWÂTISIWOKEYIMEW, see. Kisawâteyimew
+« KISEWÂTISIWOKEYIMOW, ok, (v. n.) he thinks himself charitable
+« KISEWÂTISIWOKEYIMOWIN, a, (n. f.) the action of believing oneself charitable
+« KISEWÂTISIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he speaks to him about charity
+« KISEYÂTISIW, ok, (a. a.) like kisewâtisiw, charitable, bt this means more generally: he is aged, he is old, he has attained the age where one is perfect
+« KISEYÂTISIWIN, a, (n. f.) seniority, e.g. okiseyâtisiwok, the elders, the seniors
+« KISEYINIWIW, ok, (a. a.) he is old, or, an old man, a well-finished man (because one supposes that an old man must be quite perfect)
+« KISEYINIWIWIN, a, oldness
+« KISEYINIWOKEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he believes it to be old
+« KISEYINIWOKEYIMOW, ok, (v. n.) he believe shimself to be old
+« KISEYINIWOKEYIMOWIN, a, (n. f.) the action of believing oneself to be old
+« KISEAYIWIW, ok, (a. a.) he is of an advanced age, see. Kiseyâtisiw
+« KISEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he finishes reflecting on it after having thought a long time, e.g. sâsay tchi ki kiseyitten ka witotaman? have you already juggled your business? nameskwa ni kiseyitten tânisi ke itak, I have not yet finished meditating on what I want to say to him
+
+KIS
+
+« KISIWEW, (v. a.) SAM, SUWEW, SIKEW, he burns it, he cooks it
+« KISISUW, ok, (a. a.) he burns himself, he is cooked, also, he has a fever
+« KISISUWIN, a, (n. f.) burn, cooking, fever
+« KISITEW, a, (a. in.) it is burnt, it is cooked, it is hot
+« KISITEWIN, a, (n. f.) see. Kisisuwin
+« KISÂBISKIWEW, (v. a.) SAM, SUWEW, SIKEW, he heats it on the fire, e.g. an iron, or a stone
+« KISÂBISKITEW, a, (a. in.) idem
+« KISÂGAMISWEW, (v. a.) SAM, SUWEW, SIKEW, he heats a liquid
+« KISÂGAMISUW, ok, (a. a.) it is hot, (a liquid)
+« KISÂGAMITEW, a, (a. in.) idem
+« KISISAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he makes him heat it (a liquid)
+« KISÂGAMITEKKWEW, ok, (v. n.) he drinks hot (things)
+« KISÂGAMITEKKWEWIN, a, (n.f .) the action of drinking hot (things)
+« KISISKUTEWOKISIW, ok, (a. a.) he gives a blazing fire, e.g. minahikwâttik, kisiskutewokisiw, the spruce wood gives a blazing fire, this is also taken to mean, it tastes like fire
+
+402
+
+KIJ
+
+« KISISKUTEWOKAN, wa, (a. in.) it gives a blazing fire, it is a blazing fire (it tastes of fire)
+« KISIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he finishes it, he ends it. N.B. On can also write: kijihew; in all of the following with this root, one can just as well say j as s
+« KISITCHIKEWIN, a, (n. f.) end of a thing
+« KISIHUW, ok, (v. n.) he finishes, he achieves, or
+« KISIYUW, ok, (v. n.) This word is most generally interpreted as: he has ended, that is to say, he killed him, or, he beat him, he broke him, this in mind, one says, e.g. sâsay nikisiyun nit'em, I have already broken my horse, kisiyuw opâkisigan, he breaks his rifle
+« KISIHUWIN, a, (n. f.) the action of placing something in pieces, of putting it in a worse state
+« KISIYUWIN, a, (n. f.) idem
+« KISITCHIKÂSUW, ok, (a. a.) he is ended, finished
+« KISITCHIKÂTEW, a, (a. in.) idem
+« KIJITTAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he finishes it for him
+« KIJITTOWEW, (v. a.) TTWÂKEW, idem
+« KIJITTÂGAN, a, (n. f.) amulet, superstitious object, idol
+« KIJITTÂGANIKKÂN, a, (n. f.) idem
+« KIJITTÂGANIKKEW, ok, (v. n.) he makes superstitious objects
+
+KIJ
+
+« KIJIK, wa, (n. f.) the firmament, that which appears in the air
+« KITCHI-KIJIK, wa, (n. f.) the sky
+« KIJIK, wa, (n. f.) the day, or, kijikaw, abandon
+« KIJIKAW, (v. im.) it is the day, wâban, petâban, e.g. every day, tattwawikijikâk, a day, nanikutita, the decline of the day, otâkwâsan, or, atimikijikaw, day of the year, otjettowikijikaw, or, oskiwaskiwikijikaw
+« KIJIKANISIW, ok, (a. a.) he sees the day, he spends the day; e.g. wâbaki ota ni ka kijikanisin, tomorrow, I will spend the day here
+« KIJIKANISIWIN, a, (n. f.) the action of spending the day
+« KIJIKKWEW, ok, (a. a.) he is, or, he has so many days, e.g. ni ka nijo kijikkwân, I will be two days, Jesus e ayenânewikijikkwet ki wâskâsakeswaw, Jesus, at eight days (old), was circumcised
+« KIJIKÂHOWEW, (v. im.) breath, wind, from the side on which the day appears (Translator's Note: this presumably means 'wind from the east')
+« KIJIKÂSTEW, (v. im.) there is moonlight
+« KIJIKÂNAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he makes it daylight, he lights it, he lights it up
+« KIJIKÂNAMÂKEWIN, a, (n. f.) the action of lighting up, of providing light
+« KIJIKKAMIKISIW, ok, (a. a.) he has finished with what is busying him
+« KIJIKKAMIKAN, wa, (a. in.) it is finished with this trouble
+« KIJIKKAMIKISIWIN, a, (n. f.) end of occupations
+
+403
+
+KIJ
+
+« KISIPAKAW, (v. im.) when the leaves are at their natural size
+« KISIPÂMATIN, (n. f.) at the end of the mountain, hillock, hill
+« KISIPATINAW, idem
+« KISIPASKAMIK, (n. f.) at the end of the Earth
+« KISIPASKAMIKAW, idem; e.g. appo kisipaskamikâk, tabasiwane, ki ka wâbamik Kijemanito, even if you fled to the ends of the Earth, God would see you
+« KISIPIGAMAW, ok, (n. f.) end of a lake
+« KISIPISTIKWEYAW, (n. f.) end of a river
+« KISIPÂYIK, (ad.) at the end of
+« KISIPISIW, ok, (a. a.) he has an end; e.g. namawiya kisipisiw Kijemanito, God has no end, or, kisipayiw, ok, abandon
+« KISIPAN, wa, (a. in.) it is an end, an ending; e.g. kwatakittâwin kitchi iskutek namawiya kita kisipan, the suffering (in Hell) will have no end
+« KISIPAW, a, (a. in.) idem
+« KISIPIKKUTEW, (v. a.) TAM, SIWEW, TCHIKEW, he cuts it until the end
+« KISIPÂSKWEYAW, a, (n. f.) end of the woods, of the forest
+« KISISKWEWIW, ok, (a. a.) she has reached the age of puberty
+« KIJITEPUW, ok, (v. n.) he has finished cooking his food
+« KIJITEPUWIN, a, (n. f.) finished cooking, cooked food
+
+KIJ
+
+« KIJITEPUYEW, (v. a.) TAW, YIWEW, TCHIKEW, he cooks him food
+« KISOKEW, ok, (v. n.) he finishes building his house or his lodge
+« KISOPIKKEW, ok, (v. n.) he melts snow to have water
+« KISOKEWIN, a, (n. f.) the action of finishing building
+« KISOPIKKEWIN, a, (n. f.) the action of melting snow
+« KISOPIKKÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he melts snow for him
+« KISOPWEW, (v. im.) it is hot (weather)
+« KISOPWEWIN, a, (n. f.) the heat of the day
+« KISOPWEKKATTEW, a, (a. in.) it is hot, e.g. a house where they is a large fire
+« KISOSIW, ok, (a. a.) he is hot, e.g. mustusweyânak mistahi kisosiwok, the buffalo pelts are very hot
+« KISOYAW, a, (a. in.) it is hot, e.g. k'iskutâkay namawiya kisoyaw, his clothes are not hot
+« KISOWISIW, ok, (a. a.) idem
+« KISOWAWAW, a, (a. in.) idem
+« KISONEW, (v. a.) NAM, NIWEW, NIKEW, he reheats it by touching it
+« KISOSKAWEW, (v. a.) he reheats it by putting it close to him; e.g. e nijokkwâmik kisoskutâtunâniwan, by laying two together, one can heat oneself up
+« KISOKKWÂMIW, ok, (a. a.) he sleeps warmly
+
+KIS
+
+« KISIPEKINEW, (v. a.) NAM, NIWEW, NIKEW, he washes it
+« KISIPEKINIKEWIN, a, (n. f.) the action of washing
+« KISIPEKINIGAN, a, (n. f.) soap
+« KISIPEKINAMÂWEW, (v. v.) TAM, KEW, TCHIKEW, he washes it for him
+« KISIPEKITTAKINIKEW, ok, (v. n.) he washes the floor, the parquet
+« KISIPEKITTAKINIKEWIN, a, (n. f.) the action of washing the floor
+« KISIPEKIKUNEWEW, ok, he washes his mouth
+« KISIPEKITCHITCHEW, he washes his hands
+x KISI, (rac.) go with speed
+« KISIPAYIW, ok, a, (a. a. and in.) it goes quickly
+« KISIKUTEW, a (a. in.) idem, e.g. a cannonball
+« KISIPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he throws it with great speed
+x KISIWÂK, (ad.) close; e.g. kisiwâk pe-api, come, sit close
+« KISIWÂKIWIW, a, (a. in.) it is close
+« KISIWÂKIWIWIN, a, (n. f.) closeness, proximity
+« KISIWÂKUTAHWEW, (v. a.) HAM, HUWEW, HIKEW, he hits it close
+x KISINEW, (v. a.) NAM, NIWEW, NIKEW, he tans it, he goes over (a skin)
+« KISINIKUW, ok, (v. n.) he tans, he goes over leather, or buffalo skins
+
+KIS
+
+« KISINIKUWIN, a, (n. f.) the action of tanning, going over leather
+KISSIN, (v. im.) it is cold (weather)
+KISSINAW, (v. im.) idem
+x KISISÂWISIW, ok, (a. a.) he is hard-working
+« KISISÂWISIWIN, a, (n. f.) love of work
+« KISISÂWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he believes him to be hard-working
+« KISISÂWIMOW, ok, (v. n.) he talks a lot
+« KISISÂWIMOWIN, a, (n. f.) the action of talking a lot
+x KISISIN, wok, (a. a.) he injures himself by pricking himself
+« KISITTIN, wa, (a. in.) idem
+« KISISIMEW, (v. a.) TITAW, MIWEW, TCHIKEW, he harms him by pricking him
+« KISITOTTAWEW, (v. a.) TTAM, TTÂKEW, TTÂTCHIKEW, he goes on his voice, he leads himself, according to his voice, which he hears
+x KISIW, (rac.) indicates anger, malcontentment. Note. Yâwesiw, suffix indicating the same thing
+« KISIWÂSIW, ok, (a. a.) he is angry
+« KISIWÂSIWIN, a, (n. f.) anger
+« KISIWÂHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he angers him. Note. This is the word used for: he offends him, e.g., God
+« KISIWATTWAW, ok, (v. ind.) he angers (somebody)
+« KISIWATTWÂWIN, a, (n. f.) the action of angering (somebody)
+« KISIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he shocks him, he angers him with his words
+
+405
+
+KIS
+
+« KISITTUWOK, (v. m.) they anger one another mutually
+« KISITTUWIN (n. f.) the action of mutually angering one another
+« KISIWAHITUW, ok, (v. m.) idem
+« KISIWÂHITUWIN, a, (n. f.) idem
+« KISISTAWEW, (v. a.) TAM, TÂKEW, TÂTCHIKEW, he keeps a grudge against him, he is displeased with him
+« KISISTÂKEWIN, a, (n. f.) grudge
+« KISISTÂTUWOK, (v. m.) they have a grudge against one another
+« KISISTÂTUWIN, a, (n. f.) mutual grudge
+« KISIWEW, ok, (v. n.) he has an angry tone of voice. Note. Ordinarilly, this word means: he speaks strongly, loudly
+« KISIWEWIN, a, (n. f.) strong voice
+« KISIMOW, ok, (v. n.) he speaks angrily
+« KISIMOWIN, a, (n. f.) angry speech
+« KISIWÂSINÂKUSIW, ok, (a. a.) he seems angry
+« KISIWÂSINÂKUSIWIN, a, (n. f.) an angry look/appearance
+« KISIWÂSINÂKWAN, wa, (a. in.) idem
+« KISIWENÂKUSIW, ok, (a. a.) idem
+« KISIWENÂKUSIWIN, a, (n. f.) idem
+« KIWENÂKWAN, wa, (a. in.) idem
+« KISIWASKATEW, ok, (a. a.) he has a stomach ache
+
+KIS
+
+« KISIWASKATEWIN, a, (n. f.) stomach ache
+« KISIWAPPINEW, ok, (a. a.) he is impatient with his pain/sickness
+« KISIWAPPINEWIN, a, (n. f.) impatience for pain
+« KISIWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks him angry, displeased
+« KISIWEYITTAM, wok, (a. a.) he is not happy, he is angry in his thoughts, he is in a bad mood
+« KISIWEYITTAMOWIN, a, (n. f.) angry, displeased thoughts
+x KISK, (1) (rac.) cut, separated in two, trimmed (Pay attention that this root is long, without which it would be the same as kiskisiw, he remembers)
+« KISKAHWEW, HAM, he tears it by hitting it
+« KISKAPPINATEW, he tears it to death, or, kiskaganâmew
+« KISKISIW, ok, (a. a.) he is cut, sliced up, trimmed
+« KISKISIWIN, a, (n. f.) trimming
+« KISKISIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it cut, he cuts it
+« KISKAW, a, (a. in.) it is trimmed, it is cut squarely; e.g. kîskosi, barge, or canoe, which is squared in the back
+« KISKITÂS, a, (n. f.) short loincloth, false underwear. N.B. The savages sometimes call women: kiskitâsis, ak, the little loincloths, because their loincloths are shorter than those of men
+
+406
+
+KIS
+
+« KISKISWEW, (v. a.) SAM, SUWEW, TCHIKEW, he cuts it with a knife, with scissors, or with fire
+« KISKISIGAN, a, (n. f.) trimming, resizing
+« KISKISIKÂSUW, ok, (a. a.) he is cut, trimmed
+« KISKISIKÂTEW, a, (a. in.) idem
+« KISKATAHWEW, (v. a.) HAM, HUWEW, HIKEW, he cuts it in two, with an axe
+« KISKATAHIKÂSUW, ok, (a. a.) he is cut in two with an axe
+« KISKATAHIKÂTEW, a, (a. in.) idem, e.g. wooden logs
+« KISKATAHIKEW, ok, (v. n.) he cuts wood, he logs, though the real word for logging is nikuttew
+« KISKATAHIKEWIN, a, (n. f.) the action of cutting wood
+« KISKIPAYIW, ok, a, (a. a. and in.) he breaks in two, e.g. a stick
+« KISKIPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he breaks it in two, he separates it
+« KISKINEW, (v. a.) NAM, NIWEW, NIKEW, he breaks it with his hands
+« KISKIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he breaks it with his arms, he tears it
+« KISKIKKUTTEW, (v. a.) TTAM, SIWEW, TCHIKEW, he cuts it in two with a slicing edge, e.g. a knife
+« KISKIKWESIN, wok, (a. a.) he breaks his neck by falling
+« KISKIKWETTIN, wa, (a. in.) it breaks by falling
+« KISKIKWENEW, (v. a.) NAM, NIWEW, NIKEW, he breaks his neck, or, he twists his neck
+
+« KISKIKWEPITEW, (v .a.) TAM, SIWEW, TCHIKEW, he breaks his neck by using his arms
+« KISKIKWESWEW, (v. a.) SAM, SUWEW, SIKEW, he cuts his neck
+« KISKISIGAN, a, (n. f.) instrument which is used for cutting, also, a cut piece, a slice, a cutting
+« KISKÂYUW, a, (n. f.) cut tail
+« KISKÂYOWEW, ok, (v. a.) he has a cut tail
+« KISKÂYOWEWIN, a, (n. f.) the action of having the tail cut off
+« KISKÂYOWESWEW, (v. a.) SAM, SUWEW, SIKEW, he cuts his tail with scissors
+« KISKÂYOWETAHWEW, (v. a.) HAM, HUWEW, HIKEW, he cuts his tail with an axe, or another instrument, with which he cuts
+« KISKIKKASWEW, (v. a.) SAM, SUWEW, SIKEW, he cuts it, he separates it by burning it
+« KISKIKKASUW, ok, (a. a.) he is cut by the fire
+« KISKIKKASUWIN, a, (n. f.) breaking by fire
+« KISKIKKATTEW, a, (a. in.) it is broken, separated by fire
+« KISKIPUYEW, (v. a.) he cuts it, he separates it in two, with a saw or a file
+« KISKIPUTÂWIN, a, (n. f.) horizontal sawing
+« KISKIPUTCHIKEWIN, a, (n. f.) idem
+
+407
+
+KIS
+
+« KISKIPUTCHIKEWIYINIW, ok, (n. f.) horizontal wood sawer
+« KISKIPUTCHIGAN, a, (n. f.) a saw which is used to saw horizontally
+« KISKIMAN, a, (n. f.) a file (tool)
+« KISKIMANIKKEW, ok, (v. n.) he makes files
+« KISKIMANIKKEWIN, a, (n. f.) the action of making files
+« KISKISOSUW, ok, (v. r.) he cuts himself with a knife
+« KISKISOSUWIN, a, (n. f.) a cut
+« KISKATAHUSUW, ok, (v. r.) he cuts himself with an axe
+« KISKATAHUSUWIN, a, (n. f.) a cut with an axe
+« KISKATINAW, a, (n. f.) hill, steeply, perpendicularly cut hillock
+« KISKATCHAW, a, (n. f.) elevated, steep ground, e.g. mistahi kiskatchaw tchikakâm, it is cut steeply around the water
+« KISTATCHAW, (n. f.) idem
+« KISKÂBISKAW, a, (n. f.) steeply cut rock, cut, trimmed metal
+« KISTÂBISKAW, a, (n. f.) idem
+« KISKATAWOKKAW, a, (a. in.) it is precipitous, e.g. the edge of a lake or river
+« KISKIMISIW, ok, (a. a.) he is numb
+« KISKIMISIWIN, a, numbness
+« KISKIMIPAYIW, ok, a, (a. a. and in.) idem
+« KISKIMIPAYIWIN, a, (n. f.) numbness
+
+KIS
+
+« KISKIMISITEW, ok, (a. a.) he has numb feet
+« KISKIMITCHITCHEW, ok, (a. a.) he has numb hands
+« KISKIMATCHIW, ok, (a. a.) he is numb from the cold, e.g. piponiyiki ayekak kiskimatchiwok, during the winter, frogs are numbed by the cold
+« KISKIMISITEWATCHIW, ok, (a. a.) he has numb feet from the cold
+« KISKIMATCHIWIN, a (n. f.) numbness from the cold
+« KISKISIS, ak, (n. f.), mare, bitch (female dog)
+« KISKISISSIWIW, ok, (a. a.) she is a mare, she is a bitch (dog)
+« KISKÂNAK, wok, (n. f.) idem
+« KISKÂNAKUS, ak, (n. f.) idem, small mare, filly
+« KISKÂNAKWAY, ak, short sleeves, cut sleeves
+x KISK, (rac.) to teach, to know, to remember, mark
+« KISKISIW, ok, (v. n.) he remembers; one says wani-kiskisiw, he loses his memory, or also, he loses knowledge, he faints
+« KISKISIWIN, a, (n. f.) memory, remembrance, wani-kiskisiwin, forgetting
+« KISKISOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes him remember, e.g. mayowes âtjimisuyan, kakwe kiskisohisu kakiyaw ki pâstahuwina, before confessing, try to recall all of your sins
+« KISKISOMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he recalls to him the memory of some distant thing, e.g. ekwa nama kekway ni ki kiskisin, matte kakwe-kiskisomin, I remember nothing anymore, so try to make me remember
+
+408
+
+KIS
+
+« KISKEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he knows it, he is aware of it, e.g. Kijemanito kakiyaw ayisiyiniwa kiskeyimew, God knows all men, nama kiskeyittuwok, they do not know one another, kakiyaw kekwaya kiskeyittam, he knows all things, nama kekway ni kiskeyitchikân, I don't know anything. N.B. One also uses this word if one wishes to speak decently about copulation (copula), e.g. kiskeyimew nijo iskwewa, cognovit duas mulieres (he knows two women, in a sexual context), or, habuit copulam cum duabus mulieribus (he has had sex with two women)
+« KISKEYITTAMOHEW, he lets him know
+« KISKEYITCHIGAN, a, (n. f.) that which is used to inform
+« KISKEYITTAMOWIN, a, (n. f.) knowledge
+« KISKIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he designates a time, a meeting, e.g. kiskittuwok ayamihewikamikok, they have arranged to meet at the church, ki kiskimitin kitchi wâbamiyan ke miyoskamik nikik, I arrange a meeting with you to come see me at my home in the springtime, nama ki ki kiskimitin, I could not arrange a meeting with you
+« KISKIMOW, ok, (v. n.) he marks a time, he designates a meeting
+
+KIS
+
+« KISKIMOWIN, a, (n. f.) meeting
+« KISKINOHAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he teaches him. he instructs him
+« KISKINOHAMÂKEWIN, a, (n. f.) instruction, education
+« KISKINOHAMÂKEWIYINIW, ok, (n. f.) schoolmaster, e.g. keskinohamâkeyan, kiskinohamâwinân tchi mâwimustchikeyâk, headmaster, teach us to pray, niyâk kiskinohikew, ok, he predicts, niyâk manitowi-kiskinohikewin, a, prediction, prophecy
+« KISKINOHWEW, (v. a.) HAM, HUWEW, HIKEW, he indicates it, he describes it, e.g. ekusi ka iji-kiskinohwât mistatimwa, it is thus that he described the horse, kiskinoham mwetchi ka ki wâbattak, he describes the thing, he depicts the thing just as he saw it
+« KISKINOTTAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he drives it, he leads it, e.g. matte kwayask kiskinottahin ite ka wikit n'ottâwiy, lead me straight to where my father lives
+« KISKINOWÂTJIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he marks it, he decorates it, e.g. awiyak e sikâtchikâsut, kiskinowâtjihikowisiw, he who is baptised is marked by God, he has a divine character, kiskinowâtjihew otema, he marks his horse, kiskinowâtjihik kitchi okimâwa, he is decorated by the king
+
+409
+
+KIS
+
+« KISKINOWÂTJITCHIGAN, a, (n. f.) mark, sign, e.g. ayamihewinanâtawihun k'etamik, kiskinowâtjitchiganiwiw e nokwak, the sacrament is a sensible sign
+« KISKINOWÂSUTTAWEW, (v. a.) TTAM, TTÂKEW, TTÂTCHIKEW, he teaches himself by listening, he says (it) like him, he learns by repeating his words, e.g. kiskinowâsuttawin, repeat what I say, so that you learm, or, pay attention, take note of what I say
+« KISKINAWEW, (v. a.) NAM, NÂKEW, NÂTCHIKEW, he imitates him, he does (it) like him, he teaches himself by seeing him act
+« KISKINOWÂBAMEW, (v. a.) TTAM, MIWEW, TCHIKEW, idem, e.g. miyo-pimâtisiyani ki ka kiskinowâbamikok kit awâssimissak, if you live well your children will take your example
+« KISKINOWÂTEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he takes note of it, there is a note in his thought, he remembers it; e.g., mitchet ayisiyiniwok eyâbitch ni kiskinowâteyimâwok, kayâs ka ki wâbamakik, I still remember lots of people who I saw in the olden days
+« KISKISITOTAWEW, (v. a.) TAM, TÂKEW, TCHIKEW, he keeps his memory, he does not forget; e.g. wani-kiskisitotawew, he forgets it; kâkike wi-kiskisitotaw Tebeyimiwet, always remember the Lord; nama wikkâtch ki ka wanikiskisototâtin, I will never forget you
+
+KIS
+
+« KISKINÂKEWIN, a, (n. f.) imitation
+« KISKINOWÂBAKKEWIN, a, (n. f.) idem
+« KISKINAWÂTCH, (ad.) by imitation, trying from an example; e.g. eyiwek kiskinowâtch ni ka ojittân, I will always try to do it; kiskinawâtch totam, kis kinawâtch ayittiw, he does (it) like the others, konata kiskinawâtch atuskew, he pretends to work
+« KISKIWEHUN, a, (n. f.) flag
+« KISKIWEHUW, ok, (v. r.) he decorates himself
+« KISKIWEHUWIN, a, (n. f.) decoration
+« KISKIWEHWEW, (v. a.) HAM, HUWEW, HIKEW, he makes marks, e.g. someone who makes marks or signs to indicate the route to those who come after him, kiskiwehikew, ok, (indef.)
+« KISKIWEHIGAN, a, (n. f.) mark, sign
+« KISKINOWÂBÂWAYEW, TAW, he signs it with water, he ripples it
+KISIK, (ad.) at the same time; e.g. mitjisuw kisk pimuttew, he eats at the same time as he walks; ayamihaw kisk atuskew, he prays while working; mispun kisk kimiwan, it snows and rains at the same time; kisik ni ka masinahikân, at the same time I will write
+
+410
+
+KIS
+
+x KISP, (rac.) thick, voluminous
+« KISPAKISIW, ok, (a. a.) he is thick
+« KISPAKISIWIN, a, (n. f.) thickness
+« KISPAKAW, a, (a. in.) it is thick, or, kistekipayiw
+« KISPAKINEW, (v. a.) NAM, NIWEW, NIKEW, he makes it thick
+« KISPAKAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he places it thickly, he piles it up
+« KISPAKISIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it thick
+« KISPAKEKISIW, ok, (a. a.) he is thick, e.g. a sheet
+« KISPAKEKITTIN, wa, (a. in.) idem, cotton.
+« KISPAKEGIN, wa, (n. f.) sheet, Indian fabric, thick leather
+« KISPAKEGINWEW, ok, (a. a.) this fabric is thick, etc.
+« KISPAKEGINWEKISIW, ok, (a. a.) he as thick skin
+« KISPAKEGINWEGAN, wa, (a. in.) it is thick skin, or, fabric, etc.
+« KISPAKISWEW, (v. a.) SAM, SUWEW, SIKEW, he cuts it thick, and he makes it thick leather
+« KISPAKAMOW, ok, a, (a. a. and in.) the ones which are attached are thick; it is of a considerable thickness, e.g. kispakamowok ikkwok k'istikwânik, the lice are all thick on your head; misiwe kispakamow ajiskiy k'ikkwâganik, you have lots of dirt on your face
+« KISPAKAMOWIN, a, (n. f.) great quantity of, etc., attached to, etc. 
+
+KIS
+
+« KISPAKATCHIW, ok, he is deeply frozen, e.g. the river
+« KISPAKATIN, wa, (a. in.) idem; e.g. sâsay kispakatinwa sâkahigana, the lakes are already deeply frozen
+KISPEW, (ad.) so little that, at least, as best they could; e.g., kispew ki ka miyitin, what little I have, I will give it to you; kispew miyo kijikaw anotch, at least the weather is nice today; kispew namawiya kiyâskiskiw, at least he is not a liar
+x KISPEWEW, ok, (v. n.) he goes on the defense, he goes to help
+« KISPEWEWIN, a, (n. f.) defense of (one's) neighbours
+« KISPEWEKITOW, ok, (v. n.) he goes on the defense, etc., by his speech; e.g. kispin pasastehutwâwo kit awâssimissak, ekawiya mana kispewekiyo, when your children are smited, do not go to their defense
+« KISPEWEKITOWIN, a, (n. f.) defense, giving help to, etc.
+« KISPEWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he goes to his defense, he takes his side, he pleads for him, e.g. pehutamiki ayamihâwin, kiyâm kispewekito, or, kispewâta, when one maligns religion, take its defense, ni mamisin kita kispewâsit k Marie kitchi kijikok, I hope that Mary pleads for me in Heaven, metchi-ayimomitji mana ayisiyiniw kiyâm kispewâtik, when one speaks ill of someone, take his defense
+
+411
+
+KIS
+
+« KISPEHUWEW, ok, (v. n.) see. Kispewew
+« KISPEHWEW, (v. a.) (irregular), see. Kispewâtew
+x KISPIN, (prep.) if, e.g. kispin ki miyo pimâtisin, if you live well, kispin sâkihatji, if you love him
+« KISPINATEW, (v. a.) TAM, SIWEW, TCHIKEW, he earns it, he acquires it. Note. Sometimes, this also means, he completely kills him
+« KISPINATAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he acquires it for him, he earns it for him, he obtains it for him, he deserves it,; v.g. Jesus-Christ ki ki kispinatamâkonow kâkike pimâtisiwin, Jesus Christ earned us eternal life
+« KISPINATAMÂSUW, ok, (v. r.) he ears for himself; e.g. awiyak tânisi ke kispinatamâsukwe, kita iji miyikowisiw, to those who are deserving, God will give it
+« KISPINATAMÂKEWIN, a, (n. f.) (something) deserved for another
+« KISPINEW, ok, (v. n.) he promptly dies
+x KISPISIW, ok, (a. a.) he is rough to the touch
+« KISPAW, a, (a. in.) idem
+KISTAHWEW, (v. a.) HAM, HUWEW, HIKEW, he shoots him at close range
+x KIST, (rac.) to form, to be all solid
+
+
+KIS
+
+« KISTAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he makes it into a pile, a solid heap
+« KISTÂPISKAW, a, (n. f.) solidly seated rock
+« KISTAPIW, ok, (a. a.) he is solidly seated
+« KISTAPIWIN, a, (n. f.) solid seat, or place of residence, village
+« KISTASTEW, a, (a. in.) it is solidly placed
+« KISTATCHAW, a, (n. f.) elevation in solid ground
+« KISTASKISUW, ok, (a. a.) he is solidly planted, fixed
+« KISTASKITEW, a, (a. in.) idem
+« KISTÂSKWAPPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he fixes it solidly while attaching it
+« KISTEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he is very fond of it, he thinks much of it, he reveres it, he venerates it
+« KISTEYIMOW, ok, (v. r.) he believes himself to be something, he is proud
+« KISTEYIMOWIN, a, (n. f.) arrogance, vanity
+« KISTEYITTÂKUSIW, ok, (a. a.), he is honorable, venerable, noble
+« KISTEYITTÂKUSIWIN, a, (n. f.) honour, nobility
+« KISTEYITTÂKWAN, wa, (n. in) it is honourable, venerable, noble
+« KISTEYITCHIKÂSUW, ok, (a. a.) he is made honourable, noble
+« KISTEYITCHIKÂTEW, a, (a. in.) it is rendered honourable
+« KISTOPEK, wa, (n. f.) vast expanse of water, place where there is always water
+
+412
+
+KIS
+
+« KISTOPEKOK, in a vast expanse of water
+« KISTIN, (v. im.) great, violent wind, hurricane
+« KISTUTTEW, ok, (v. n.) he walks on a heavy, slow pace
+« KISTUTTEWIN, a, (n. f.) heavy (weighed-down) walk
+« KISTOTEW, ok, (a. a.) all of a family; e.g. kistote-pitchiw, he moves camp with all of his family; kistote-sipwettew, he leaves with all of his family
+« KISTIKÂN, a, seed field
+« KISTIKEW, ok, he seeds a field
+« KISTIKÂTEW, TAM, he seeds it
+« KISTOKKAN, a, (n. f.) door of a lodge, of a tent
+« KISTOKKEW, ok, (v. n.) he puts down a door
+x KISTAKÊ, (ad.) very numerous; v.g. kistakê ayisiyiniwok takusinwok, many men arrived
+« KISTAKEWOK, (a. a.) they are very numerous
+« KISTAKEYITIWOK, (a. a.) idem
+« KISTEYATIW, ok, (a. a.) idem
+« KISTEYATIWIN, a, great number
+« KISTATAHWEW, (v. a.) HAM, HUWEW, HIKEW, he traces it very visibly, e.g. somone who, walking in the same place many times, ends up tracing a track, kistataham meskanaw
+« KISTÂBÂWÂYEW, (v. a.) TAW, YIWEW, TCHIKEW, he rinses it, he dips it in liquid
+« KISTATAMUW, a, (a. in.) well-traced trail, which appears clearly, e.g. mitoni kistatamuwa meskanawa, the trails appear well
+
+KIT
+
+x KITTA, (rac.) to lose sight of, to consume, to submerge in, etc.
+« KITAW, ok, (v. n.) he eats everything, he consumes all. Note. I only know the inanimate form of this verb, and I do not write it with a 't' for the pronunciation, though it seems to come from the root kitta
+« KITÂNAWEW, ok, (v. n.) he eats everything that he is served, e.g. someone who is invited to a feast
+« KITÂWIN, a, (n. f.) the action of eating everything
+« KITÂNAWEWIN, a, (n. f.) idem
+« KITAMWEW, (v. a.) (irregular) he eats all of it, e.g. ki wi-kitamon tchi? do you want to eat me?
+« KITÂMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he consumes his provisions, he eats all of him
+« KITTÂHWEW, (v. a.) HAM, HUWEW, HIKEW, he plunges it in the water
+« KITTÂNEW, (v. a.) NAM, NIWEW, NIKEW, idem
+« KITTÂWIPAYIW, ok, a, (a. a. and in.) it sinks in the water, it engulfs
+« KITTÂWIPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he engulfs it, he swallows it
+x KIT, (rac.) to forbid, to hold back
+« KITÂHAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, e.g. he forbids him, he impedes him, e.g. Kijemanito kitahamâkew kimotiwin, God forbids theft 
+
+413
+
+KIT
+
+« KITÂSOMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he forbids him, he impedes him
+« KITÂHAMÂKEWIN, a, (n. f.) prohibition
+« KITÂHAMAW, ok, (v. n.) he forbids, he impedes
+« KITÂHAMÂWIN, a, (n. f.) prohibition
+« KITINEW, (v. a.) NAM, NIWEW, NIKEW, he holds it back, he stops it
+« KITCHITINEW, etc., idem
+« KITEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he watches over him, he guards him, he takes care of him
+« KITÂBAMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he surveys it, he keeps it under surveillance, he considers it, or, kitânâweyimew, kitânâwâbamew
+x KITIKKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he is only a little injured, it only brushed the skin
+« KITIKKIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he says harsh words to him, he harms him through speech
+x KITCHIW, ok, (a. a.) he makes an effort, he is in pain from too overtensing his muscles
+« KITCHIWIN, a, (n. f.) effort
+« KITINEW, (v. a.) NAM, NIWEW, NIKEW, he feels it, he senses it by touch, he harms him through touching
+« KITISIW, ok, (a. a.) or more often, kâkitisiw, he is sensitive, he easily feels pain when one touches him
+« KITISIWIN, a, (n. f.) or, kâkitisiwin, a, sensitivity, pain
+
+
+KIT
+
+x KITISIMOW, ok, (v. n.) he is reluctant, he does not want to go, he remains in the same place
+« KITISIMOWIN, a, (n. f.) the action of being reluctant, reluctance
+« KITISIMOTOTAWEW, he refuses to act with, or, on, him
+« KITISIMOSTAWEW, TAM, he refuses to rake it, to undertake it
+« KITISIMOWÂTISIW, ok, (a. a.) he is of a reluctant character
+« KITISIMOWÂTISIWIN, a, (n. f.) reluctant character
+x KITIM, (rac.) to give misfortune, to pity, worthy of compassion
+« KITIMAHWEW, (v. a.) TTAW, HIWEW, TCHIKEW, he gives him misfortune, makes him miserable; one could say: kitimahikowisiw, he is distressed by God
+« KITIMÂKISIW, ok, (a. a.) he is destitute, he takes pity, he is dead, he is no more, okitimâkisiwok, the unfortunate. This word also sometimes means, he is poor, it also has the same meaning as nipiw, or, namatew, he is dead
+« KITIMÂKISIWIN, a, (n. f.) misery, poverty
+« KITIMÂKAN, wa, (a. in.) it is pitiable, it is destitute, e.g. kitimâkan askiy, poor country
+« KITIMÂKAKKAMIKAN, (a. in.) there is misery, desolation
+« KITIMÂKEYIMEW, (v. a.) TTAM, HIWEW, TCHIKEW, he takes pity, compassion on him
+« KITIMÂKINAWEW, (v. a.) NAM, NÂKEW, NÂTCHIKEW, he looks at him with compassion
+
+414
+
+KIT
+
+« KITIMÂKITTAWEW, (v. a.) TTAM, TTÂKEW, TÂTCHIKEW, he listens to him with tenderness, his speech touches him
+« KITIMÂKEYITTAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he takes pity on him for it
+« KITIMÂKIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he makes him worthy of pity by his speech, he makes him destitute by means of what he says to him
+« KITIMÂKIMOW, ok, (a. a.) he makes a touching speech, also, he makes an insignificant speech, for pity
+« KITIMAHISUW, ok,(v. r.) he makes himself destitute
+« KITIMAHUW, ok, (v. r.) idem
+« KITIMAHISUWIN, a, (n. f.) or, kitimahuwin, voluntary misery, poverty
+« KITIMATTÂSUW, ok, (v. indef.) he makes (him) miserable, he gives (him) misfortune
+« KITIMATTÂSUWIN, a, (n. f.) the action of giving misfortune
+x KITISKINEW, (v. a.) NAM, NIWEW, NIKEW, he escapes his hand
+« KITISKIPITEW,(v. a.) TAM, SIWEW, TCHIKEW, he escapes from his arms
+« KITISKIPAYIW, ok, a, (a. a. and in.) it escapes, it slides on the ground
+« KITISKIPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he lets it escape
++ KITCHIKISIW, ok, (a. a.) he is notched, he is dented
+
+KIT
+
+« KITCHIKISIWIN, a, (n. f.) notch, dent
+« KITCHIKAW, a, (a. in.) it is notched
+« KITCHIKIKKUTEW, (v. a.) TAM, SIWEW, TCHIKEW, he makes notches in it with a knife
+« KITCHIKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he makes notches in it with an axe
+« KICHIKIPASÉS, ak, (n. f.) grey geese
+« KITCHEKUSIW, ok, (v. n.) he climbs a ladder, a tree, etc.
+« KITCHEKUSIWIN, a, (n. f.) the action of climbing a ladder, a tree, etc.
+« KITCHÉKUSIWINÂTTIK, wa, ladder, stairway
+« KITCHEKUSITISAHWEW, (v. a.) HAM, HUWEW, HIKEW, he hunts it while riding
+« KITCHEKUSEW, ok, (v. n.) see. KITCHEKUSIW
+KITCHI, sign of the subjunctive, or, tchi, so that, in order for, that, in order to, for, e.g. ki paskewok kitchi ojittwâsutjik, they lengthen themselves in order to make one as they wish mitjisu tchi pimâtisiyan nayestow tchi mitjisuyan, eat to live, but one must not live only to eat
+KITA, idem
+
+415
+
+KIT
+
+KITA, or, KATA, sign of the future, and of the third person imperative, e.g. mâskutch anotch kita mispun, perhaps it will snow to day, kata ayiman, that is going to be difficult, kita kiwew, let him go, namawiya ota kita mitjisuw, that he does not eat here, kita ki ikkin, or, kitchi ki ikkik, it could well happen
+KIWATI, see. Pitane, e.g. kiwati ikkin! let it happen! and so on for all verb persons, by making wi precede by the pronoun, e.g. ni ka wi miyo ayân! that I be well! ki ka wi miyo pekiwân! please God so that you may return well! kitawi ayamihaw! that he wishes to pray!
+x KITCHI, (ad. and rac.) at the beginning, to begin, e.g. namawiya ki kitchi ittaw Kijemanito, God has no begnning, e wi kitchi pikiskwet, when he wanted to begin to speak, ekweyâk kitchi ayamihâwok, they do nothing but begin to pray, ekweyâk kitchi anotch, it is only today
+KITCHIPAYIW, ok, a, (a. a. and in.) it begins
+« KITCHISIN, wok, (a. a.) he begins
+« KITCHITTIN, wa, (a. in.) it begins, e.g. tânisi ka iji kitchittik eoko ayamihâwin? how does this prayer begin?
+« KITCHIPAYIHEW, (v. a.) TTAW, HIKEW, TCHIKEW, he makes it begin; e.g. kayâs Jesus-Christ ka kitchipayittât ayamihâwin, a long time ago, Jesus Christ started the religion
+
+KIT
+
+« KITCHITTOWEW, ok, (v. n.) he begins to speak; e.g. ekusi e kitchittowet, (et aperiens os suum docebat eos (and he opens his mouth to teach them)) okiskinohamâwattay
+x KITCHI, (ad. and rac.) many, of a great price, holy, great; e.g. ki kitchi Kijemanitominow, our great God; kitchi ayisiyiniw, it is a great man; ki kitchi iskwewiw K. Marie, Mary was a great woman; kitchi wâskahigan, large-sized house, famous house; kitch'astim, highly valued horse; kitchi kijikok, in the sky (Heaven), kitchi iskutek, in Hell
+« KITCHI-PIKISKWEW, ok, (v. n.) he takes an oath, he judges
+« KITCHI-ITWEW, ok, (v. n.) idem
+« KITCHI-PIKISKWEWIN, a, (n. f.) oath
+« KITCHI-ITWEWIN, a, (n. f.) idem
+« KITCHI-AYAMIHEWIYINIW, ok, (n. f.) the great priest, the bishop
+« KITCHINASUW, ok, (v. n.) he hunts a valuable prize
+« KITCHINATEW, (v.a .) TAM, SIWEW, TCHIKEW, he kills someone of great value
+« KITCHENAWEW, (v. a.) TTAM, NIWEW, NIKEW, he makes a big deal of it while looking at it
+« KITCHEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he values it greatly, he holds it in high regard
+
+416
+
+KIT
+
+« KITCHEYITTÂKUSIW, ok, (a. a.) he is venerable, well regarded, esteemed
+« KITCHEYITTÂKUSIWIN, a, (n. f.) esteem, high regard
+« KITCHEYITTÂKWAN, wa, (a. in.) it is venerable, esteemed
+« KITCHITWA, (adj.) holy, venerated, (word which always joins itself to the following one); e.g. kitchitwa Marie, holy Mary, kitchitwa Joseph, etc., etc.
+« KITCHITWAW, ok, (v. n.) he acts holy, he behaves in a venerable fashion
+« KITCHITWÂWIN, a, (n. f.) holy behaviour
+« KITCHITWÂWIHUW, ok, (a. a.) he is dressed in a holy fashion
+« KITCHITWÂWIHUWIN, a, (n. f.) holy garment
+« KITCHITWÂWISIW, ok, (a. a.) he is holy, venerable
+« KITCHITWÂWISIWIN, a, (n. f.) holiness
+« KITCHITWÂWISIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it holy, venerable
+« KITCHITWÂWAN, wa, (a. in.) it is holy, venerable; e.g. mistahi manitowan ayamihâwin, eokotchi eji-kitchitwâwak, religion is divine, and thus it is holy
+« KITCHITWAW, a, (a. in.) idem
+« KITCHITWÂWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks it holy
+« KITCHITWÂWEYITTÂKUSIW, ok, (a. a.) he is worthy, he is thought to be holy
+
+KIT
+
+« KITCHITWÂWEYITTÂKWAN, wa, (a. in.) it is holy, esteemed, venerable
+« KITCHAN, wa, (n. f.) holy place; kitchanok, in a holy place
+« KITCHIKÂWISIW, ok, (a. a.) he has a high price, he is of a high value
+« KITCHIKÂWISIWIN, a, (n. f.) high price, great value
+« KITCHIKÂWAN, wa, (a. a.) it has a high price
+x KITTIMIW, ok, (a. a.) he is lazy
+« KITTIMIWIN, a, (n. f.) laziness
+« KITTIMIGANEW, ok, (a. a.) lazy down to the bones
+« KITTIMIGANEWIN, a, (n. f.) great laziness
+« KITTIMUTTEW, ok, (a. a.) he is (too) lazy to walk
+« KITTIUTTEWIN, a, (n. f.) laziness for walking
+« KITTIMEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks him lazy
+« KITTIMIGAN, ak, (n. f.) a lazy person
+« KITTIMEYITTAM, wok, (v. n.) he feels lazy for it; e.g. awiyak e kittimeyittak ot ayamihâwin kiyipa kita pâstâhuw, he who is lazy in religion will soon fall into sin
+x KITCHITASKATEW, (v. a.) TAM, SIWEW, TCHIKEW, he keeps following him at a certain distance
+« KITCHISTINAHOKOW, ok, (a. a.) he is stopped by wind or bad weather, (he is deteriorated)
+
+417
+
+KIT
+
+« KITCHISTINAHOKOWIN, a, (n. f.) delay caused by bad weather
+x KITTOK, (Ad.) see. kisâtch
+« KITOW, ok, (v. n.) he gives him a sound, he says; e.g. namawâtch kitow, he doesn't say a word; tâneki eka k'o kitoyek? why don't you say a word? N.B. This word is also used to refer to all animal and bird cries; e.g. mistatimwok kitowok, the horses neight; mustuswok kitowok, the buffalo bellow, piêsissak kitowok, the birds sing. When speaking of the moose or deer, one says: sâsay kitowok, they are already crying, that is to say they run in heat, or they are in heat; kitow also appears to refer to the noise of thunder; ; e.g. piesiwok kitowok, the thunder rumbles
+« KITOWIN, a, (n. f.) sound, noise
+« KITOWEPAYIW, ok, a, (a. a. and in.) it gives off a sound, a noise
+« KITOWEPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes him a noise, he makes him a sound
+« KITOTEW, (v. a.) TAM, SIWEW, TCHIKEW, he speaks to him, he addresses his speech to him, (but, more generally this means: he quarrels with him, he reprimands him.)
+« KITOTCHIKEW, ok, (v. n.) he plays a musical instrument
+« KITOTCHIKEWIN, a, (n. f.) the action of playing musical
+« KITOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he plays it (a musical instrument); v.g. nanantok kitottaw kinotchigana, he plays all sorts of instruments
+
+KIT
+
+« KITOTCHIGAN, a, (n. f.) musical instrument
+« KITOKEW, ok, (v. n.) he guards the house (a dog)
+x KITTWÂM, (ad.) see. kâwi, once more, again; e.g. kittwâm ayamiha, pray again; mina kittwâm kiskinohamâwin, teach me again; kâkittwâm, often
+« KITTWÂMISIW, ok, (a. a.) he acts once more
+« KITTWÂMEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks of him once more
+KITTINEW, NAM, he places it in his hand
+x KIW, (rac.) to wander from one side to another, to be orphaned
+« KIWÂTISIW, ok, (a. a.) he is an orphaned
+« KIWÂTAN, wa, (a. in.) it is abandoned, forsaken
+« KIWÂTEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks him to be orphaned, he finds it forsaken
+« KIWÂTEYIMOW, ok, (v. r.) he finds himself orphaned, abandoned, destitute
+« KIWÂTEYITTÂKUSIW, ok, (a. a.) he is like an orphan, he is abandoned
+« KIWÂTEYITTÂKWAN, wa, (a. in.) idem
+« KIWÂTEYIMOWIN, a, (n. f.) the act of believing onself to be an orphan
+« KIWÂTEYITTÂKUSIWIN, a, (n. f.) etc.
+« KIWIHUW, ok, (v. n.) he is errant, having no residence
+
+418
+
+KIY
+
+« KIWIHUWIN, a, (n. f.) errant life
+« KIWÂHUTTEW, ok, (v. n.) he walks from one side to the other, not knowing where to go
+« KIWÂTJIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he orphans him
+« KIWÂTJIHIKOWISIW, ok, (a. a.) God has made him an orphan
+« KIWÂTJIHUW, ok, (v. n.) he leads the life of an orphan, of an errant vagabond
+« KIWÂTJIPIMÂTISIW, ok, (v. n.) idem
+« KIWÂTJIHUWIN, a, (n. f.) errant, destitute life
+« KIWÂTJIHAYIS, ak, (n. f.) vagabond, bad rascal
+x KIWEW, ok, (v. n.) he returns to his place
+« KIWEWIN, a, (n. f.) return
+« KIWEHUW, ok, (v. n.) he returns by the water. (Note. In this country, this word refers to the return of Whites to their homeland)
+« KIWEHUYEW, (v. a.) TAW, YIWEW, TCHIKEW, he sends him back to his country. Also, he leads him back by water
+« KIWETTAHEW, (v. a.) TAW, HIWEW, TCHIKEW, he transfers him to his place
+« KIWETIN, (v. im.) north wind, Aquilon, returning wind
+« KIWETINOK, (n. f.) from the northern side
+« KIYUTEW, ok, (v. n.) he makes a visit, he goes visiting; okiyutew, ok, the visitor
+« KIYUKEW, ok, (v. n.) see. Kiyutew
+
+KIY
+
+« KIYUTEWIN, a, (n. f.) visit, stroll to somebody's place
+« KIYUKEWIN, a, (n. f.) idem
+« KIYUTAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he pays him a visit
+« KIYUKAWEW, (v. a.) KÂTAM, KÂKEW, KÂTCHIKEW, idem
+x KIWÂHIKKWEYIW, ok, (v. n.) he tilts his head by wobbling it
+« KIWÂHIKKWÂYÂWEYIW, ok, (v. n.) he tilts his head by bending his neck
+x KIYAKINEW, (v. a.) NAM, NIWEW, NIKEW, he tickles him, he makes him itch
+« KIYAKISIW, ok, (a. a.) he has an itch
+« KIYAKATTAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he causes him an itch, e.g. a louse when biting
+« KIYAKINAM, wok, (v. n.) he makes a noise while walking, one hears him walking
+« KIYAKITTÂW, ok, (v. n.) he makes a noise while doing something, e.g. someone in separate room makes a noise, one says to him: kekway ka kiyakittâyan? what is that noise you are making?
+« KIYAKITTÂWIN, a, (n. f.) a noise which is caused (by something)
+x KIYÂWESIW, ok, (a. a.) he is slippery
+« KIYÂWEYAW, (a. in.) it is slippery
+x KIYÂSKIW, ok, (n. f.) he lies
+« KIYÂSKIWIN, a, (n. f.) a lie
+« KIYÂSKÂTJIMOW, ok, (v. n.) he tells lies
+
+419
+
+KIY
+
+« KIYÂSKIKKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he tells him lies
+« KIYÂSKIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes him lie, that is to say, he passes it off as saying what he did not say
+KIYAWEMA, (ad.) see. Wâwiyak. kisâtow, a bit too much, e.g. kiyawema osâm mistahi ki kiyâskin, you are a bit too much of a liar, kiyawema osâm mistahi ni totâk, it does me a bit too much
+x KIYÂM, (ad.) indifference, acceptance, to be untroubled, e.g. kiyâm pemitjisu, it is all the same, come eat, kiyâm ekawiya nando iteyitta, it doesn't matter, don't think about it, kiyâm tchi, kiteyitten? are you indifferent about it? namawiya kiyâm n't'eyitten, I am not indifferent about it, kiyâm kita pittukewok, it doesn't matter that they enter
+« KIYÂMEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks it wise, calm
+« KIYÂMEWISIW, (a. a.) he is wise, calm
+« KIYÂMEWISIWIN, a, (n. f.) modesty, wisdom
+« KIYÂTISIW, ok, (a. a.) like kiyâmewisiw
+« KIYÂMÂTISIWIN, a, (n. f.) like kiyâmewisiwin
+« KIYÂMAPIW, ok, (a. a.) he is sitting calmly, he does not moves
+« KIYÂMASTEW, a, (a. in.) it is calm, it does not stir
+
+KIY
+
+« KIYÂMIKÂBAWIW, ok, (a. a.) he is calm, standing
+« KIYÂMIKÂBAWISTAWEW, (v. a.) TAM, TÂKEW, TÂTCHIKEW, he is standing, calm, close to him
+x KIYEKAW, (ad.) jumble, e.g. kiyekaw ayâwok, they are jumbled, kiyekaw nehiyâwew mina wemistikojimow, he speaks in a jumble, sometimes in Cree, sometimes in French
+« KIYEKÂWAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he places it in a jumble
+« KIYEKÂWINEW, (v. a.) NAM, NIWEW, NIKEW, he places it in a jumble
+« KIYASUW, he goes at top speed
+x KIYIPA, or, KIPA, (ad.) quick, promptly, e.g. kiyipa kiwe, go there quickly, kipa tota, do it promptly
+« KIYIPIW, ok, (ok, (a. a.) he acts promptly, with speed
+« KIYIPIWIN, a, (n. f.) quickness, that which requires little time
+« KIYIPAN, wo, (a. ln.) it happens quickly, e.g. kiyipan ki pimâtisiwininow, our life passes quickly
+« KIYIPINEW, (v. a.) NAM, NIWEW, NIKEW, he spends it quickly, e.g. ki kiyipinam ka ki miyikut ottâwiya, in a little time, he had spent that which his father had given him
+« KIYIPINEW, ok, he dies in a short time
+« KIYIPINEWIN, a, (n. f.) a prompt death
+x KIYOMA, (ad. and rac.) continually, without cease, e.g. ni kiyoma-kikkâmik, he is always quarreling, arguing with me
+
+420
+
+KWI
+
+« KIYOMÂHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he tires him without cease, he is always annoying him, hassling him
+« KIYOMÂSKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he is always around him, annoying him
+« KIYOMÂYEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he finds it tiring, boring, annoying, e.g. ni kiyomâyeyittan oma etittâkwak, I am annoyed with hearing this noise all of the time
+x KIYUW, ok, (n. r.) eagle
+« KIYUWATANIY, a, (n. f.) beautiful feather from the tail of an eagle
+« KIWAYAWIW, ok, (v. n.) e.g. a bird which glides in the air
+« KIYASUW, ok, (v. n.) he runs away with all of his might, he flees
+« KIYASUWIN, a, (n. f.) fleeing, e.g. an animal which is being chased
+x KWIT, (rac.) to be in need, to be in embarrassment, to not know what to do
+« KWITAMAW, ok, (v. n.) he is in need of something, e.g. ni kwitaman mokkumân, I am missing my knife, mitchet kekwaya kwitamaw, he is missing many things
+« KWITÂWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he is in need of him, he desires him, he is weary, e.g. nametchi ki kwitâweyimaw k'istes? can't you wait to see your brother? or, don't you think that your brother is delaying?
+
+KWI
+
+« KWITAWI, (prep.) e.g. ni kwitawi-pehun, I've been waiting for a long time, or, I don't know what to expect anymore, I am discouraged at having waited so long
+« KWITATE, (prep.) e.g. kwitate ittiw, he does not know what to do, or, he makes himself unbearable by all means possible, kwitate totam, he does not know how to do (it), kwitate itâmow, he does not know where to flee, kwitawi mitjisunâniwan, we are running out of things to eat, kwitate ituttew, he does not know how to go
+K'O K'OTCHI, K', this is written in three different ways, k'otchi, when the verb begins with a consonant, k' when it begins with an 'o', and k'o when it begins with another vowel. These prepositions mean: that is why, due to, because; see Eokotchi, and, otchi, these three abbreviations are for: ko otchi, e.g. eokotchi k'otinamân, that is why I took it, eka e wâbamak k'opekiweyân, not having seen it, that is the reason for which I returned, e sâkihak Kijemanito k'otchi wi-atuskewok, loving God, that is why I want to serve him, tâneki k'o totaman? why did you do this? tâneki k'otchi miyiyan? why are you giving it to me?
+x KOKIW, ek, (v. n.) he dives in the water
+« KOKIWIN, a, (n. f.) the action of diving
+
+421
+
+KON
+
+« KOKIHEW, (v. a.) TYAW, HIWEW, TCHIKEW, he makes it sink, dive
+« KOKINEW, (v. a.) NAM, NIWEW, NIKEW, he submerges it
+« KOKIPITEW, (v. a.) NAM, SIWEW, TCHIKEW, idem.
+x KOKUS, ak, (n. r.) pig
+« KOKUSIWIYAS, a, (n. f.) pork
+« KOKUSIWIYIN, wa, (n. f.) lard
+« KOKUSIWIW, ok, (a. a.) he is a pig, he is unclean
+« KOKUSIWIWIN, a, (n. f.) uncleanliness, piggishness
+x KOKKWÂWÂTISIW, ok, (a. a.) he is wise, chaste
+« KOKKWÂWÂTISIWIN, a, (n. f.) chastity
+« KOKKWÂWÂTEYINEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks it chaste
+KONATA, without any reason, without design, (this is the banal word of the Cree language), or, pikonata, e.g. tâneki eka k'o ayamihâyan? why do you not pray? one responds, konata, no reason, konata pikiskwew, he speaks, and in doing so says nothing, konata ki mâmitjimon, you praise yourself without reason, konata pikiskwewina, useless speech, konata ki kisiwâsin, you anger your self for no reason, konata kit itwân, you speak without reason, or, you have lied
+x KONA, (n. r.) snow, e.g., timikoniw, there is thick snow, atâmakonak, under the snow, konik, on, or, in the snow, mwâkonew, he eats snow
+
+KON
+
+« KONIWIW, ok, a, (a. a. and in.) there is snow, it is covered with snow; e.g. misiwe ki koniwin, you are all covered in snow; koni wiwa ki maskisina, your shoes are covered in snow
+« KONIWAN, wa, (a. in.) it is covered in snow
+x KOPPA, (rac.) to dirty, to debase
+« KOPPÂTISIW, ok, (a. a.) he is dirty, vile
+« KOPPÂTAN, wa, (a. in.) idem
+« KOPPÂTJIHEW, (v. a.) TTAM, HIWEW, TCHIKEW, he debases it with his speech
+« KOPPÂTEYIMEW, (v. a.) he finds it dirty, debased
+« KOPPÂTEYITTÂKUSIW, ok, (a. a.) he is despicable
+« KOPPÂTEYITTÂKWAN, wa, (a. in.) idem
+« KOPPÂTEYITTÂKUSIWIN, a, (n. f.) contempt, disgust
+x KOSÂPEW, ok, (v. n.) he lingers in the water, he sinks in the water
+« KOSÂPEWIN, a, (n. f.) action of sinking in water
+« KOSÂPESKÂWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he holds it in the water, he shoves it in the water
+« KOSÂPEPITEW, (v. a.) TTAM, SIWEW, TCHIKEW, idem
+« KOSÂPEPAYIW, ok, a, (a. a. and in.) it sinks
+x KOSÂWEKUTCHIN, wok, (a. a.) he is hung, he is suspended
+« KOSÂWEKUTTIN, wa, (a. in.) idem
+
+422
+
+KUS
+
+« KOSÂWENEW, (v. a.) NAM, NIWEW, NIKEW, he hangs it, he hooks it to the top of, etc., etc
+« KOSÂWEPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he hands it, or, oppâpekipitew
+« KOSÂWEPISIWEWIN, a, (n. f.) hanging
+« KOSÂWEPITÂGAN, ak, (n. f.) a hanged (person)
+KOTÂSKEHAM, wok, (v. n.) he finds the bottom of the water
+x KOSÂBATTAM, wok, (v. n.) he does juggling
+« KOSÂBATTAMOWIN, a, (n. f.) the action of doing juggling
+« KOSÂBATCHIGAN, a, (n. f.) juggling, the place where one does it
+KOKUSIMÂN, a, (n. f.) pumpkin
+« KUSIKWATIW, ok, (a. a.) he is heavy
+« KUSIKWATIWIN, a, (n. f.) heaviness
+« KUSIKWAN, wa, (a. in.) it is heavy
+« KUSIKWATIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he weighs it down, he makes it heavy
+« KUSIKUHEW, etc., idem
+« KUSIKWATEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he finds it heavy
+« KUSIKWATEYITTÂKUSIW, ok, (a. a.) he is seen as heavy, he is judged heavy
+« KUSIKWATEYITTÂKWAN, wa, (a. in.) idem
+« KUSIKWATISKOSOW, ok, (a. a.) he is heavy from the burden that he is carrying
+
+KUS
+
+« KUSIKWATISKOTEW, a, (a. in.) it is heavy, being overburdened
+« KUSIKWATISKOYEW, (v. a.) TAW, YIWEW, TCHIKEW, he makes it heavy by placing a burden on it
+x KUSKUKAW, ok, (a. a.) he is not sturdy, he budges, he wobbles
+« KUSKUSKÂWIN, a, (n. f.) the action of wobbling, of not being sturdy
+« KUSKUSKWAW, a, (a. in.) it budges. N.B. This word is used to say: he wakes up, he awakens from sleep
+« KUSKUSKUPAYIWIN, a, (n. f.) waking up
+« KUSKUSKUPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it wobble, budge
+« KUSKUNEW, (v. a.) NAM, NIWEW, NIKEW, he wobbles it, he budges it with his hand. This also means: he wakes him up; e.g. kuskun ekwa osâm kinwes nipaw, wake him up now, he's been sleeping too long
+« KUSKUPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he shakes it, he rattles it, strongly budging it
+« KUSKUSK, a, (n. f.) the bars of snowshoes
+x KUSKWEYIMEW, TTAM, MIWEW, TCHIKEW, he thinks it dreadful, terrible
+« KUSKWEYITTAMOWIN, a, dread, terror
+« KUSKWEYITTÂKUSIW, ok, he is dreadful
+KUSKWEYITTÂKWAN, wa, inan.
+
+423
+
+KUS
+
+« KUSKWEYINÂKUSIW, ok, he is terrible to see
+« KUSKWEYINÂKWAN, wa, in.
+KUSA, (at the end of the word) certainly, without any doubt, but usually, it must always be joined with some adverb or pronoun; e.g. ata kusa ki ki miyitin, but nevertheless I gave it to you; ki ki otinen kusa oma, nevertheless, you certainly took it
+x KUSKWÂTISIW, ok, (a. a.) he is melancholic, he is sad, calm
+« KUSKWÂTISIWIN, a, (n. f.) melancholy, sadness
+« KUSKWÂTAN, wa, (a. in.) it is melancholic
+« KUSKWÂTAKKAMIKAN, wa, (a. in.) idem
+« KUSKWAWÂTAPIW, ok, (a. a.) he is sitting there melancholically. One also says to children: kakwe kuskwawâtapi, be quiet
+« KUSKWAWÂTAPIWIN, a, (n. f.) place of sadness, of boredom
+« KUSKWAWÂTEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he believes it melancholic, sad
+x KUSPIW, ok, (v. n.) he rushes into the woods, he lengthens the trail to enter the forest, he goes to the side where the ground is wooded
+« KUSPIWIN, a, (n. f.) the action of rushing into the woods
+« KUSPITISAHWEW, (v. a.) HAM, HUWEW, HIKEW, he hunts it from the edge of the woods
+« KUSPIPATTAW, ok, (v. n.) he runs away into the woods
+
+KUS
+
+« KUSPAMUW, a, (v. im.) path which goes to the edge of the woods. N.B. All of these words are also used to refer to someone who leaves the water to reach the shore, probably because it is assumed that on the banks of rivers or lakes, there are trees
+x KUSTÂMIKUSIW, KWAN, he is frightening
+x KUSTEW, (v. a.) TAM, SIWEW, TCHIKEW, he fears it, he is afraid of it; e.g. Kijemanito piko tchi kustit, or, Kijemanito tchi kustânikkâtit, it is only God that one must fear
+« KUSIWEWIN, a, (n. f.) dread
+« KUSTAMOWIN, a, (n. f.) idem
+« KUSTCHIGANIWIW, ok, (a. a.) he is to be feared, dreadful
+« KUSTÂTCHIW, ok, (a. a.) he is fearful, tremulous
+« KUSTÂTCHIWIN, fear
+« KUSTEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he finds it to be feared, he thinks it dreadful
+« KUSTÂTEYIMEW, etc, idem
+« KUSTÂTEYITTÂKUSIW, ok, (a. a.) he is dreadful
+« KUSTÂTEYITTÂKWAN, wa, (a. in.) it is dreadful, it is terrible; e.g. kustâteyittâkwan kitchi iskutew, Hell is a dreadful thing
+« KUSPANEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he dreads it, he fears him
+« KUSPAN, wa, (a. in.) it is dreadful
+« KUSPANEYITTÂKUSIW, ok, (a. a.) he is terrible, formidable
+
+424
+
+KUS
+
+« KUSPANEYITTÂKWAN, wa, (a. in.) it is terrible, formidable
+« KUSTONÂMEW, (v. a.) he dreads to speak with him, with the implication that it is because he will misinterpret what he says
+« KUSTONÂMOW, ok, (v. n.) he dreads speaking with someone
+« KUSTONÂMOWIN, a, (n. f.) fear of speaking with (someone)
+KUTAK, ak, (pro. an.) another; e.g. kutak miyin, give me another; namawiya kutak n't'ayâwaw, I don't have another of them
+KUTAK, a, (pro. in.) idem
+x KUTAWEW, ok, (v. n.) he makes fire, he lights a fire
+« KUTAWINEW, NAM, he shoves it in
+« KUTAWEWIN, a, (n. f.) the action of lighting a fire
+« KUTAWÂGAN, ak, (n. f.) match (for starting fires)
+« KUTAWÂN, wa, (n. f.) place of fire, where one makes fire
+« KUTAWÂNABISK, wa, (n. f.) fireplace; piwâbiskutawânâbisk, wa, stove
+x KUT, (rac.) to try, to attempt, to taste
+« KUTCHI, (prep.) before the verb, to try; e.g. ni kutchi-toten, I'm going to try to do it; eyiwek kutchi-mitjisu apsis, always try to eat a bit; nametchi ki wi-kutchi-ayamihân? don't you want to try to pray?
+« KUTCHIW, ok, (v. n.) This word pertains to superstitions; e.g., when the savages try to wondrous things to impose
+
+KUT
+
+« KUTCHIWIN, a, (n. f.) test of superstition
+« KUTCHISTAWEW, (v. a.) TAM, TÂKEW, TÂTCHIKEW, he attempts it, he tries it. Also, he tastes it, e.g., meat
+« KUTEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he attempts it
+« KUTCHIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he attempts it, he tries it, he tries to do it, to overcome it
+« KUTCHIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he asks him something as if trying it, wanting to obtain it, e.g., I am always going to try to ask it of him, eyiwek ni ka kutchimaw
+« KUTCHISKÂWEW, ok, (v. n.) used for: he runs a race
+« KUTCHISKÂWEWIN, a, (n. f.) a race
+« KUTÂHÂSKWEW, ok, (v. n.) he fires a blank
+« KUTÂHÂSKWEWIN, a, (n. f.) firing blanks
+« KUTÂHÂSKWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he fires a blank, taking it for a blank
+« KUTISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he tries it, e.g., someone who tries on a suit
+« KUTOWEW, ok, (v. n.) he tries to speak, to say
+« KUTOWEWIN, a, (n. f.) attempt in speech
+« KUTATÂMOW, ok, (v. n.) he tries to sing
+
+425
+
+MÂ
+
+« KUTATÂMOWIN, a, (n. f.) attempt in song
+« KUTCHIPPWEW, (v. a.) he tastes it, e.g. a dish
+« KUTCHISPITEW, (v. a.) TAM, SIWEW, TCHIKEW, like, Kutchipwew
+« KUTCHIPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he swallows it
+« KUTCHIPASTEMEW, ok, (v. n.) he swallows smoke
+« KUTTAMEW, ok, (v. n.) idem
+x KUTIKUSWEW, SAM, SUWEW,SIKEW, he cuts off his limbs, he separates his limbs from his body
+« KUTIKUNEW, (v. a.) NAM, NIWEW, NIKEW, he breaks off his limbs, he takes them off of him
+« KUTIKUSIN, wok, (a. a.) he has a limb taken off
+« KUTIKUTTIN, wa, (a. in.) it is taken off, undone
+« KUTIKUSIMEW, (v. a.) TITAW, MIWEW, TCHIKEW, he takes off his limbs, he dislocates his limbs
+« KUTTEW, TTAM, he swallows it
+MÂ! exclamation to attract attention, e.g. look!... listen!... one hears a noise, one wants to attract somebody's attention, e.g. mâ! miyâmay matwe takusinwok, listen! they are probably arriving
+MÂ, synonym of appo, and, keyiwek; sometimes this is used as a response to this idea; see then, e.g. mâ, ka totak, he does it well, mâ wiya meyiyit! see then, we're going to give it! also, like, ayis, e.g. mâwiya nipiw! what to do, he is dead!
+
+
+MÂM
+
+« MÂMITÂK, (ad.) on the side at the end of the current, e.g. kakiyaw, mustuswok mâmitâk ayâwok, all of the buffalo are at the end (of the current)
+« MÂMITÂK IJI, (ad.) idem
+« MÂMIWIW, (v. im.) there is a direction of the current, of the river, e.g. kakiyaw eokoni sipiya mâmiwiwa pakisimotâk, all rivers have their course towards the setting sun, tande ka iji mâmiwik eoko sipiy? in what direction does the course of this river run?
+x MAHIGAN, ak, (n. r.) wolf
+« MAHIGANIWIW, (a. a.) he is a wolf
+« MAHIGANIWEYÂN, ak, (n. f.) skin of a wolf with hair
+« MAHIGANÂTTIK, wa, (n. f.) white willow, wolf tree
+x MÂKA, (ad.) but, said before or after the word, e.g. mâka Jesus omisi itew, but Jesus said so to him, kiya mâka tânisi kit eyitten? but you, what you do think? mânamâka, assuredly, certainly
+« MÂKA MINA, (ad.) again, newly, e.g. mâka mina ka mâtut, here he is, crying again, mâka mina ituke ki kisiwâsin, you are without doubt angry again, maka mina wi-mispun, here, it looks like it will snow again
+« MÂKA ÂWÂH, (ad. et pro.) but here it is again! e.g. mâka âwâh ka pe-mikuskâtjimit, here he is again, come to tire me
+« MÂKA OMA, idem, (inan.) e.g. mâka oma ka wi otittikuyân, here again, the same thing wants to happen to me
+
+MÂH
+
+x MÂH, (rac.) to go down the current of a river, to go the side to which the current is running
+« MÂHAM, wok, (v. n.) he goes down the current in a canoe, in a barge, or in a vessel. N.B. This word is usually used, in this country, for those who make the York voyage for the Hudson's Bay Company, because one is always going down the current during the voyage, omâhamo, wok, that which goes down the current
+« MÂHAMOWIN, a, (n. f.) the action of going down the current
+« MÂHABOYUW, ok, (v. n.) he goes down the current
+« MÂHABOYUWIN, the action of going down the current
+« MÂHISKAM, wok, (v. n.) he goes, he walks to the side where the current is leading. N.B. This word is used here exclusively to say that one wishes to buy goods at a fort, e.g. nameskwa pe-mâhiskamwok iyiniwok, the savages have not yet come to trade, anotch ni wimâhiskan, today I am going to go trading at the fort
+« MÂKISKAMOWIN, a, (n. f.) the action of doing to trade at the fort
+« MÂHISKAMOTTAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he carries it to the fort as an object for trading and exchange, e.g. kekway ka wi-mâhiskamottatâyan? what do you bring to trade? wâbistânak ni wi-mâhiskamottahâwok, these are the martens that I want to bring
+
+426
+
+MÂM
+
+« MÂHISKAMOSKANAW, a, (n. f.) trail by which one travels to trade at the fort
+« MÂHUTTEW, ok, (v. n.) he walks to the side which goes down the river
+« MÂHUTTEWIN, a, (n. f.) walking in the direction of the current
+« MÂHUTTAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he brings it, he transports is in the direction of the current
+« MÂHUTTESKANAW, a, (n. f.) trail which goes in the direction of the current
+« MÂHÂBUYEW, (v. a.) TTAW, YIWEW, TCHIKEW, he makes it go down, or, he transports it by water by drifting
+« MÂHÂBOKOW, ok, (a. a.) he goes there by drifting with the current
+« MÂHÂBOTEW, a, (a. in.) idem
+« MÂHUNÂN, a, (n. f.) location, place at the end of a current, at the beginning of a river. N.B. This is how the people of this country refer to York, because it is the place where, in the old days, one went to seek goods by going down the current
+« MÂMIK, (ad.) at the end of a current, at the side at the end, e.g. mâmik ispitchiwok, they set up camp at the side by the end (of the current) mâmik iyiniwok, the savages of the end, mâmik ottuttewok, they arrive at the end
+
+427
+
+MÂK
+
+x MÂHAWÂH! but despite him, see Mâ, as, Mâwiya, e.g. mâhawâh tiyotak, eyiwek kiya mina ki pa toten, himself, he can do it, also yu, you could do it, or, he does it to him well, why not it, could you not? mâhawâh eyamihât, even he prays
+« MÂHOMA, idem, (inan.) e.g. mâhoma ka ikkik, even that happens
+« MÂH EKA! (ex.) it is done! this word is composed of ma above and of eka, a sign of negation, e.g. mâheka ni ka wâbamaw! it is done, I will not see it! mâh eka tchi pimâtisit! it is done, he will not live! see Mânéka
+« MÂKEYAKAM, see Mâwista and Appowiya, e.g. mâkeyakam mâmiyeyât, eka ka wi miyit, now he gives some to someone, and then me, without wanting to give me any, mâkeyakam mâmitjisut eka ja wi-assamit, as he is to eat anyway, why does he give none to me
+« MÂKAHITTAM, idem
+x MAK, (rac.) to place in sorrow, in embarrassment, to press under the hand or foot, to frighten, to seize by fear
+« MÂKOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he encumbers it by pressing it too much, as if squeezing it, he presses it to the end, to the final extremities, e.g. mâkohew o notinâgana, he reduices his enemy to the extremities, mâkohikowisiw, he is as if pressed by God, (he does not know where to flee) tcheskwa ki ka mâkohikun ki matchiayiwin, wait, your bad conduct will lead you to bad things, mistahi kimâkohikmaskwa, a terrible alert has been given to him by a bear. (Usage will provide an understanding of the true meaning of this word, and of all of its derivations)
+
+MÂK
+
+« MÂKOHIWEWIN, a, (n. f.) the action of causing fear, of causing (people) embarrassment
+« MÂKONEW, (v. a.) NAM, NIWEW, NIKEW, he presses it, he clamps it with his hand, he holds it tightly in his hand, mâkonam otchitchiyiw, he tightens his hand on him, namawiya wiya ni ki mâkonikân, I can no longer hold anything with my hand, mâkonikepayiw, he clenches his hands
+« MÂKONIKEWIN, a, (n. f.) clasping with the hands, the action of holding something in the hand and squeezing it
+« MÂKOSKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he presses it under his feet, he tramples it with his feet, e.g kitchitwaw Michel ki mâkuskawew matchi manitowa e matchustehwât, St. Michael tramples the Devil with his feet and threw him into the fire, mâkoskam ajiskiy, he tramples the earth with his feet
+« MÂKWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks it to be encumbered, or, he thinks it able to be made encumbered
+
+428
+
+MÂK
+
+« MÂKWEYITTAM, wok, (v. n.) he is highly embarrassed, he does not know what to do, he is closing in on the game, his wits are tightened, pressed under the weight of fear, in embarrassment or pain, e.g. poni-askiwiyiki mistahi kita mâkweyittamwok omatchi pimâtisiwok, at the end of the word, the wicked will be in a terrible shame, mâkweyittâganiwiw mana ipsi e wi-ninik, one is normally in great spiritually pain when one must die
+« MÂKWEYITTAMOWIN, a, (n. f.) embarrassment, internal pain
+« MÂKEYIMOWIN, a, (n. f.) see Mâkeyittamowin
+« MÂKWÂMOW, ok, (v. n.) he runs away in terror, as if pressed, trampled under fear
+« MÂKWÂMOWIN, a, (n. f.) hasty escape
+« MÂKWATCHIW, ok, (a. a.) he is cold, it is as if he is tightened by the cold
+« MÂKWATCHIWIN, a, (n. f.) being very cold
+« MÂKWÂKKATOSUW, ok, (a. a.) he is pressed by hunger
+« MÂKWÂKKATOTEW, a, (a. in.) it is hardened, pressed, e.g. a piece of leather that is wet, and which when dry, has hardened
+« MÂKWAPPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he attaches it tightly, by pressing it
+« MÂKWAPPISUWIN, a, (n. f.) very tight connection
+
+MÂT
+
+« MÂKWAPPITEW, a, (a. in.) it is connected strongly
+« MÂKUPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he presses it by pulling
+« MÂKUPAYIW, ok, a, (a. a. et in.) it presses itself, it is crowded
+« MÂKWATCHIGANIKAN, a, (n. f.) pincer, pliers
+« MÂKWATCHIGAN, a, (n. f.) a press
+« MÂKWAMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he crushes it with his teeth, he bites it
+« MÂMÂKWAKKEW, ok, (v. n.) he crushes it with his teeth
+« MÂKOKKASWEW, (v. a.) SUWEW, SIKEW, he burns it a lot
+« MÂKOKKASUW, ok, (a. a.) he is very burnt
+« MÂKOKKATTEW, ok, (a. in.) idem.
+x MÂKWA, plural Mâkwok, (n. r.) a loon
+x MAK, (rac.) big, large, wide
+« MAKKIGAMAW, (v. im.) wide basin/pool of water
+« MAKKISTIKWEYAW, (v. im.) wide river
+« MAKKISIW, ok, (a. a.) he is fat, big
+« MAKKISIWIN, a, (n. f.) size, thickness
+« MAKKAW, a, (a. in.) it is big, of large dimensions
+« MAKKISTIKWÂN, a, (n. f.) large head
+« MAKKISTIKWÂNEW, ok, (a. a.) he has a large head
+« MAKKITESKANEW, ok, (a. a.) he has broad horns
+« MAKKIKKWEW, ok, (a. a.) he has a large face
+« MAKKITONEW, ok, (a. a.) he has a large mouth
+
+429
+
+MAK
+
+« MAKKÂPITEW, ok, (a. a.) he has wide teeth
+« MAKKÂBIW, ok, (a. a.) he has large eyes
+« MAKKITTAWOKAY, a, (n. f.) large ear
+« MAKKITTAWOKAYEW, ok, (a. a.) he has large ears
+« MAKKIKWEYAWEW, ok, (a. a.) he has a fat neck
+« MAKKITOTOSIMEW, ok, (a. a.) she has large breasts
+« MAKKITCHITCHEW, ok, (a. a.) he has large hands
+« MAKKIKASEW, ok, (a. a.) he has large claws
+« MAKKÂYOWEW, ok, (a. a.) he has a broad tail
+« MAKKIKÂTEW, ok, (a. a.) he has fat legs
+« MAKKISITEW, ok, (a. a.) he has large feet
+« MAKKATÂTTAM, wok, (v. n.) he breathes a heavy sigh
+« MAKKATÂMOW, ok, (v. n.) idem.
+« MAKKATÂTTAMOWIN, a, (n. f.) heavy sigh
+« MAKKATÂMOWIN, (n. f.) idem.
+« MAKKISKAW, ok, (a. a.) he is enormous, vast
+« MAKKISKAM, wok, (v. n.) the tracks of his path are large, e.g. mishahi ayaw mâmakkiskam, the grey bear has a wide track
+« MAKKISKAMOWIN, a, (n. f.) broad footprint
+« MAKKAK, wa, (n. .f) barrel, bowl, cask; mistahi makkak, a large barrel; e.g. tântatto makkak pakkwejiganak ki wimiyin? how many barrels of wheat do you want to give me? nijo makkak, only two barrels
+
+MAK
+
+« MAKKAKKWÂBISK, wa, (n. f.) iron ring of a barrel, or of a cask
+« MAKKASKAW, a,  (n. f.) hay, broad grass
+« MAKKASKWAW, a, (n. f.) large cloud
+« MAKKÂSKAW, a, (n. f.) large wave, big surge
+« MAKKÂHAN, a, (n. f.) idem
+« MAKUSEHEW, MEW, (v. a.) he invites him, he makes him a large feast, he invites him to eat lots
+« MAKUSEW, ok, (v. n.) he makes him a big feast
+« MAKUSEWIN, a (n. f.) copious feast
+x MAKKAY, ak, (n. r.) expression of contempt; e.g. matchi makkayak! ah! the bad people! winikunewimakkay! ah, the wicked, stinking mouth. THis is the only swear of the savages, with matchastim, bad dog! One also says: makkaye makkay! the bastard!
+« MAKKAYEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he finds him a rascal, a scoundrel
+x MAKKESIS, ak, (n. r.) fox
+x MAKAHITTAWEW, (v. a.) he discovers it, he removes the snow or other thing which covers it. See Pânahwew
+« MAKAHIPÂN, a, (n. f.) instrument which is used for sweeping away, cleaning, shoveling. See Akwâhistkupân
+x MÂMÂSIS, (ad.) to do something without care, without precaution, hastily. See Tebiyâk; e.g. tâpwe mâmâsis kit ojittân, in truth, you are doing it carelessly; mâmâsis masinahikew, he writes without any precaution
+
+430
+
+MÂM
+
+« MANJIMÂTJIW, ok, (v. n.)he acts negligently, without care; e.g. manjimâtjiwok ata e wi-kiskino-hamâketjik, by wishing to teach, they do it harm through negligence; manjimâtjiw kekway tiyotaki, he is very clumsy in what he does
+« MANJIMÂTJIWIN, a, (n. f.) clumsiness, negligence
+x MÂMASKA, (rac.) to admire with awe, to do extraordinary, miraculous things
+« MÂMASKÂTCH! (ex.) it is shocking! it is marvellous! e.g. mâmaskâtch eji-kakebâtisit! it is shocking how crazy he is! mâmaskâtch k'etweyan! what you are saying is shocking; mâmaskâtch ka itâbattamân! what I have seen is marvellous! mâmaskâtch eji-kisopwek! it is strange how hot it is
+« MÂMASKÂTCHIKKIN, (v. im.) it happens in a strange fashion
+« MÂMASKÂTJITCHIKEW, ok, (v. n.) he does marvels
+« MÂMASKÂTJITCHIKEWIN, a, (n. f.) marvel
+« MÂMASKÂTCHAYITTIW, ok, (a. a.) he behaves strangely
+« MÂMASKÂTCHAYITTIWIN, a, (n. f.) strange behaviour
+« MÂMASKÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he finds it strange, he admires it; e.g. ni mâmaskâkâwok iyiniwok eyikok e kitimâkisitjik, I could not help but find it strange how pitiful the savages are; ki mâmaskâtitin ka tottaman, I find you strange for doing that
+
+MÂM
+
+« MÂMASKÂTEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks it shocking, marvellous, strange; e.g. kakiyaw mâmaskâteyimewok e wâbattakik o mâmaskâteyittamak eji-kijewâtisit Jesus, we must be in admiration of the charity of Jesus
+« MÂMASKÂTIKUSIW, ok, (a. a.) he is admirable, stunning
+« MÂMASKÂTIKUSIWIN, a, (n. .) admiration
+« MÂMASKÂTIKWAN, wa, (a. in.) stunning, marvellous thing
+« MÂMASKÂTCHINAWEW, (v. a) NAM, NÂKEW, NÂTCHIKEW, he watches it with amazement, with admiration
+« MÂMASKÂTCHITTAWEW, (v. a.) TTAM, TTÂKEW, TTÂTCHIKEW, he listens to it, he listens to it with admiration
+« MÂMASKÂSITTAWEW, (v. a.) idem
+« MÂMASKÂTCHITTÂKUSIW, ok, (a. a.) he has a strange voice, cry
+« MÂMASKÂTCHITTÂKUSIWIN, a, (n. f.) strange voice, cry
+« MÂMASKÂTCHINÂKUSIW, ok, (a. a.) he has a strange face
+
+431
+
+MÂM
+
+« MÂMASKÂTCHINAKWAN, wa, (a. in.) idem
+« MÂMASKÂTEYITTÂKUSIW, ok, (a. a.) one thinks it strange, admirable
+« MÂMASKÂTEYITTÂKWAN, wa, (a. in.) idem
+« MÂMASKÂTIKOKKÂSUW, ok, (v. n.) he is insolent, he pretends to be something
+« MÂMASKÂTIKOKKÂSUWIN, a, (n. f.) insolence, impudence, trying to pass oneself off as something marvellous
+x MÂMÂPPINEW, ok, (v. n.) he complains of pain
+« MÂMÂPPINEWIN, a, (n. f.) complaint caused by pain
+x MÂMÂT, (rac.) powerful, extraordinary
+« MÂMÂTTÂKUMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he glorifies it, he gives him praise for his powerful
+« MÂMÂTTÂKUSIW, ok, (a. a.) he is glorious, exalted, renowned, e.g. ni ka mâmâttâkusin iyiniwok eyigok kakiyaw ayamihâtwâwi, I will be glorious, when all of the savages pray, tcheskwa omiyopimâtisiwok kita mâmâttâkusiwok kitchi kijikok, a day will come when the righteous will be glorified in the sky
+« MÂMÂTTÂKUSIWIN, a, (n. f.) glory, exaltation
+« MÂMÂTTÂKWAN, wa, (a. in.) it is glorious, it is triumphal, e.g. mâmâttâkwan Katolik ayamihâwin, the Catholic religion is glorious, mâmâttâkwanok, in glory
+
+MÂM
+
+« MÂMÂTTÂWÂKÂTCH! (ex.) it is marvellous, it is miraculous; e.g. mâmâttâwâkâtch ayitotam, he does marvellous things
+« MÂMÂTTAWI-TOTAM, wok, (v. g.) he does marvellous, stunning things, he does miracles
+« MÂMÂTTAWI-IJITJIKEW, ok, (v. n.) he acts marvellously
+« MÂMÂTTAWIPAYIW, ok, a, (a. a. and in.) it happens in a miraculous fashion; e.g. ispi Jesus-Christ ka iskwatâmot, mistahi ki mâmâttawipayiyiw, when Jesus Christ breathed his last breath, amazing things happened
+« MÂMÂTTÂKWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, See. Mâmâttâkumew
+« MÂMÂTTÂWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks it admirable, powerful, marvellous
+« MÂMITTEYIMEW, etc., idem
+« MÂMITTEYITTÂKUSIW, ok, (a. a.) he is worthy of glory, he is glorious; e.g. kita mâmitteyittâkusiw weyottâwimit, etc., glory be to the Father, etc.
+« MÂMITTEYITTÂKUSIWIN, a, (n. f.) glory, exaltation
+« MÂMÂTTÂWIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it powerful, he makes it capable of doing marvellous things; e.g. Kijemanito ki mâmâttâwihew ayamihewiyinwa kita kâssinamowâyit ayisiyiniw omatchitotamowiniyiwa, God has given power to the priests to pardon the sins of men
+
+432
+
+MÂM
+
+« MÂMÂTTÂWIHIWEWIN, a, (n. f.) ability, power which one gives
+« MÂMÂTTÂWIHIKOWIN, a, (n. f.) power which one receives
+« MÂMÂTTÂWIHIKOWISIW, ok, (a. a.) he receives a power from the sky, e.g. ni mâmâttâwihikowisin n'itatchâk kitchi paskewiyak, mina kâwi kita witjewok, I have received the power from on high to leave behind my soul, and to take it anew
+« MÂMÂTTÂWIHIKOWISIWIN, a, (n. f.) power from on high
+« MÂMÂTTAWISIW, ok, (a. a.) he is powerful, supernatural
+« MÂMÂTTAWISIWIN, a, (n. f.) supernatural power
+« MÂMÂTTAWAN, wa, (a. in.) it is supernatural
+« MÂMITJIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he glorifies it, he praises it, he boasts of it
+« MÂMIYOMEW, etc., idem
+« MÂMITJIMIKUSIW, ok, (a. a.) he likes that he is given praise
+« MÂMITJIMOW, ok, (v. r.) he brags, he gives himself praise
+« MÂMITJIMISUW, ok, (v. r.) idem
+« MÂMITJIMOWIN, a, (n. f.) boasting, speaking of one's own esteem
+« MÂMITJIMISUWIN, a, (n. f.) idem
+« MÂMITTISIW, ok, (a. a.) he is proud, vain
+« MÂMITTISIWIN, a, (n. f.) vanity, mad pride
+« MÂMIYÂKÂTJIMOW, ok, (v. n.) big talker, talkative
+
+MÂM
+
+« MÂMIYÂKÂTJIMOWIN, a, (n. f.) speech of useless words
+« MÂMITÂKÂTJIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he annoys him, he tires him with his useless or bizarre speech
+MAMEN, (ad.) from place to place, by location; e.g. mamen piko koniwiw, there is only snow in certain places; mâmamen ni kiskisin, I only remember a part. See Âspis, Âyâspis
+MAMEKKUSIW, ok, (a. a.) he is hard-working, industrious
+« MAMEKKUSIWIN, a, (n. f.) hard work
+MÂMIYWÊ, (ad.) very well, with ease; e.g. ekwa mâmiywe ni pimuttân, at the moment I can walk well; namawiya mâmiywe ni ki kaskihun, it is not with ease that I came to the end; namawiya mâmiywe pimâtisiw, he lives with difficulty; mâmiywe anotch kita ki takusinwok, he could very well arrive today
+MAMEKKUTCHINEW, ok, (a. a.) he is entirely naked, he has no clothes. This can also refer to having bare legs
+« MÂMEKKUTCHINEWIN, a, (n. f.) bareness, nudity
+MÂMESKUTCH, (ad.) alternatively, alternately, sometimes one way and sometimes another. N.B. This is a reduplication of meskutch. See further
+MAMEYÂWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he it suits him to do that to him (be it a good or bad thing). One says: mameyâweyimew eokoni iskwewa, he has bad wishes for this woman
+
+433
+
+MAM
+
+x MAMISIW, ok, (v. n.) he has confidence, he trusts. N.B. This verb, though neutral, is also used for the animate and inanimate; e.g. ni mamisin K. Marie kitchi wi-ayamihestamâwit, I trust in Mary, that she shall finally pray for me; namawiya awiyak ni mamisin kitchi otchikkamâwit, I have nobody whom I can trust to help me; kekway ke mamisiyan eka ayamihayân? How can I put my trust in you if you are not Christian? ni mamisin ni pâskisigan tchi naskwâyân, I trust in my rifle to defend me
+« MAMISIWIN, a, (n. f.) trust, hope in, for, etc.
+« MAMISITOTAWEW, (v. a.) TAM, TÂKEW, TÂTCHIKEW, he places his trust in him, he trusts in him for rescue; e.g. ata kwetakittâyaki ekawiya poni-mamisitotawâtâk Kijemanito, even when in suffering, never cease trusting in God
+« MAMISITOTÂKEWIN, a, (n. f.) trust in someone
+« MAMISITOTAMOWIN, a, (n. f.) trust in something
+« MAMISIWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, like mâmisitotawew
+« MAMISEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, thinking of him, he trusts him
+
+MAM
+
+MAMIK, (ad.) This word is only normally used with negation, e.g. namawiya mamik atuskew, he does not work for the trouble; namawâtch mamik ki pe-ayamihân, you hardly come to pray; namawiya mamik otchi kisiwâsiw, he angers himself over nothing; nama mamik pikiskwew, he says nothing, he says nonsense. See namatchachek
+x MAMWESAKKIW, ok, (v. n.) he removes all of his clothes
+« MAMWESAKKIWIN, a, (n. f.) the action of removing one's clothes
+« MAMWESAKKINEW, (v. a.) he strips him of his clothes, he makes him nude
+« MAMWESAKKIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he removes his clothing, he makes him nude
+x MÂMÂWI, or, MÂMAW, (ad.) together, at the same time, e.g. mâmâwi ayâwok, they are together, ekawiya mâmâwi pikiskwek, do not speak all at once, mâmaw takusinwok, they arrive at the same time, mâmâwi etasitjik, iyiniwok ni kiskeyimâwok, I know all of the savages
+« MÂMÂWIPAYIW, ok, a, (a. a. and in.) it happens at the same time, it comes together
+« MÂMÂWIPAYIWIN, a, (n. f.) coincidence of events
+« MÂMOKKAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he assembles himself, he reunites to attack it, e.g. mâmokkamâwaw e wip-nipahit, we get together to kill him
+
+434
+
+MAM
+
+« MÂMOKKAMÂTUWOK, (v. m.) they get together to help one another, e.g. kiyipan kekway kitchi kijittâk kispin e mâmokkamâtuk, we would do something quickly if we got together to help one another
+« MÂMOKKAMÂTUWIN, a, (n. f.) union to help one another
+« MÂMAWIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he brings it together, he puts it together
+« MÂMÂWAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he places it together
+« MÂMÂWIHITUW, ok, (v. m.) (shameless speech) he commits fornication, mâmâwihituwok, fiunt una caro (they fornicate (lit. 'they do flesh'))
+« MÂMÂMÂWIHITUWIN, a, (n. f.) fornication
+« MÂMÂWINEW, (v. a.) NAM, NIWEW, NIKEW, he puts it together, he brings it together, e.g. mâmâwinam kakiyaw mikiwâppa, he brings together all of the lodges
+« MÂMÂWITISAHWEW, (v. a.) HAM, HUWEW, HIKEW, he leads it (he leads it together)
+« MÂMÂWIYES, (ad.) superlative, the most, very, v.g. mâmâwiyes miyo-pimâtisiw, it is the best living, mâmâwiyes kiya ka sâkihitân, it is you that I like the most, mâmâwiyes ka ayimeyittamân, that which I find the most troubling, mâmâwiyes ka iyinisit, the wisest, ayamihâwin eoko mâmâwiyes ka abatak, religion is the most important thing
+x MAMISKOMEW, (v. a.) TAM, MIWEW, TCHIKEW, he speaks of it, he speaks of him, e.g. awenâ ka mamiskomâyek? what are you talking about? ekawiya eoko mamiskotamuk, don't talk about that
+
+MAM
+
+« MAMISKOTAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he speaks to him, he discusses something with him, e.g. ki wi-mamiskotamâtinâwaw kimotiwin, I want to speak to you about theft, ekawiya eoko kitwâm mamiskotamâwin, do not speak to me about that any longer, manitowi masinahiganik nama mamiskotchikâteyiw kakyiw kekwaya ka mâmâttawi-totak Kijemanito, the marvels that God has done are not all reported in the Bible
+« MÂMAWINÂTCH, (ad.) without looking at it, e.g. someone who comes to interefer in a matter which does not concern them, or who takes that which does not belong to them, (rac.) of mâwineskam, see this root
+MAMETCH, (expression which can only be understood through use); to speak too much in advance, beforehand, or to say something out of time, e.g. mametch kit ayitwân, you speak out of turn too much, you say things which will bring you misfortune, mametch kit ayitoten, you do too much in advance, for example, if someone made a coffin for someone who is not yet dead
++ MANA (rac.) pay attention, be on guard, take care, respect
+« MANÂTJIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he respects it; this also means, he mixes it, he takes care not to waste it, e.g. osâm mistahi ki manâtjihâwok kit emak, you keep your horses too much, mitoni manâtjitta ki masinahigana, take care of your books, nama awiya manatjihew, he has no regard for anyone
+
+435
+
+MAN
+
+« MANÂTJITCHIKEW, ok, (v. n.) he is sparing, careful, he saves
+« MANÂTJITTOWEW, (v. a.) TTWÂKEW, he conserves it for him, he saves it for him
+« MANÂTJIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he respects it, he spares it in his speech. One uses this word to speak of the son-in-law with his stepfather and stepmother who are ashamed to speak with him, manâtjittuwok, they do not speak with each other
+« MANÂTJIMÂGAN, ak, (n. f.) that which one does not speak of due to shame, such as the son-in-law with his step-mother and his stepfather, and vice versa, e.g. namawiya ni ki ayamihâwok ni manâtjimâganak, I do not dare speak of those which I spare
+« MANÂTOTAWEW, (v. a.) TAM, TÂKEW, TÂTCHIKEW, he treats it with regard, respect, e.g. manâtotaw kiseyiniw, treat the elder with respect, tâpwe nama ki manâtoten, in truth, you do not take care in what you do
+« MANÂTISIW, ok, (a. a.) he is respectful, polite, he takes care in his behaviour
+
+MAN
+
+« MANÂTISIWIN, a, (n. f.) respect, politeness. N.B. One may follow in this pattern placing manâ before many words which can come together, e.g. mana kimoti, mana kiyâski, be on guard against theft, be on guard against lying, nama mana matchi itwew, he does not take caution when speaking, mana pikiskwâniwan konata ayamihewikamikok, one takes guard against speaking uselessly in the church
+x MAN, (rac.) take from, etc., take off, pull off, etc.
+« MANAHUW, ok, (v. n.) he takes for him
+« MANAHUWIN, a, (n. f.) appropriation, spoils
+« MANAHIGAN, a, (n. f.) that which one lifts off, the cream
+« MANAHWEW, (v. a.) HAM, HUWEW, HIKEW, he lifts it off, as if removing the cream
+« MANAHIPIMEW, ok, (v. n.) he skims off the floating fat
+« MANAHIPIMEWIN, a, (n. f.) the action of skimming off the fat
+« MANAHIPIMÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he takes the cream from it
+« MANINEW, (v. a.) NAM, NIWEW, NIKEW, he lifts it off with his hand
+« MANIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he lifts it off using his arms, he pulls it off
+« MANIKKUMÂNEW, ok, (v. n.) he takes a knife, he arms himself with a knife
+« MANITCHIKAHIGANEW, ok, (v. n.) he takes an axe
+
+436
+
+MAN
+
+« MANÂSKWEW, ok, (v. n.) he arms himself, he takes up arms
+« MANASKWEWIN, a, (n. f.) arms, defense
+« MANÂSKWETOTAWEW, (v. a.) TAM, TÂKEW, TÂTCHIKEW, he arms himself, he defends himself against him
+« MANAYAPEW, ok, (v. n.) he checks on his net
+« MANAYAPEWIN, a, (n. f.) the action of, etc.
+« MANAKISTEW, (v. a.) TAM, SIWEW, TCHIKEW, he serves him food
+« MANAKISUW, ok, (v. n.) he shares his food
+« MANAKISUWIN, a, (n. f.) sharing of food
+« MANAHISKIWEW, ok, (v. n.) he collects gum
+« MANAHISKIWEWIN, a, (n. f.) action of collecting, etc
+« MANASKUSIWEW, ok,(v. n.) he cuts the hay
+« MANASKUSIWEWIN, a, (n. f.) the action of cutting hay
+« MANASKUSIWÂGAN, a, (n. f.) instrument for cutting hay, scythe
+« MANÂWEW, ok, (v. n.) he collects eggs
+« MANÂWEWIN, a, (n. f.) hunting for eggs
+« MANÂWÂN, a, (n. f.)place where one collects eggs
+« MANIKKWAMIW, ok, (v. n.) he lifts the bark off of a tree
+« MANIKKUMÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he lifts off his bark
+
+« MANIKKWÂMIWIN, a, (n. f.) the lifting off of bark
+« MANATCHISTEW, (v. a.) TAM, SIWEW, TCHIKEW, he takes his spoils. N.B. This is used when speaking of returning from war, to take the spoils of one's enemy
+« MANISWEW, (v. a.) SAM SUWEW, SIKEW, he cuts it with scissors or a knife, (also, to neuter, castration)
+« MANIKKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he cuts off a piece with the axe
+« MANISIKEWIN, a, (n. f.) the action of cutting, (harvest)
+« MANISIGAN, a, (n. f.) instrument for cutting, sickle
+« MANIKWEYÂWESWEW, (v. a.) SAM, SUWEW, SIKEW, he cuts his neck
+« MANIPAYIW, ok, a, (a. a. and in.) he pulls himself from, etc., he detaches himself from, etc.
+« MANISOWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he cuts him
+« MANISTIKWÂNESWEW, (v. a.) SAM, SUWEW, SIKEW, he cuts at his head, he removes his head
+« MANIWATEW, (v. a.) TAM, SIWEW, TCHIKEW, he loots him, he takes his weath after having killed him
+« MANITAWÂGANEW, ok, (v. n.) he amasses pelts
+« MANESIW, ok, (a. a.) he is poor, he lacks, etc.
+« MANEWISIW, ok, (a. in.) idem
+« MANEWAN, wa, (a. in.) it is poor, sterile
+
+
+
+
+
+« MANESIWIN, a, (n. f.) poverty, need, the state of want
+x MÂNÂ (ad.) ordinarily, (this is a most commonplace word in the Cree language, and is perpetually on one's mouth.)
+« MÂNÂ MÂKA, (ad.) certainly
+« MÂNÂPIKO, (ad.) one says that, etc., etc., e.g. mânâpiko wi-mispun, one would say that is is going to snow, mânâpiko eoko, one says well that it is him
+« MÂNEKA! (ex.) disappointment, maneka kitchi pimâtisit! it is over, he will not live! mâneka ni ka wâbamaw! it is over, I will not see it!
+« MÂNÉ (ad.) see Mânâpiko, etchikâni, miyâmaw
+« MANOM-Â! (ex.) too much! e.g. mano-mâ kimiwanoban! it is raining a bit too much; it is still going to rain for a bit
+« MÂNINAKISK! (ad.) and then, again and again, comprised of mâni and nakisk, it is not for an instant
+« MANINÂK-ITUKE! maninâk na? maninâk tchi? (ex.) is it possible! would it be possible? it is not possible! e.g. maninâk tchi ki ka pakamahuk? would it be possible for him to hit you? see. Wesâmik
++ MANITO, (rac.) divine, supernatural, divine spirit, e.g. Kijemanito, the perfect spirit, God, matchi Manito, the evil spirit, the Devil
+« MANITOWIW, ok, (a. a.) he is divine, supernatural, he is God, e.g.
+« MANITOWAN, wa, (a. in.) it is supernatural, divine, e.g. ayamihewijittwâwin iyeppine manitowan, the religion is very divine
+
+« MANITOWIWIN, a, (n. f.) divinity, kijemanitowiwin
+« MANITOWÂTISIW, ok, (a. a.) he is religious, devout
+« MANITOWÂTAM, wa, (a. in.) idem, e.g. eoko masinahigahigan manitowâtan, this book is religious, devout
+« MANITOWÂTISIWIN, a, devotion, piety
+« MANITOKKEW, ok, (v. n.) he worships idols
+« MANITOKKEWIN, a, (n. f.) idolatry
+« MANITOKKÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he adores it, or rather, he deifies it, he makes it a god
+« MANITOKKÂSUW, ok, (v. n.) he makes it divine, he performs spells, superstitions, he does juggling
+« MÂNITOKKÂSUWIN, a, (n. f.) spell, juggling, superstitions
+« MANITOKKÂN, a, idol, amulet
+« MANITOWOKOSISSÂN, ak, (n. f.) the sons of God
+« MANITOWÂKÂTCH, (ad.) divinely, supernaturally
+« MANITOBA, for Manitowapaw, or, in Salteaux, Manitowabân, supernatural, divine strait, This is the name given to the new province of the Red River
+« MANITOWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks it God, divine
+« MANTIOWEYITTAMOWIN, a, (n. f.) supernatural thought
+
+438
+
+MÂN
+
+« MANITOWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he has it as a God
+« MANITOWOKEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he believes it to be God
+« MANITOWOKEYIMOW, ok, (v. r.) he thinks himself divine, capable of the supernatural
+« MANITOWOKEYIMOWIN, a, (n. f.) the action of believing oneself divine
+« MANITOWATÂMOW, ok, (v. n.) he sings in a superstitious fashion
+« MANITOWATÂMOWIN, a, (n. f.) superstitious song
+« MANITOWEGIN, wa, (n. f.) supernatural sheet, fabric
+« MANITOPIWÂBISK, wa, (n. f.) steel, divine iron
+« MANITOSKÂTÂSK, wok, (n. f.) supernatural root, moreau carrot (poison)
+« MANITOWEYÂN, ak, (n. f.) cover sheet
+« MANITUS, ak, (n. f.) insect
+« MANITOWIMASINAHIGAN, a, (n. f.) Holy Scripture, the divine book
+« MANITOMIN, ak, (n. f.) black seed
+« MANITOMINÂTTIK, wa, (n. f.) tree with a black seed. N.B. By placing the root manito before nouns or suffixes, coming together, one can form a multitude of words which refer to divinity
++ MÂNOTEW, ok, (v. n.) he goes walking in another place, omânotewiw, he is a walker, omânotekkawew, he goes walking to his place
+
+MÂN
+
+« MÂNOTEWIN, a, (n. f.) a walk
++ MÂSIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he scuffles with him, he fights with him
+« MÂSITTAW, ok, (v. n.) he works at that
+« MÂSIHITUWOK,(v. m.) they fight physically
+« MÂSIHITUWIN, a, (n. f.) physical fight
+« MÂSIKKEW, ok, (v. n.) he grabs his body
+« MÂSIKKEWIN, a, (n. f.) grabbing hold of the body
++ MANISTÂN, ak, (n. r.) sheep
+« MANISTÂNIS, ak, (n. f.) lamb
++ MÂNOKEW, ok, (v. n.) he fixes the tent, the lodge in place
+« MÂNOKEWIN, a, (n. f.) the action of fixing in place,  etc., the tent
+« MÂNOKÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he plants it, e.g. a tent, a lodge
+« MANSIKISK, ak, (n. f.) cedar, cypress
+« MANSIKISKAW, (v. im.) there are many cedars
+MASAKAY, a, (n. r.) skin of the human body, n'asakay, my skin, wasakay, his skin
+MASÂN, ak, (n. r.) nettle
+MASANAK, (ad.) on all side, from all direction
++ MASASK, (rac.) strip completely, shave
+« MASASKUNEW, (v. a.) NAM, NIWEW, NIKEW, he strips it completely
+
+439
+
+MAS
+
+« MASASKUYAWEW, etc. idem
+« MASASKUPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he tears it off entirely
+« MASASKUKKASWEW, (v. a.) SAM, SUWEW, SIKEW, he burns it entirely
+« MASASKUKKASUW, ok, (a. a.) he is all burned
+« MASASKUKKATEW, ok, (a. in.) idem
+« MASASKUKKUSIN, wok, (a. a.) he is completely broken
+« MASASKUKKUTTIN, wa, (a. in.) idem
+« MASASKUPAYIW, ok, a, (a. a. and in.) completely destroyed, shaven
+x MASIN, (rac.) to write, to draw lines, to paint, to make marks on paper
+« MASINAHWEW, (v. a.) HAM, HUWEW, HIKEW, he writes it, he marks it
+« MASINAHIKEW, ok, (v. n.) this word has many meanings; 1) he writes; 2) he takes credit; 3) he is committed, busy. The rest of the sentence always makes it clear which meaning is being used, e.g. kwayask ki masinahikân, you write well, mistahi ki masinahikân, you are quite indebted, taneyikok isko ki masinahikân, until what time are you busy?
+« MASINAHIKEWIN, a, (n. f.) writing, debt, commitment
+« MASINAHIKEHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes him write, he makes him take credit, he commits him
+
+MAS
+
+« MASINAHIGAN, a, (n. f.) book, letter
+« MASINAHIGANÂTTIK, wa, (n. f.) pencil
+« MASINAHIGANÂBISKUS, a, (n. f.) iron plume pen, slate pencil
+« MASINAHIHANÂBUIY, a, (n. f.) ink
+« MASINAHIGANEGIN, wa, (n. f.) paper
+« MASINAHIKEWIYINIW, ok, (n. f.) writer, scribe
+OMASINAHIKESIS, ak, (n. f.) clerk
+« MASINAHAMÂTUWIN, a, (n. f.) reciprocal trading of letters
+« MASINÂSUW, ok, (a. a.) he has marks, he is multi-coloured, for example, a spotted horses
+« MASINÂSUWATIM, wok, (n. f.) a quail horse
+« MASINÂSTEW, a, (a. in.) there are different colours, it is flowery
+« MASINÂSUWIN, a, (n. f.) mark, colour
+« MASINAHIKÂSUW, ok, (a. a.) he is written, painted
+« MASINAHIKÂTEW, a, (a. in.) it is written, painted
+« MASINAHIKÂKKEW, ok, (v. n.) it is written with, or by means of, etc.
+« MASINAHAMÂKEWIN, a, (n. f.) credit to someone, a letter
+« MASINEGIN, wa,  (n. f.) paper, indian paper
+« MASINÂSKISWEW, (v. a.) SAM, SUWEW, SIKEW, he stamps it, he marks it with fire
+
+440
+
+MÂS
+
+« MASINÂSKISIGAN, a, (n. f.) instrument for stamping
+« MASINÂSKISIKEWIN, a, (n. f.) stamp
+« MASINISTAHWEW, (v. a.) HAM, HUWEW, HIKEW, he describes it, he does it in flowers, he embroiders it
+« MASINIKWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he embroiders it with a needle
+« MASINIKWÂTCHIGANEYÂPIY, a, (n. f.) straigh ribbon, a sort of large thread for embroidering, (miret)
+« MASINIKKUTEW, (v. a.) TAM, SIWEW, TCHIKEW, he cuts it off, he sculpts it
+« MASINIKKWEHWEW, (v. a.) HAM, HUWEW, HIKEW, he paints his face
+« MASINIKKWEHUSUW, ok, (v. r.) he paints his own face
+« MASINIPEHWEW, (v. a.) HAM, HUWEW, HIKEW, he paints it
+« MASINIPEHIGAN, a, (n. f.) painting
+« MASINIPEHIGANÂTTIK, wa, (n. f.) paintbrush
+« MASINISÂWÂN, a, (n. f.) model, painted patron, e.g. on paper
+x MÂSK, (rac.) infirm, defective
+« MÂSKISIW, ok, (a. a.) he is infirm
+« MÂSKAW, a, (a. in.) he is defective, deformed
+« MÂSKISIWIN, a, (n. f.) infirmity, derformity
+« MÂSKIPAYIW, ok, a, (a. a. and in.) he is lame 
+
+MÂS
+
+« MÂSKIGAN, a, (n. f.) deformed bone, stomach; n'âskigan, my stomach, wâskigan, his stomach
+« MÂSKIGANEW, ok, (a. a.) he is infirm in his stomach
+« MÂSKAKKÂN, a, (n. f.) worn out, broken down tool, which is no longer good for anything
+« MÂSKIKÂTEW, ok, (a. a.) he is infirm in his legs, he is lame
+« MÂSKIKIW, ok, (a. a.) he believes in defects, he grows up infirm
+« MÂSKIKIN, wa, (a. in.) idem
+« MÂSKIPITUNEW, ok, (a. a.) he has an infirm arm
+« MÂSKISITEW, ok, (a. a.) he has an infirm foot
+« MÂSKITCHITCHEW, ok, (a. a.) he has an infirm hand
+« MÂSKINITTÂWIKIW, ok, (a. a.) he is born with a deformity
+« MÂSKISK, ak, (n. f.) cedar. See. mânsikisk
+x MASKAMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he loots it, he strips it
+« MASKATCHIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, idem, he takes it off him by violence
+« MASKATCHIHIWEWIN, a, (n. f.) pillaging, action of taking things by violence
+« MÂSKATTWEW, ok, (v. n.) he takes (it) by force
+« MASKATTWEWIN, a, (n. f.) taking by force
+x MASKAW, (rac.) strong, solid, hard, etc.
+« MASKAWISIW, ok, (a. a.) he is strong
+« MASKAWISIWIN, a, (n. f.) strength
+
+441
+
+MAS
+
+« MASKAWAW, a, (a. in.) it is strong, solid
+« MASKAWÂGAMIW, a, (v. im.) it is a strong liquor
+« MASKAWÂKUNAKAW, (v. im.) the snow is strong, hard
+« MASKAWÂPEGAN, wa, (a. in.) it is strong, solid, speaking of rope, thread, etc.
+« MASKAWÂPISKUSIW, ok, (a. a.) he is strong, resistant, (speaking of metal)
+« MASKAWÂPISKAW, a, (a. in.) it is a solid metal
+« MASKAWÂSKUSIW, ok, (a. a.) it is a strong, solid wood
+« MASKAWÂSKWAN, wa, (a. in.) idem
+« MASKAWÂTTIK, wok, wa, (n. f.) hardwood, oak
+« MASKAWÂTISIW, ok, (a. a.) he has a strong character
+« MASKAWÂTISIWIN, a, (n. f.) strength of character
+« MASKAWAHYEW, (v. a.) STAW, HYIWEW, TCHIKEW, he places it firmly
+« MASKAWIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it strong
+« MASKAWIKKASWEW, (v. a.) SAM, SUWEW, SIKEW, he hardens it by fire
+« MASKAWIKKASUW, ok, (a. a.) he is hardened by fire
+« MASKAWIKKATTEW, a, (a. in.) it is hardened by fire
+« MASKAWEYIMEW, (v. a.) he thinks it strong
+« MASKAWEYITTAM, wok, (v. n.) he is resolved, strongly decided
+
+MAS
+
+« MASKAWEYITTAMOWIN, a, (n. f.) decisive resolution
+« MASKAWIPIWÂBISK, wa, (n. f.) steel, hard iron
+« MASKAWITEHEW, ok, (a. a.) he has a hard heart
+« MASKAWITEHEWIN, a, (n. f.) hardness of the heart
+« MASKAWITEHEHEW, etc., he hardens his heart
+« MASKAWISKIWOKAW, (v. im.) mud, gum, hard liquid
+« MASKAWATCHIW, ok, (a. a.) he is hardened by the cold
+« MASKAWATIN, wa, (a. in.) it is hardened by the cold
+« MASKAWATIMEW, (v. a.) TTAW, MIWEW, TCHIKEW, he hardens it by the cold
+x MASKWA, (in plural.) maskwok, (n. r.) bear
+« MASKWEYÂN, ak, (n. f.) bearskin. N.B. The sufffix ask always indicates bear; e.g. osâwask, yellow bear; wâbask, white bear
+« MASKOMIN, a, (n. f.) bear seed
+x MASKIKKIY, a, (n. r.) medicine, root, herb
+« MASKIKKIWIYINIW, ok, (n. f.) doctor
+« MASKIKKIWIYINIWIW, ok, (a. a.) he is a doctor
+« MASKIKKIWIPAK, wa, (n. f.) medicinal leaf
+« MASKIKKIWOGAN, wa, (a. in.) the smell of medicine
+« MASKIKKIWÂBUIY, a, (n. f.) medicinal soup, this is what the savages call teach
+
+442
+
+MAS
+
+MASKIKIWIPOKWA, (n. f.) tea leaf
+x MASKIMUT, a, (n. r.) bag, pocket. N.B. The suffix wat indicates a bag; e.g. mistatimowat, horse bag, mistikowat, wooden bag, box
+« MASKIMUTTIKKEW, ok, (v. n.) he makes a bag
+x MASKISIN, a, (n. r.) shoe
+« MASKISINIKKEW, ok, (v. n.) she makes shoes
+« MASKISINIKKAWEW, (v. a.) she makes shoes for him
+x MASKUSIY, a, (n. r.) hay, grass
+« MASKUSIKKEW, ok, (v. n.) he makes hay
+« MASKUSIKKÂN, a, (n. f.) grindstone for hay (mill)
+« MASKUSIWIN, a, (n. f.) wild oats, wild rice
+« MASKUSISKAW, (v. im.) there is plenty of hay
+« MASKUSIWIKAMIK, wa, (n. f.) hayshed
+« MASKUSIWASTOTIN, a, (n. f.) straw hat, or hay hat
+x MASKUTEW, a, (n. r.) prairie; paskwaw, desert
+« MASKUTEWIW, ok, a, (a. a. and in.) there is a prairie
+« MASKUTEWAN, wa, (a. in.) idem
+« MASKUTEWIYINIW, ok, (n. f.) man of the prairies
+« MASKUTEWIMUSTUS, wok, (n. f.) prairie cow, buffalo
+x MASKEK, wa, (n. r) swamp, marsh, trembling ground, savannah
+« MASKEKOWIW, a, (a. in.) or, maskekaskaw, there is a swamp
+
+MAS
+
+« MASKEKOWIYINIW, ok, (n. f.) man from the swamps, the Maskêgons, or, Maskekowok
+« MASKEKOPAK, wa, (n. f.) leave of the swamps, savage tea
+« MASKEKOWASKAMIK, wa, (n. f.) savannah moss
+MÂSKUTCH, (ad.) perhaps
+x MASTA (rac.) afterwards
+« MASTAW, (ad.) afterwards, since, after; e.g. mastaw takusin, he arrives after. See mwestes
+« MASTAMEW, ok, (v. n.) he passes there afterwards, as if someone already passed by a trail and somebody else passed there after them
+« MASTATTEW, (v. a.) TTAW, he passes there after him. (The three following rots are often used in shameless speech)
+x MATEW, (v. a.) facit actum coitus cum ea (he performs coitus with him/her)
+« MASIWEW, ok, (v. n.) facit illud. (the act of doing so (coitus))
+« MASIWEWIN, a, (n. f.) copulatio, fornicatio (copulation, fornication)
+MÂSKWEMUTÂS, a, (n. r.) bag made from the entire pelt of an animal, without sewing
+x MÂTÂMEW, ok, (v. n.) he arrives, he falls on a track
+MÂTÂWISIW, ok, (v. n.) he falls, he arrives on the path
+MÂTÂHEW, (v. a.) TTAW, he falls on his tracks, his footprints
+MÂTÂTTUYUW, ok, (v. n.) he arrives on a track
+MÂTÂBESTKUTEWEYAW, (n. f.) prairie which is jutting out (Mission of Saint Paul to the Cree)
+x MÂTAHIKEW, ok, (v. n.) she scrapes, she removes the hair from the skin
+
+443
+
+MÂT
+
+« MÂTAHIGAN, a, (n. f.) scraper, instrument for removing hair
+« MÂTAHWEW, (v. a.) HAM, HUWEW, HIKEW, he strips the hair off of it by scraping
+« MÂTTAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he gives him his loot, his effects, as a gift
+« MÂTTAHITUWOK, (v. m.) they exchange their belongings
+« MÂTTAHITUWIN, a, (n. f.) mutual gifts
+MÂTAYAK, (ad.) quickly, promptly. See Kiyipa.
+MATÊ! (ex.) let's see! let's go! e.g. matê! kutchitota, let' see! try to do it; matê! ekwa sipwettetâk, let's see! let's go now! matê! ni ka wâbatten, let's go! I'm going to see it
+MATAY, a, (n. r.) belly, n'atây, my belly; watây, his belly, mistatayew, ok, he has a big belly
+x MÂTIN, (rac.) to share
+« MÂTINAWEW, ok, (v. n.) he shares food, or, manakisuw, ok
+« MÂTINAWEWIN, a, (n. f.) the sharing of food
+« MÂTINAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he shares with him, he divides with them in equal portions
+« MÂTINAMÂKEWIN, a, (n. f.) share, division
+MÂTAKUSKAWEW, (v. a.) KÂKEW, KAM, KÂTCHIKEW, he tramples him with his feet
+x MÂTCH, (rac.) to begin
+« MÂTCHIPAYIW, ok, a, (a. a. and in.) he (it) begins
+
+MÂT
+
+« MÂTCHIPAYIHEW, (v. a.) TTAW, HIWEW, HIKEW, he begins it
+« MÂTCHIHEW, etc., idem
+« MÂTCHI-ATUSKEW, ok, (v. n.) he begins to work
+« MÂTCHI-MITJISUW, ok, (v. n.) he begins to eat. So on, using the root mâtchi
+« MÂTCHIPAYIWIN, a, (n. f.) beginning
+MÂTJISTAN, (v. im.) the ice leaves and drifts into a river. One says pakkuskwâhan for a lake
+x MÂTISWEW, (v. a.) SAM, SUWEW, SIKEW, he makes an incision on him
+« MÂTISOWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, idem
+x MÂTJIW, ok, (v. n.) he goes hunting
+« MÂTJIWIN, a, (n. f.) hunting
+« MÂTJIPITCHIW, ok, (v. n.) he goes hunting in a group, by moving camp
+« MÂTJIPITCHIWIN, a, (n. f.) large hunt, by all of a camp
+x MÂTJIW, ok, (v. n.) he moves, he changes place
+« MÂTJISTAWEW, etc., (v. a.) he moves it
+« MÂTTAPIW, ok, (v. n.) he changes position
+« MÂTTAPIWIN, a, (n. f.) changing position
+« MÂTCHIKÂBAWIW, ok, (v. n.) he changes position, while standing
+« MÂTTINEW, (v. a.) NAM, NIWEW, NIKEW, he changes its position
+x MÂTAPPINEWIN, a, (n. f.) beginning of a sickness
+
+444
+
+MAT
+
+« MÂTAPPINEW, ok, (v. n.) he begins to be sick
+« MÂTAMATCHIHUW, ok, (v. n.) he begins to feel pain
+x MATTÂMIN, ak, (n. r.) Indian wheat, corn
+« MATOKAP, a, (n. r.) old encampment
+x MATOTISIW, ok, (v. r.) he makes himself sweat, he takes a steam bath
+« MATOTISÂN, a, (n. f.) or , matotisânikamik, sweat cabin, sweat lodge
+« MATOTISIKKEW, ok, (v. n.) he prepares a sweat lodge
+« MATOTISIKKAWEW, etc., (a. a.) he prepares him a sweat tent, he makes him a sweat lodge
+MATCHIMUTÂWIN, a, (n. f.) bravery
+« MATCHIMUTAW, ok, (a. a.) it is a brave, a soldier, okitchitaw, ok
+x MATCH, (rac.) bad, ill, of a bad kind. This is the same meaning as mây
+« MATCHÂYIWIW, ok, (a. a.) he is cruel, a sinner
+« MATCHÂYIWIWIN, a, (n. f.) cruelty, sin, fault
+« MATCHÂYIWAN, wa, (a. in.) it is bad
+« MATCHÂTISIW, ok, (a. a.) he has a bad character
+« MATCHÂTISIWIN, a, (n. f.) bad character
+« MATCHÂTJIMOW, ok, (v. n.) he tells bad news
+« MATCHÂTJIMOWIN, a, (n. f.) bad news
+
+MAT
+
+« MATCHÂBISKUSIW, ok, (a. a.) badly made iron
+« MATCHÂBISKWAN, wa, (a. in.) idem
+« MATCHÂSKUSIW, ok, (a. a.) badly made wood, tree, bad wood
+« MATCHÂSKWAN, wa, (a. in.) idem
+« MATCHÂSPINEW, ok, (a. a.) he has a bad sickness
+« MATCHÂSPINEWIN, a, (n. f.) bad sickness
+« MATCHÂTTIK, wa, (n. f.) bad tree
+« MATCHEGIN, wa, (n. f.) tent, lodge
+« MATCHEYITTÂKUSIW, ok, (a. a.) his is dishonoured, he has no honour
+« MATCHEYITTÂKWAN, wa, (a. in.) it is vile, base, reprehensible
+« MATCHEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he despises him, he disdains him
+« MATCHEYITTAMOWIN, a, (n. f.) contempt, disdain
+« MATCHEYIMIWEWIN, a, (n. f.) idem
+« MATCHI-ATCHÂK, wok, (n. f.) bad spirit
+« MATCHI-ÂTJIMEW, etc., he speaks ill of him
+« MATCHI-AYIMWEW, ok, (v.n.) he speaks ill
+« MATCHI-AYIMWEWIN, a, (n. f.) negative gossip
+« MATCHI-AYIMOMEW, etc., he speaks ill of him
+« MATCHI-ÂBATJIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he is in bad use, he makes it profane
+
+445
+
+MAT
+
+« MATCHI-ITWEW, ok, (v. n.) he speaks ill, he blasphemes
+« MATCHIPAYIW, ok, (a. a. and in.) it goes badly
+« MATCHIPAYIWIN, a, (n. f.) bad business
+« MATCHIHUW, ok, (v. n.) he does not succeed
+« MATCHIHUWIN, a, (n. f.) bad success
+« MATCHIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he does him wrong, he abuses him
+« MATCHIKIJIKAW, a, (n. f.) bad day, bad weather
+« MATCHIKOSISSÂN, ak, (n. f.) bad son
+« MATCHIKOSISSÂNIWIW, ok, (a. a.) he is a bad son
+« MATCHINÂKUSIW, ok, (a. a.) he has a bad appearance
+« MATCHINÂKWAN, wa, (a. a.) idem
+« MATCHIKKWEW, ok, (a. a.) he has a bad face
+« MATCHIKKWEYIW, ok, (v. n.) he grimaces
+« MATCHIMÂKUSIW, ok, (a. a.) he has a bad odour
+« MATCHIMAKWAN, wa, (a. in.) idem
+« MATCHIMITONEYITCHIGAN, a, (n. f.) bad thought
+« MATCHIMITONEYITTAM, wok, (v. n.) he has bad thoughts
+« MATCHIMITONEYIMEW, etc., (v. a.) he thinks badly on his account
+« MATCHI-MANITOW, ok, (n. f.) the Devil, demon
+« MATCHI-MANITOWIW, ok, (a. a.) he is diabolical
+
+MAT
+
+« MATCHI-MANITOWAN, wa, (a. in.) idem
+« MATCHIPOKUSIW, ok, (a. a.) he has a bad taste
+« MATCHIPOKWAN, wa, (a. in.) idem
+« MATCHIPOKUSIWIN, a, (n. f.) bad taste
+« MATCHISPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he finds a bad taste
+« MATCHITEHEW, ok, (a. a.) he has a bad heart
+« MATCHITEHEWIN, a, (n. f.) bad heart, cruelty
+« MATCH'ITTIW, ok, (v. n.) he behaves badly, he sins
+« MATCH'ITTIWIN, a, (n. f.) bad behaviour, sin
+« MATCHITONEW, ok, (a. a.) he has a bad tongue
+« MATCHITONEWIN, a, (n. f.) bad language
+« MATCHITOTAM, wok, (v. n.) he does bad (things), he sins
+« MATCHITOTAMOWIN, a, (n. f.) doing bad things, sin
+« MATCHITOTAWEW, etc., (v. a.) he does him wrong, badly
+« MATCHITTWAW, ok, (a. a.) he has a bad way of acting
+« MATCHITTWÂWIN, a, (n. f.) bad way of behaving oneself
+« MATCHIW, ok,, (a. a.) or, matchiwiw, ok, he is bad
+« MATCHAN, wa, (a. in.) it is bad
+« MATCHIKONÂS, ak, (n. f.) bad lad, good-for-nothing
+« MATCHIKONÂS, a, (n. f.) filth, sweepings
+
+446
+
+MÂT
+
+« MATCHIKONÂSIWIW, ok, (a. a.) it is a bad gas
+« MATCHIKONÂSIWAN, wa, (a. in.) it is rubbish
+« MATCHASTIM, wok, (n. f.) bad dog! (word used to judge, or, insult someone)
+« MATCHIKASTEW, ok, (a. a.) he is proud, boastful, arrogant
+« MATCHIKASTEWIN, a, (n. f.) boastfulness, arrogance
+« MATCHUTEPAYIW, ok, a, (a. a. and in.) he falls, he throws himself into the fire
+« MATCHUSTEHWEW, (v. a.) HAM, HUWEW, HIKEW, he throws it into the fire
+« MATCHUSTEWEBINEW, (v. a.) NAM, NIWEW, NIKEW, idem
+« MATCHAKIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he condemns him
+« MATCHAKIMIWEWIN, a, (n. f.) condemnation
+MÂTJIKUTITÂN! (ex.) you will see! e.g. mâtjikutitân! namawiya kita pekiwew, you shall verily see, he will not return, mâtjikutitân! ki ka wâbatten, wait! you will see
+« MÂTJIKUTJI! idem
+MÂTJIKA! , or, MÂTIKA! ah! see! I told you so, e.g. mâtjika! namawiya, ayiman, ah, see! I told you it wouldn't be so bad
++ MÂTUW, ok, (v. n.) he cries
+« MÂTUWIN, a, (n. f.) the action of crying
+« MOHEW, (v. a.) HIWEW, he makes him cry
+
+MÂW
+
+« MÂWIKKÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he cries for him, he cries about him
+« MÂWIKKÂSIWEW, ok, (v. ind.) he cries for deaths, etc. N.B. This is used when someone wishing to form a war party cries for the warriors, their parents killed by the enemy
+« MÂWIKKÂSIWEWIN, a, (n. f.) crying for the dead
+« MÂWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks of it sorrowfully
+« MÂWIMOW, ok, (v. n.) he laments by weeping
+« MÂWIMOWIN, a, (n. f.) lamentation
+« MÂWIMUSTAWEW, (v. a.) TAM, TÂKEW, TCHIKEW, he begs her by weeping
+« MAWIMUSTCHIKEW, ok, (v. indef.) he begs, he prays
+« MÂWIMUSTCHIKEWIN, a, (n. f.) supplication, prayer
++ MATTONÉ, (rac.) without reason, for no reason
+« MATTONEHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he attacks him for no reason
+« MATTONEHWEW, (v. a.) HAM, HUWEW, HIKEW, he hits him for no reason, e.g. he unleashes his anger on someone who is not at fault
+« MATTONEMEW, etc., (v. a.) he attacks him, he argues that he is wrong, though he knows that he is not at fault
+« MATTONEWOKEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, v.g. Kijemanitowa mattonewokeyimew, he attacks God for the evil that has befallen him, mattonewokeyittam ayamihâwin, he accuses religion
+
+447
+
+MAT
+
+« MATTONETOTAWEW, etc., see. Mattonehew
++ MATWÂN,? (ad.) I do not know if? e.g. matwân anotch kita pekikew, I do not know if he will return today
+« MATWÂN TCHI? idem, e.g. matwân tchi miweyittam? I do not not if he is happy
+« MATWE? idem, e.g. matwân ni ka miyaw, I am not sure if I will give it to him
+« MATOTÂNI? idem, e.g. matwân kita totam? I do not know if he will do it, matwân tchi anotch kita takusin? I have my doubts that he will arrive today, matwe wi-ayamihaw? (irony) it is to be believed that he wishes to pray, matotâni ni ka miyik? I do not know if he will want to give it to me, as a response to: matwân tchi, I am not sure
++ MATWE, to hear, one says
+« MATWEPAYIW, ok, a, (a. a. and in.) he (it) makes a noise by a blow, a jolt
+« MATWEHWEW, (v. a.) HAM, HUWEW, HIKEW, he makes him make a sound, a noise by hitting him
+« MATWEKKASUW, ok, (a. a.) the noise of crackling fire
+« MATWEKKATTEW, (a. in.) idem
+« MATWETJIWAN, (v. im.) the noise of water flowing
+« MATWEKITOW, ok, (v. n.) one hears neighing, bellowing, crying
+
+MAT
+
+« MATWEMÂTUW, ok, (v. n.) one hears crying
+« MATWEMEW, (v. a.) TTAM, etc., he bites, making a noise with his teeth
+« MATWEKKWÂMIW, ok, (v. n.) he snores while sleeping
+« MATWESKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he makes him make a sound by placing his foot on him
+« MATWESKWATCHIW, ok, (a. a.) e.g. a tree or ice which sounds out when splitting from the cold
+« MATWESKWATIN, wa, (a. in.) it sounds out from the cold
+« MATWESIN, wok, (a. a.) he makes a noise while falling
+« MATWETTIN, wa, (a. in.) idem.
+« MATWESIMEW, (v. a.) TTITAW, SIMIWEW, SITCHIKEW, he makes him make a noise by throwing him against the ground
+« MATWEWEW, (v. im.) one hears a gunshot
+« MATWESIKEW, ok, (v. n.) one hears the firing of a rifle
+« MATWEWESTIN, (v. im.) one hears the wind blowing. N.B. So on, by placing the root matwe before a multitude of words, or suffixes, etc. One can also place it after, as one may also say: kimiwan matwe, as well as: matwe kimiwan, one hears rain, itwâniwiw matwe, or, matwe itwâniwiw, one hears something said, etc.
+x MÂW, (rac.) collect, gather, put together
+
+448
+
+MÂW
+
+« MÂWI, (adv.) together, but more used is mâmâwi, see. this word
+« MÂWISUW, ok, (v. n.) he collects seeds
+« MÂWISUWIN, a, (n. f.) harvest of seeds
+« MÂWISWÂTEW, (v. a.) TAM, SIWEW, SIKEW, he collects seeds on this tree
+« MÂWÂTJIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he assembles them, he collects them
+« MÂWÂTJIHITUWIN, a, (n. f.) assembly, congregation
+« MÂWÂTJIHITUWOK, (v. m.) they assemble
+« MÂWÂTJIMITTEW, ok, (v. n.) he collects firewood
+« MÂWÂTJITCHIKEW, ok, (v. in.) he collects, he makes a subscription
+« MÂWÂTJITCHIKEWIN, a, (n. f.) collection
+« MÂWÂSAKUKWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he sews them together
+« MÂWÂSAKUWEPAHWEW, (v. a.) HAM, HUWEW, HIKEW, he collects them in a pile, as with hay
+« MÂWÂSAKUPITEW, (v. a.) TAM, SIWEW, TCHIKEW, pull together
+« MÂWÂSAKUPAYIW, ok, a (a. a. and in.) it assembles
+« MÂWÂSAKUPAYIHEW, (v. a.) TTAW, HIWEW, HIKEW, he pushes it to put it together
+« MÂWÂSAKUTISAHWEW, (v. a.) HAM, HUWEW, HIKEW, he hunts them, he pursues them to put them together
+
+MÂW
+
+« MÂWÂSAKUSENAM, wok, (v. n.) he collects them in a pile, like embers, coals
+« MÂWÂSAKWAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he puts them together
+« MÂWÂSAKWAPPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he attaches them together, in boots, etc.
+x MAWINEHIKEW, ok, (v. ind.) he provokes, he attacks, (he challenges)
+« MAWINEHIKEWIN, a, (n. f.) provocation
+« MAWINEHWEW, (v. a.) HAM, HUWEW, HIKEW, he provokes him
+« MÂWIYA! (ex.) what to do! see. Ayis!
+MÂWÂTJI, (ad.) principally, very large, e.g. mâwâtji nikân, or, mâwâtji'oskatch, at the beginning of everything
+x MAY, (rac.) like the root match, bad, cruel, nearly every word which forms with the latter may be formed with the former
+« MAYÂTISIW, ok, (a. a.) though this word means: he has a bad character, one almost always uses it to mean: he is ugly, deformed
+« MAYÂTISIWIN, a, (n. f.) ugliness
+« MAYÂTAN, wa, (a. in.) it is ugly, bad
+« MAYINÂKUSIW, ok, (a. a.) he has a bad appearance
+
+449
+
+MAY
+
+« MAYINÂKWAN, wa, (a. in.) it is bad
+« MAYIKKWEW, ok, (a. a.) villanous face, he grimaces
+« MAYAKUSIW, ok, (a. a.) he is unlucky
+« MAYAKUSIWIN, a, (n. f.) bad luck
+« MAYAKWAN, wa, (a. in.) it is unlucky
+« MAYAKUSKAWEW, (v. a.) KAM, etc., he brings him bad luck
+« MAYAKWAMEW, (v. a.) idem
+« MAYIPAYIW, ok, a, (a. a. and in.) he (it) succeeds badly, it goes badly
+« MAYIPAYIWIN, bad business
+« MAYIPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he causes him bad business
+« MAYÂSOMEW, (v. a.) He gives him bad advice
+« MAYATTIK, wok, (n. f.) sheep
+« MAYEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he despises it, he doesn't care, he revolts against him
+« MAYEYITCHIKEW, ok, (v. ind.) he revolts against, etc.
+« MAYEYITCHIKEWIN, a, (n. f.) revolt, rebellion
+« MAYEYITTÂKUSIW, ok, (a. a.) he is despicable
+« MAYEYITTÂKWAN, wa, (a. in.) it is despicable
+« MAYEYITTAMOWIN, a, (n. f.) scorn, disdain
+« MAYI-AYÂW, ok, (a. a.) he is in a bad position, he has misfortune
+
+MAY
+
+« MAYI-AYÂWIN, a, (n. f.) calamity, misfortune
+« MAYITOTAWEW, etc., (v. a.) he causes him misfortune
+« MAYITOTAM, wok, (v. n.) he does bad, he sins
+« MAYITOTAMOWIN, a, (n. f.) the act of doing bad things, sin
+« MAYIMITUS, ak, (n. f.) black poplar
+« MAYÂBISIW, ok, (n. f.) a type of swan, grey goose (brayard)
+« MAYINIKWAN, (v. im.) difficult walk, difficult, harsh trail
+« MAYISKWAN, (v. im.) when the ice is bumpy, and makes walking difficult
+« MAYATCHAW, a, (n. f.) difficult, bumpy terrain
+« MAYASKAMIKAW, a, (n. f.) idem
+« MAYATINAW, a, (n. f.) bad mountain
+« MAYINEW, (v. a.) NAM, NIWEW, NIKEW, he holds it, he seizes it badly
+« MAYINIKEW, ok, (v. n.) he is awkward, he doesn't know how to do it
+« MAYINIKEWIN, a, (n. f.) awkwardness, clumsiness
+« MAYINAWEW, (v. a.) NAM, NÂKEW, NÂTCHIKEW, he look at it with a bad eye
+« MAYISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he pressures him in a bad way
+« MAYÂBIW, ok, (a. a.) he sees badly, he has a bad view
+« MAYAPIW, ok, (a. a.) he is seated badly
+« MAYASTEW, a, (a. in.) it is badly placed
+x MAYO, (ad.) as soon as, etc.; e.g. mayo e wâbamit, as soon as he sees me; mato e ki kiji-mitjisut wayawiw, as soon as he had finished eating, he left; eki ayamihât mayo, etc., as soon as he had prayed
+
+450
+
+MEK
+
+MAYEYAW, (ad.) see. miyâmaw, kisâstow
+MAYOWÊS, (ad.) or, mayawês, before, beforehand, etc., e.g. mayowês takusik, before he arrives, mayawês nipîk, before dying
+MWÂSI, (ad.) a little, not much; e.g. namawiya ni misken mwâsi, I did not find much there, or, namawiya mwâsi ni misken; namawiya mwâsi pikiskwew, he spoke little. This word does not appear to be used without negation. As a response, one says: nama mwâsi, a little, not much
+MWÂKUNEW, ok, (v. n.) he eats snow
+x MAWASKEW, ok, (v. n.) he goes walking in a foreign land
+« MAWASKÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he goes to visit him in a foreign country
+« MAWASKAWEW, etc., (v. a.) idem
+x MEKIW, ok, (v. n.) he gives
+« MEKIWIN, a, (n. f.) gift, present. See. Miyew
+« MEKINAWÂTEW, (v. a.) he gives it to him, he shares it with him, he gives him (something) to eat
+« MEKINAWEW, ok, (v. n.) he gives (something) to eat
+« MEKINAWEWIN, a, (n. f.) gift of food
+
+
+MEK
+
+« MEKASTIMOWEW, ok, (v. n.) he gives a horse
+« MEKASTIMWÂTEW, etc., (v. a.) he gives him a horse
+x MEKWA, (rac.) while, during, in the midst of, in
+« MEKWÂNOK, (ad.) in the middle of, etc., among
+« MEKWÂYIK, (adv.) idem
+« MEKWÂKAMIK, (ad.) in the midst of the houses, the residences
+« MEKWA-KIJIKAW, (ad.) during the day
+« MEKWA-TIBISKAW, (ad.) during the night
+« MEKWA-AYISIYININÂK, (ad.) among men
+« MEGWA-PIMÂTISIT, (v. n.) while he lives
+« MEGWA-MITJISUW, ok, (v. n.) he is in the middle of eating
+« MEGWA-AYAMIHAW, ok, (v. n.) he is in the middle of praying
+« MEGWÂSIN, wok, (v. n.) he arrives just at the moment. This especially means when someone arrives just when one is in the middle of setting the table
+« MEKWÂSKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he arrives while he is still there
+« MEKWÂSAKÂK, (ad.) in the middle of the forest
+« MEKWÂTTIK, (ad.) idem
+« MEKWÂTCH, (ad.) during, in this time, then; e.g. mekwâtch e pikiskwet, while he speaks; ni kaskeyitten mekwâtch, I am sad at this time; mekwâtch omiweyitte, then he was happy
+x MEMEKKWESIW, ok, (n. r.) small beings, dwarves, spirits which reside in the water and in the earth
+
+451
+
+MES
+
+MEMUTCH, (ad.) visibly, clearly; e.g. memutch wittamâwew, he confesses to him clearly; memutch nokusiw, he appears visibly
+x MENISK, a, (n. r.) rampart for defending against the enemy; hurdle, menikkân, a, or menigan, a
+« MENISKEW, ok, (v. n.) he makes a rampart
+« MENISKÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he surrounds the ramparts
+x MESKANAW, a, (n. r.) trail, path. N.B. Tamuw and muw are two suffixes which indicate the idea of a trail; e.g. miyomuw, it is a good trail; ekute ka itamuk, that's where the trail leads. Also, skanaw, e.g. kekoskanaw? which trail?
+x MESKUT, (rac.) to change, in exchange, in return
+« MESKUTCH, (ad.) in exchange, in return; e.g. kekway meskutch ke miyiyan? what will you give me in return? meskutch eoko otina, take that instead; nawatch ota askik tchi kwatakittâyak ekusi meskutch kitchikijikok kita miyawâtamak, it is well worth it to suffer down here, since in return, we will rejoice in Heaven
+« MÂMESKUTCH, (ad.) each in turn
+« MESKUTONEW, (v. a.) NAM, NIWEW, NIKEW, he changes it, he exchanges it; e.g. meskutonam ot ayowinissa, he changes his clothing; meskutonew otema, he exchanges his horse
+
+MES
+
+« MESKUTONAMÂKEWIN, a, (n. f.) exchange of one part and another
+« MESKUTONAMÂWEW, etc., (a. a.) he exchanges him
+« MESKUTONAMÂTUWOK, (v. m.) they exchange one another
+« MESKUTAHYEW, (v. a.) he changes its place
+« MESKUTCHIMOW, ok, (a. a. and in.) change of nature, or colour, or of substance
+« MESKUTCHIMOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he changes its nature, like kweskimohew, which also means: he fixes it elsewhere, he puts another in its place; e.g., meskutchimohew mistatimwa, he puts another horse on the car, or, he harnesses it to another car
+« MESKUTASÂKEW, ok, (v. n.) he changes clothes
+« MESKUTAYOWINISSEW, ok, (v. n.) he changes his rags
+« MESKUTCHIPAPIKIWEYÂNEW, ok, (v. n.) he changes his shirt
+« MESKUTASKISINEW, ok, (v. n.) he changes his shoes
+« MESKUTCHIPAYIW, ok, a, (a. a. and in.) he (it) changes his way of being
+« MESKUTCHIPAYIWIN, a, (n. f.) change. N.B. And so on, by placing the root meskut before words or parts of words which may come together
+
+452
+
+MES
+
+x MESTAN, ak, (n. r.) tree sap
+« MESTANIWIW, ok, a, (a. a. and in.) there is sap; e.g. sâsay mestaniwiwok mistikwok, the trees already have sap
+« MESTASUW, ok, (v. n.) he takes the bark off of trees, and he eats the sap
+« MESTANIPIWEYÂN, a, (n. f.) down of birds
+x MEST, (rac.) expend, destroy entirely
+« MESTINEW, (v. a.) NAM, NIWEW, NIKEW, he expends all of it, kakiyaw ki mestinew osoniyâma, he has spent all of his money
+« MESTINISUW, ok, (v. r.) he ruins himself, he leaves himself with nothing
+« MESTCHIPAYIW, ok, a, (a. a. and in.) he (it) is all ruined, spent; e.g. sâsay ni mitjimina mestchipayiwa, my provisions are already expended
+« MESTIKKASWEW, (v. a.) SAM, SUWEW, SIKEW, he consumes it, he burns it entirely
+« MESTÂSKISWEW, etc., (v. a.) idem
+« MESTÂSKISUW, ok, (a. a.) he is consumed, he is burned entirely
+« MESTÂSKITEW, a, (a. in.) idem
+« MESTÂSUW, ok, (a. a.) he is all melted by water or the sun
+« MESÂTTEW, a, (a. in.) idem
+« MESTÂSPUW, ok, (a. a.) he is not satiated, he does not have enough of what one gave him to eat
+« MESTISIN, wok, (a. a.) he is all worn out, expended, e.g. a piece of clothing
+« MESTITIN, wa, it is worn out
+
+MET
+
+x METT, same root as mest, etc. perhaps meaning a little more
+« METCHIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he destroys it, he annihilates it
+« METCHITTÂSUW, ok, (v. n.) he causes destruction
+« METCHITTÂSUWIN, a, (n. f.) destruction
+« METCHINEWIN, a, (n. f.) destruction by sickness
+« METCHINEWOK, (a. a.) they are destroyed by sickness
+« METTISIN, wok, (a. a.) he is destroyed, completely worn out
+« METTITIN, wa, (a. in.) idem
+« METCHIKKASWEW, (v. a.) SAM, SUWEW, SIKEW, he burns it all, entirely
+« METCHIKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he cuts it all with an axe
+« METCHIPAYIW, ok, a, (a. a. and in.) he is all destroyed, worn out, e.g. the paint that comes off of a piece of furniture. N.B. And so on, by placing the roots mest, or mett, one can form a great number of other words, e.g. metchi sipwettewok, they have all left, metchi-pakittin, it has all fallen, metchi-nipiwok, they have all died, metchipitew, tam, he tears all of it, metchi wanikiskisiw, he has forgotten everything, metchikitaw, he has eaten everything, ni metchi-nakatikwok, they have all abandoned me
+METCHIKAWIHEW, TTAW, he spills it all, e.g. metchikawittaw omikkum, he spills all of his blood
+
+453
+
+MET
+
+METCHIKKAWIW, ok, a, he, or, it all pours out
+METCHIKAWIKKWEW, he loses all of his blood
+MEY, a, or, MIY, a, (n. r.) waste, excrement, e.g. mistatimomiya, horse excrement, mustusomiya, cow droppings, ayisiyiniwomiy, human excrement
+x METAWEW, ok, (v. n.) he has fun, he plays, he plays a game of chance
+« METAWÂGAN, a, (n. f.) toy
+« METAWÂKEW, ok, (v. ind.) he plays with, he makes it a toy
+« METAWÂKÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he makes a toy of him
+« METAWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he puts it to the game
+« METAWÂTOTAWEW, etc., (v. a.) idem
+METUKE! (irony) e.g. metuke ni ka miyaw, do you think I will give it to him! that is to say, I am not crazy enough to give it to him, metuke nama ni ka miyaw, I cannot stop myself from giving it to him, see. Iyekama
+MEYANKWÂM! (ex.) pay attention! from now on, e.g. meyankwâm ekawiya ekusi tota, pay attention to this, don't do that anymore, meyankwâm! pe-nisokkamâwin, I implore you, come to my rescue, wittamâwâkkan, meyankwâm, do not forget to tell him, be careful
+
+MWE
+
+MWETCHI, (adv.) at the moment of, etc., just at the moment, in time, e.g. mwetchi e wi-mitjisuyân, as I was going to eat, mwetchi e wi-pâskiswok, tabasiw, just as at the moment of shooting it, it fled, mwetchi k'etwet, that's how he said it, mwetchi ekusi, it is just like that, k'etakimâwate ki tjâyisiyiniw, ekusi mwetchi ki ka itakamikawin, as you judge your neighbour, so too will you be judged
+x MWES, (rac.) to do something afterwards, after the desired time
+« MWESTAS, (ad.) after, e.g. mwestas pikiskwekkan, you will speak afterwards, mwestas takusin, he arrives afterwards
+« MWESISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he arrives after he already left, he misses the opportunity to meet him, e.g. mwesiskam Lamesse, he arrives after the Mass is over
+« MWESTINEW, (v. a.) NAM, NIWEW, NIKEW, he wants to grab it, but he misses it
+« MWESTAMEW, (v. a.) TAM, MIWEW, TCHIKEW, he wants to grab it with his mouth, but he misses it
+« MWESTAHWEW, (v. a.) HAM, HUWEW, HIKEW, he misses it while wanting to hit it
+« MWESTASISIN, wok, (v. n.) he arrives after (the) time
+« MWESTÂTEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he is bored of always seeing it in this state
+« MWESTÂSITTAWUW, (v. a.) TTAM, TTÂKEW, TCHIKEW, he is bored, tired of hearing it
+
+454
+
+MIK
+
+« MWESTÂSITTÂKUSIW, ok, (a. a.) he has a boring speech
+« MWESTÂSITTÂKWAN, wa, (a. in.) it is boring to listen this way
+x MIKKIW, ok, (v. n.) one says this word when women, with a pointed bone, take off the meat which is still stuck to the skin of an animal, as one says in this country: she removes the macque
+« MIKKIKWAN, a, (n. f.) pointed bone which is used for scraping skins
+« MIKKITEW, (v. a.) TAM, SIWEW, TCHIKEW, she scrapes it, to remove the macque, she slashes it
+x MIKISIW, ok, (n. r.) eagle
+« MISIKIWIPISIM, (n. f.) February, month of the eagle
+MIKIWÂP, a, (n. r.) leather tent, lodge
+x MIKKAWIKIW, ok, (v. n.) he goes quickly, he runs hard
+« MIKKAWIKIWIN, a, (n. f.) the action of running hard, swiftness
+x MIKISKAW, a, (v. im.) beginning of winter, space between autumn and winter
+x MIKISIS, ak, (n. r.) bead
+« MIKISIKKATTEW, (v. a.) TTAM, she places beads on him
+« MIKISIYÂGAN, a, (n. f.) plate, all sorts of earthenware
+x MIKISIMOW, ok, (v. n.) he barks
+« MIKISIMOWIN, a, (n. f.) barking
+« MIKITEW, (v. a.) TAM, SIWEW, TCHIKEW, he barks at him, see. Okkokkâtew
+
+MIK
+
+x MIKITIK, wa, (n. r.) the bone placed in front of the knee, the kneecap
+x MIKWAN, ak, (n. r.) feather
+« MIKWANÂWIY, ak, (n. f.) feathers prepared to adorn shoes
+x MIKWASIWÂN, ak, (n. r.) tamed wild animal
+« MIKWASIWEW, ok, (a. a.) he is tamed
+« MIKWASWÂTEW, etc., (v. a.) he tames it
+x MIKK, (rac.) that which is red
+« MIKKO, wa, (n. f.) blood
+« MIKKOWIW, ok, (a. a.) he has blood on him, e.g. misiwe mikkowiw, he is covered with blood, bloodied
+« MIKKOWAN, a, (a. in.) he has blood on, etc., bloodied
+« MIKKWEYÂPIY, a, (n. f.) (red rope) vein
+« MIKKOSIW, ok, (a. a.) he is read
+« MIKKOSIWIN, a, (n. f.) redness
+« MIKKWÂW, a, (a. in.) it is red
+« MIKKOWIHEW, (v. a.) TAW, HIWEW, HIKEW, he bloodies him
+« MIKKOHEW, etc., (v. a.) idem
+« MIKKOPAYIW, ok, a, (a. a. and in.) he (it) reddens, becomes red
+« MIKKOKKWEW, ok, (a. a.) he has a red face
+« MIKKOKKWEPAYIW, ok, (v. n.) a redness comes to his face
+« MIKKWASEW, ok, (a. a.) he has red skin, he has measles, scarlet fever
+
+455
+
+MIK
+
+« MIKKWASEWIN, a, (n. f.) measles
+« MIKOTCHITCHEW, ok, (a. a.) he has red hands, or, covered in blood
+« MIKKOKÂTEW, ok, (a. a.) he has red legs
+« MIKKOKKWAYAWEW, ok, (a. a.) he has a red neck
+« MIKKOMIN, a, (n. f.) red seed
+« MIKKOSITEW, ok, (a. a.) he has red feet
+« MIKKOSIKKWEW, ok, (v. n.) he spits blood
+« MIKKOWÂSPINEWIN, a, (n. f.) sickness of the blood, hemorrhage
+« MIKKOWÂSPINEW, ok, (a. a.) he has a hemorrhage
+« MIKKOWATÂMOW, ok, (a. a.) he has blood in his mouth
+« MIKKWÂGAMIW, (v. im.) red liquid
+« MIKKWÂGAMIWISIPIY, (n. f.) Red River
+« MIKKWÂPEMAK, wa, (n. f.) red willow
+« MIKKWÂPISKITEW, a, (a. in.) iron reddened in the fire
+« MIKKWASKWAN, (v. im.) red cloud
+« MIKKWÂSUW, ok, (a. a.) the sun is red
+« MIKKWÂSTEW, a, (a. in.) red weather, red sky
+« MIKKWÂBAN, (v. im.) red dawn
+« MIKKWÂBUIY, a, (n. f.) red broth
+« MIKKWEGIN, wa, (n. f.) red cloth, or sheet
+
+« MIKKWATISÂWIYEW, ok, (v. n.) he dyes (it) red
+« MIKKWATOW, ok, (n. f.) red mushroom. The suffix atow indicates mushroom; e.g. wâbatow, white mushroom
+MIKKAMEW, (v. .a) TTAM, he flicks him, he insults him, he flicks him on the nose
+MIKOSIS, ak, (n. r.) a son
+« MIKOSISSIMAW, ok, (a. a.) one sees him as a son
+« MIKOSISSIKKÂWIN, ak, (n. f.) an adopted son (*N.B. One will find at the end of the dictionary all of the names of different parts of the body, in the same list)
+x MIKUSK, (rac.) unwelcome, quarrelsome, etc.
+« MIKUSKÂTISIW, ok, (a. a.) he is unwelcome, annoying
+« MIKUSKÂTAN, wa, (a. in.) it is quarrelsome, bothersome
+« MIKUSKÂTCHIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he annoys him, he torments him, he bothers him
+« MIKUSKÂTCHIMEW, etc., (v. a.) idem
+« MIKUSKATCHIHIWEWIN, a, (n. f.) teasing, (the act of) annoying
+« MIKUSKÂTCHIHITUWOK, (v. m.) they are looking for a quarrel
+« MIKUSKÂSITTÂKUSIW, ok, (a. a.) he causes an annoying noise
+« MIKUSKÂSITTÂKUSIWIN, a, (n. f.) annoying noise
+
+456
+
+MIN
+
+« MIKUSKÂTEYMIEW, etc, (v. a.) he finds it annoying
+« MIKUSKÂTEYITTAM, wok, (v. n.) he is bored, tired
+« MIKUSKÂTEYITTAMIHEW, etc., (v. a.) he gives him trouble, burdens, he bothers him
+x MIKWEYAW, a, (n. r.) the neck; nikweyaw, my neck; okweyaw, his neck
+x MIMIKUNEW, (v. a.) NAM, NIWEW, NIKEW, he rubs it in his hands
+« MIMIKUPÂTINEW, etc., (v. a.) he rubs it in water
+« MIMIKUPITEW, (v. a.) TAM, SIWEW, he rubs it by stretching it
+« MIMIKWÂBIW, ok, (v. n.) he rubs his eyes
+x MIMINIK, wok, (n. r.) type of duck
+MINA, (conj.) and, again, also, placed before and after the word alike; e.g. niya mina, me too; mina miyin, give it to me again; iskutew mina nipiy, fire and water
+x MINAHEW, etc., (v. a.) he waters it, he makes it drink
+« MINIKKWAHEW, etc., (v. a.) idem
+« MINIKKWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he drinks it
+« MINIKKWEW, ok, (v. n.) he drinks
+« MINIKKWEWIN, a, (n. f.) a drink
+« MINAHIWEW, ok, (v. in.d) he gives (it) to drink
+« MINIKKWÂGAN, a, (n. f.) instrument for drinking, vase, pot
+« MINIKKWÂTCHIGAN, a, (n. f.) idem
+
+MIN
+
+« MINIKKWÂHASTIMWEW, ok, (v. n.) he makes the horses drink
+x MIN, a, (n. r.) fruit, seed. This word is always used in the diminutive, minis, a,; n'tâmisuw, he goes to collect seeds; pâsiminew, he dries seeds; pâsiminân, a, dried seeds
+« MINISÂTTIK, wok, (n. f.) fruit tree
+« MINISIWIW, ok, a, (a. a.) it bears fruits
+« MINISIWAN, wa, (a. in.) idem
+« MINAHIK, wok, (n. r.) spruce, pine
+« MINAHIKUSKAW, a, (v. im.) there are many spruces
+x MINEWÂTIM, a, (n. r.) point of earth or rock in a lack or river
+« MINEWÂTIMIWIW, (a. a. and in.) there is a point, neyaw
+x MINAHUW, ok, (v. n.) he hunts, he kills something; on'taminahuw, the hunter
+« MINAHUWIN, a, (n. f.) hunt, that which is taken in a hunt
+x MINISTIK, wa, (n. r.) island
+« MINISTIKOWIW, (a. a. and in.) there is an island
+« MINISTIKOMINAHIKUSKAW, (n. f.) spruce island
+« MINISTIKWÂBISK, wa, (n. f.) stone island
+« MINISTIKWÂBISKAW, (v. im.) there is an island of stone
+« MINISTIKWÂSKWEYAW, (v. im.) there is an island of wood
+« MINISTIKWÂWOKKAW, (v. im.) there is an island of sand
+
+457
+
+MIS
+
+MINOHWEW, HAM, he governs it well, minowepahwew, ham
++ MINWEK, a, (n. r.) type of fragrant root
+x MIPIT, a, (n. r.) tooth; nipit, my tooth; wipit, his tooth
++ MIPWÂM, a, (n. r.) buttock; nipwâm, my buttock; opwâm, his buttock
+« MIPWÂMEWOK, a, (n. f.) meat of the buttock
++ MISAHWEW, (v. a.) HAM, HUWEW, HIKEW, he mends it
+« MISAHAMÂWEW, etc., (v. a.) he mends him
+« MISAHAYAPEW, ok, (v. n.) he mends a net
++ MIS, (rac.) large, of great dimensions, many, entirely
+« MISI, (ad.) many, very; e.g., misi-kimiwan, it rains a lot; misi-yotin, it is very windy; misi-abweyaw, very hot; misi-mitjisuw, he eats a lot
+« MISISÂK, wok, (n. f.) horsefly, large fly
+« MISISÂKUSKAW, (v. im.) there are many flies
+« MISIGAMAW, a, (v. im.) large body of water, large lake
+« MISISTIKWEYAW, a, (v. im.) large river
+« MISAKKAMIK! (ex.) there is lots
+« MISATCHI! (ex.) idem
+« MISAKKAMIKISIW, ok, (a. a.) it is very numerous
+« MISÂSKWAT, a, (n. f.) wild pear tree
+« MISÂSKWATTÂTTIK, wok, (n. f.) pear tree wood
+
+MIS
+
+« MISÂSKWATOMIN, a, (n. f.) fruit of the wild pear tree
+« MISAKÂMÊ, (adv.) from one end to the other, the whole length
+« MISAKÂMEPAYIW, ok, a, (a. a. and in.) he (it) goes from one end to the other
+« MISAKÂMENEW, (v. a.) NAM, NIWEW, NIKEW, he takes it, he touches it from one end to the other
+« MISAKÂMESKAWEW, (v. a.) he passes them, he passes by them from one end to the other
+« MISAKÂMEHWEW, etc., idem
+« MISAKÂMEHAM, wok, (v. n.) he goes the whole length on the water
+« MISISITÂN, a, (n. f.) the big toe
+« MISITCHITCHÂN, a, (n. f.) the thumb
+« MISITTAW, ok, (v. n.) he makes, or, he has plenty of provisions
+« MISIYÂBISKAW, (n. f.) rust on iron
+« MISÂBIWINÂN, a, (n. f.) eyelid
+« MISOTTAKAW, a, (n. f.) big canoe
+« MISITTAKAW, a, (n. f.) large wooden building
+« MISIKITIW, ok, (a. a.) he is big
+« MISIKITIWIN, a, (n. f.) size
+« MISAW, a, (a. in.) it is big
+« MISAMIW, ok, (v. n.) he forces
+« MISAMIHEW, or, WIYEW, he makes him force, he forces him
+« MITTAMIHEW, or, WIYEW, idem
+« MITTAMIW, ok, (v. n.) he forces
+« MITTAMIWIN, a, (n. f.) the action of forcing, effort
+« MISAMIWIN, a, (n. f.) idem
+
+458
+
+MIS
+
+« MISÂHEW, (v. a.) TTAW, HIWEW, HIKEW, he makes it larger, he enlarges it
+MISASKENAM, wok, (v. n.) he finds the bottom of the water
+MISAKAW, ok, (v. n.) he arrives in port, he approaches
+« MISSAWÂTCH, nonetheless, and despite, even so, e.g. missawâtch ata eka iteyittaman ni ka ituttân, even if you don't want it, I will go
++ MISAWIW, ok, (a. a.) he is corrected, he will not return there
+« MISAWÂTISIW, ok, (a. a.) idem
+« MISAWIWIN, a, (n. f.) correction
+« MISAWÂTISIWIN, idem
+« MISAWIHEW, MEW, etc., (v. a.) he corrects it, he does enough to rid him of any desire to return there
+« MISAWIHUW, ok, (v. r.) he corrects his own expenses
++ MISIHEW, MEW, (v. a.) he betrays him, he makes it known
+MISIKKEMOW, ok, he betrays
+MISIKKEMOWIN, a, betrayal
+MISIMEW, (v. a.) he chews; e.g. mîsîhew pikiwa, he chews gum. Note. Pay attention to the fact that these two 'i's are long
+« MISIMISKIWEW, ok, (v. n.) he chews gum
+x MISIWE, (adv.) everywhere
+« MISIWEPAYIW, ok, a, (a. a. and in.) he (it) spreads everywhere
+« MISITTEPAYIW, ok, a, (a. a. and in.) idem
+« MISIWESKAW, ok, (v. r.) he wakes up completely, e.g., like the Holy Virgin in her glorious Assumption, ki misiweskaw
+
+MIS
+
+MISIWEYÂWIHUW, ok, (v. r.) idem
+MISIWESIW, ok, (a. a.) he is whole, honest
+MISIWEYAW, a, (a. in.) idem
+MISIWESIWIN, a, (n. f.) totality, honesty
+MISIWEYÂTTIK, wa, (n. f.) all of a piece of merchandise, a whole piece of wood
+MISIWEPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he swallows it, he engulfs it all whole
+MISIWEPAYITCHIGAN, a, (n. f.) pill
+MISIWESKAMIK, (ad.) everywhere on the Earth
+MISITESKAMIK, (ad.) idem
+MISIWANÂTISIW, ok, (a. a.) he is spoiled, ruined, destroyed
+MISIWANÂTAN, wa, (a. n.) it is spoiled, wasted
+MISIWANÂTISIWIN, a, (n. f.) waste
+MISIWANÂTJITCHIKEW, ok, (v. ind.) he wastes, he spoils, he abuses
+MISIWANÂTJITCHIKEWIN, a, (n. f.) waste
+MISIWANÂTJIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he spoils it, he wastes it, he abuses it
+MISIWANÂTJIMEW, etc., (v. a.) he loses him reputation, he speaks ill of him
+MISIW, ok, (v. n.) he satisfies his natural needs (he shits)
+MITCHITEW, (v. a.) TAM, etc., he shits on him
+
+459
+
+MIS
+
+MISIHYEW, ok, (n. r.) large partridge, chicken, rooster
+MISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he finds it
+MISKAWEYIMEW, (v. a.) TTAM, etc., he discovers it while searching for it
+MISKAWÂHEW, (v. a.) TTAW, etc., idem
+MISKWEYIMEW, (v. a.) TTAM, etc., idem
+MISKAWÂSUMEW, he reminds him, he makes him remember, miskumew
+MISKWAMIY, ak, (n. r.) ice
+MISKWAMISSA, (n. f.) hail
+MISKUNEW, (v. a.) NAM, NIWEW, NIKEW, he finds it by looking with his hand
+MISKAWÂWEW, ok, (v. n.) he finds eggs
+MISKSTIMWEW, ok, (v. n.) he finds a, or, several horses
+MISKAWI, (ad.) by luck, by chance
+MISKAWÂKÂTCH, (ad.) idem
+MISKINÂK, wok, (n. r.) turtle
+MISKATTIK, wa, (n. r.) the forehead, n'iskattik, my forehead, oskattik, his forehead
+MISIT, a, (n. r.) the foot, nisit, my foot, osit, his foot
+MISKIJIK, wa, (n. r.) the eye, n'iskijik, my eye, oskijik, his eye
+MISKIWAN, a, (n. r.) the nose, n'iskiwan, my nose, oskiwan, his nose
+MISKUTÂKAY, a, (n. r.) garment, n'iskutâkay, my garment, oskutâkay, his garment
+MISPAYAW, a, (n. r.) ospayaw, a, the little one's sheath in the belly of his mother (Translator's Note: This presumably is in reference to placenta)
+
+MIS
+
++ MISPIKAY, ak, (n. r.) the side, (flat side)
++ MISPIKEGAN, a, (n. r.) side of the body
++ MISPISKWAN, a, (n. r.) the back, n'ispiskwan, my back, ospiskwan, his back
++ MISPUTIN, a, (n. r.) the arm, n'isputin, my arm, ospitun, his arm
++ MISTIKWÂN, a, (n. r.) the head, n'istikwân, my head, ostikwân, his head
+« MISTIKWÂNIGAN, a, (n. f.) back of the head
++ MISPUN, (v. im.) it snows
+« MISPUNITTAW, ok, (v. n.) he makes it snow
++ MIST, (rac.) big, lots
+« MISTAHI, (adv.) many, very
+« MISTANASK, wok, (n. f.) badger
+« MISTÂKESIW, ok, (n. f.) large wolf, imaginary animal of the savages
+« MISTÂYA, k, (n. f.) large being, grey bear
+« MISTÂPISKIKKUMÂN, a, (n. f.) blade of a knife
+« MISTAHIPAK, wa, (n. f.) owl
+« MISTASKUSIMIN, a, (n. f.) wild turnip, prairie root
+« MISTATAYEPPINEW, ok, dropsical
+« MISTATAYEPPINEWIN, a, dropsy
+« MISTÂBUS, wok, (n. f.) large prairie hare
+
+460
+
+MIS
+
+« MISTATAYEW, ok, (a. a.) he has a fat belly
+« MISTATIM, wok, (n. f.) horse, large dog. N.B. This word is only used in a indefinite fashion. To say: my horse, your horse, etc., one must say n't'em, ak, kit'en, ak, his horse, otema, I have a horse, n'otemin, see the Grammar section
+« MISTATCHÂGANIS, ak, (n. f.) small wolf
+« MISTAHIKKUMÂN, a, (n. f.) big or, large knife
+« MISTAHITCHIKAHIGAN, a, (n. f.) large axe
+« MISTAHI OSI, a, (n. f.) large canoe
+« MISTÂBEW, ok, (n. f.) a fat man
+« MISTÂYÂBEW, ok, (n. f.) large male bovine, or originally, deer. N.B. And so on, by placing mistahi before a noun, a verb, or an adjective, one may form a great number of other words, with the same structure as those above, e.g. mistahi ayisiyiniw, a large man, or a mature man, mistahi pikiskweskiw, he is a big talker
++ MISTAYIK, wok, (n. f.) toad, large frog
+« MISTAHI-KISKIPUTCHIGAN, a, (n. f.) godendard (Translator's Note: A long, vertical saw used in logging)
+« MISTÂPISKAN, a, (n. f.) jaw, ni tâpiskan, my jaw
+« MISTAKAY, a, (n. f.) hair; n'istakây, a, my hair
+« MISTAMEK, wok, (n. f.) large fish, whale
+
+MIS
+
+« MISTAKIK, wok, (n. f.) large boiler, cauldron
+MISPUYEW, (v. a.) he gives him nothing to eat
++MISCHÂS, ak, (n. r.) friend, brother, cousin, n'istchâs, ak, my friend, wistchâsa, his friend
++MISTIK, wok, wa, (n. r.) tree, piece of wood, bit of wood
+« MISTIKOWEMIKKWÂN, ak, (n. v.) wooden spoon
+« MISTIKOTCHIMÂN, a, (n. f.) barge
+« MISTIKOSI, a, (n. f.) wooden barge, canoe
+« MISTIKOKAMIK, wa, (n. f.) wooden cabin
+« MISTIKOMIN, a, (n. f.) acorn
+« MISTIKOMINÂTTIK, wok, (n. f.) oak
+« MISTIKOPAKÂN, a, (n. f.) acorn
+« MISTIKONÂBEW, ok, (n. f.) carpenter
+« MISTIKOWIW, ok, (a. a.) he is wooden
+« MISTIKOWAN, wa, (a. in.) it is wooden
+« MISTIKOWANEHIGAN, a, (n. f.) trap, wooden trapdoor
+« MISTIKOWAT, a, (n. f.) box, chest
+« MISTIKOWATTIKEW, ok, (v. n.) he makes a box
+« MISTIKOWATTIKAWEW, etc., (v. a.) he makes him a wooden crate
+« MISTIKWASKIK, wa, (n. f.) wooden boiler, the savage drum
+« MISTIKWASKISIN, a, (n. f.) wooden shoe, French shoe
+
+461
+
+MIT
+
++ MISWEW, (v. a.) SAM, SUWEW, SIKEW, he injures it
+« MISWÂGAN, ak, (n. f.) injured (person)
+« MISWÂGANIWIW, ok, (a. a.) he is injured
++ MITÂYOW, (n. r.) tree covered in snow
++ MITÂNIS, ak, (n. r.) daughter,; n't'ânis, my daughter
+« MITÂNISIKKÂWIN, a, (n. f.) adopted daughter
++ MITÂKKWE, (n. r.) space, room (for), prairie
+« MITÂKKWEYAW, (v. im.) there is space, there is room, there is prairie
+« MITÂKKWENEW, (v. a.) NAM, NIWEW, NIKEW, he enlarges it, e.g., someone who cuts trees to open a field
+« MITÂKKWENAMÂWEW, etc., (v. a.) he makes space for him, he makes room for him, he puts him off
++ MITÂS, a, (n. f.) female mitasse
+« MITÂSIKKEW, ok, (v. n.) she makes mitasses
+« MITÂSIKKAWEW, etc., (v. a.) she makes him mitasses. N.B. To say, my mitasses, his mitasses, etc., n'itâs, ak, or nitâs, a, otâsa, etc.
++ MITÂSKUSIS, ak, (n. r.) a swallow (bird)
++ MITÂTAT, ten
+« MITÂTATIW, ok, (a. a.) he is ten
+« MITÂTASIW, ok, (a. a.) idem
+
+MIT
+
+« MITÂTATIN, wa, (a. in.) it is ten
+« MITÂTATWAW, ten times
+« MITÂTATOHEW, (v. a.) TTAW, etc., he divides it in ten
+« MITÂTATOMITANO, one hundred, 100
+« MITÂTATOMITANOWAW, one hundred times
+« MITÂTATOMITANOWEW, ok, (a. a.) he is one hundred
+« MITÂTATOMITANOWAN, WIN, wa, (a. in.) it is one hundred
++ MITÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he regrets it, he cries about it
+« MITÂTAMÂWEW, etc., (v. a.) he regrets it for him
+« MITÂTCHIW, ok, (v. n.) he regrets that he lost the game, he does not want to give it (away)
++ MITCHET, (ad.) many, in great quantity; e.g. mawatch mitchet, more than, etc.; astameyikok, mitchet, less than, etc.; apisis mitchet, not bad (a bit much); kitchi mitchet, a very large number
+« MITCHETIS, (ad.) a bit; e.g. mitchetisiwok, they are quite numerous
+« MITCHETIW, ok, (a. a.) he is numerous, he has a large family, he has lots of people, etc.; mitchetiwok, they are in great numbers
+« MITCHETIWIN, a, (n. f.) great number, multitude
+« MITCHEN, wa, or, MITCHETIN, wa, (a. in.) it is numerous
+« MITCHETWAW, (ad.) many times
+« MITCHETOMITANOW, many tens (of something)
+
+462
+
+MIT
+
+« MITCHETWEYAK, (ad.) different manners, ways
+« MITCHETWEYAKISIWOK, (a. a.) they divide themselves in many categories
+« MITCHETWEYAKAN, wa, (a. in.) idem
+« MITCHETWEYAKIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he divides it in many categories, manners, ways
+« MITCHETOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he separates it in many parts, and, he multiplies it
+« MITCHETOKÂTEW, ok, (a. a.) he has many parts
+« MITCHETOKWÂMIWOK, (v. n.) they sleep many together
+« MITCHETOMINAK, (n. f.) many seeds, beads
+« MITCHETOSIHIKÂTEW, (v. a.) YAM, SIWEW, TCHIKEW, he calls it by many names
+« MITCHETOKKAWEWOK, (v. m.) many of them are against him
+« MITCHETOKKÂTUWOK, (v. m.) many of them help one another
+« MITCHETOKKAMOK, (v. n.) many of them are in the canoe, etc.
+« MITCHETOSKAMOK, (v. n.) their trails, their pathes, their tracks, are numerous
+« MITCHETOSKANAWA, (n. f.) many trails
+« MITCHETOWEW, ok, (v. n.) he speaks many languages
+« MITCHETWÂPITEW, ok, (a. a.) he has many teeth
+« MITCHÂKUSIW, ok, (a. a.) he is large, a tree
+
+MIT
+
+« MITCHÂSKWAN, wa, (a. in.) it is a large piece of wood
+« MITCHÂBISKISIW, ok, (a. a.) it is a large piece of metal
+« MITCHÂSKUYÂWEW, ok, (a. a.) he has a large body
++ MITCHIKIW, ok, (n. r.) dart, pointed piece of metal
++ MITCHITCHIY, a, (n. r.) hand, n'itchitchiy, my hand, otchitchiy, a, his hand
++ MITCHIKWAN, a, (n. r.) knee, n'itchikwan, a, my knee, otchikwan, a, his knee
++ MITEH, a, (n. r.) the heart, niteh, my heart, oteh, his heart
+« MITEHEMIN, a, (n. f.) strawberry, but more commonly, otehemin, a, the seed of the heart
++ MITEPIW, ok, (v. n.) he stays, he remains there, the others having left
+« MITEWIKIW, ok, (v. n.) he stays at camp alone, his lodge stays there
++ MITEW, ok, (n. r.) sorcerer, medicine man, spellcaster
+« MITEWIW, ok, (a. a.) he is a sorcerer, etc.
+« MITEWIWIN, a, (n. f.) that which concerns the great medicine
+« MITEWIKAMIK, wa, (n. f.) tent, lodge of medicine, spells
+« MITEWÂTISIW, ok, (a. a.) he is a medicine man, he has many medicines
++ MITEYANIY, a, (n. r.) the tongue, n'iteyaniy, my tongue, oteyaniy, his tongue
++ MITEYIKUM, a, (n. r.) nostril, n'iteyikum, my nostril, oteyikum, a, his nostril
+
+463
+
+MIT
+
++ MITITIMAN, a, (n. r.) shoulder, n'ititiman, a, my shoulder, otitiman, his shoulder
++ MITON, a, (n. r.) mouth, n'iton, my mouth, oton, his mouth, osâmitonew, he has too much of a big mouth
++ MITONI, or, NE, (ad.) well, many, very
+« MITONIW, ok, (v. n.) he does well in what he does
+« MITONIWIN, a, (n. f.) success
+« MITONEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he reflects on it, he meditates on it 
+« MITONEYITTAM, wok, (v. n.) he meditates, he reflects
+« MITONEYIMISUW, ok, (v. r.) he reflects on himself
+« MITONEYITTAMOWIN, a, (n. f.) meditation, reflection
+« MITONEYITCHIGAN, a, (n. f.) thought, reasoning, imagination. N.B. The word mitoni is used like the word quite in English, e.g. mitoni nipiw, he is quite dead, mitoni mayâtan, it is quite bad, mitoni ki kakebâtisin, you are quite mad
++ MITOJIMIMAW, ok, (n. r.) a nephew, nit'ojim, ak, my nephew, ot'ojima, his nephew
+« MITOJIMISKWEMAW, ok, (n. f.) a niece, n'itojimiskwem, ak, my niece, ot'ojimiskwema, his niece
+x MITOSISIMAW, ok, (n. r.) an aunt, ni'tosis, my aunt, otosisa, his aunt
+
+MIT
+
+x MITOSKWAN, a, (n. r.) elbow, ni'toskwan, a, my elbow, otoskwan, a, his elbow
+x MITATÂMIYAW, a, (n. r.) entrails
+x MITAKISIY, a, (n. r.) intestines, nitakisiy, a, my intestines, otakisiy, a, his intestines
+x MITATCHÂK, wok, (n. r.) soul, nit'atchâk, my soul, ot'atchâkwa, his soul, ot'atchâkuw, ok, he has a soul, kanâtatchâkwew, ok, he has a pure soul
+x MITJISUW, ok, (v. n.) he eats
+« MITJISUWIN, a, (n. f.) the action of eating, food, witjimitjisumew, he eats with him
+« MOWEW, (v. a.) he eats it (an animate being)
+« MITJIW, ok, (v. a.) he eats it (inanimate)
+« MITJIWIN, a, (n. f.) food, provisions
+« MITJIM, a, (idem
+« MITJIMIKKEW, ok, (v. n.) he makes provisions
+« MITJISUWÂTEW, (v. a.) TAM, that is where he eats, where he takes his food
+« MITJISUHEW, etc., he makes him eat
+« MITJISUKKAWEW, etc., (v. a.) idem
+« MITJIMÂBUIY, a, (n. f.) broth, soup
+« MITJIMÂBUKKEW, ok, (v. n.) he makes soup
+« MITJIMÂBUKKÂKEW, ok, (v. n.) he makes it into soup
+
+464
+
+MIT
+
+« MITJIMIWAT, a, (n. f.) bag of provisions, or, bag to store provisions
+« MITJIMIKKATTAM, wok, (v. n.) he places bait in his traps
+« MITJIMIKATCHIGAN, a, (n. f.) bait for traps
+« MITJIMIKAMIK, wa, (n. f.) food storehouse, shed
+« MITJIMIKAMIKÂTAM, wok, (v .n.) he makes a food shed
+« MITJISUKKÂSUW, ok, (v. n.) he pretends to eat
+« MITJISUWINÂTTIK, wa, (n. f.) dining table
+« MITJISUWINÂTTIKAKWANAHIKAN, (n. f.) tablecloth
+« MITJISUWIKAMIK, wa, (n. f.) inn, hotel
+x MITJIM, (rac.) to hold on, to hold, to shackle, to attach
+« MITJIMINEW, (v. a.) NAM, NIWEW, NIKEW, he binds it, he holds it back
+« MITJIMIW, ok, (v. n.) he attaches himself to something, he holds himself attached to, etc.
+« MITJIMOYUW, ok, (a. a.) he is stuck, he cannot tear himself away
+« MITJIMITISIW, ok, (a. a.) idem, or, he holds himself there, not wanting to let go
+« MITJIMEYIMEW, etc., (v. a.) he has a fixed idea about him
+« MITJIMEYITTAM, wok, (v. n.) he does not let go, he does not abandon that thought, that plan
+« MITJIMÂSKWAHWEW, (v. a.) HAM, HUWEW, HIKEW, he binds it, he shackles it strongly
+« MITJIMAPPITEW, (v. a.) TAM, SIWEW, TCHIKEW, idem, like mitjimâskwahwew
+
+MIT
+
+« MITJIMAPPISUW, ok, (a. a.) he is tightly bound
+« MITJIMEHIGAN, a, (n. f.) hinge, junction
+« MITJIMIKWÂTCHIGAN, a, (n. f.) anchor
+« MITJIMINIGAN, a, (n. f.) handle, shaft
+« MITJIYÂWESIW, ok, (v. a.) he has repentance, he is angry to have done that
+« MITJIYÂWEMOW, ok, (a. a.) idem
+« MITJIYÂWESIWIN, a, (n. f.) repentance, grief
+« MITJIYÂWEYITTAMOWIN, a, (n. f.) idem
+« MITJIYÂWEYITTAM, wok, (v. n.) he repents, he is sorrowful
+« MITJIMUSIN, wok, (a. a.) he is hooked, he is stranded, he is taken
+« MITJIMUTTIN, wa, (a. in.) it is stranded, e.g. a canoe which is grounded
+« MITJIMWÂTJI, (ad.) without return, forever, e.g. mitjimwâtji ekute ayaw, he is there forever, sâsay mitjimwâtji ekusi itâtjihuw, he is already used to it, mitjimwâtji ni kiskeyimaw, I have known about it for a long time, mitjimwâtji otchi, from time immemorial, mitjimwâtji otchi itâtisiw, he has always behaved this way
+« MITJIMUTHI, (ad.) idem
+« MITJIMUSKIWEW, ok, (a. a.) he gets bogged down
+« MITJIMUSKIWOKAW, a, (n. f.) quagmire
+
+465
+
+MIT
+
+« MITJIMÂKÂTCH, (conj.) again, once more. See. Wâwâtch
+« MITJIMÂSKWAHIGAN, straitjacket
+« MITJIMASKWÂHWEW, he takes him in a straitjacket
++ MITTAWEW, ok, (v. n.) he is discontent with the fact that he was not given enough
+« MITTAWEWIN, a, (n. f.) sulking because of food
+« MITTAWAMEW, etc., (v. a.) he is discontent with him because of food
++ MITOTOSIM, ak, (n. r.) breast; n'itotosim, ak, my breast; ototosima, her breast
+« MITOTOSIMOSTIKWÂN, a, (n. f.) the end of the breast, nipple
++ MITTÂWOKAY, a, (n. r.) ear; n'ittâwokay, a, my ear; otâwokay, a, his ear
+x MITTI, (n. r.) forms mitta in the plural, firewood; nâtjimittew, ok, he goes searching for wood; mâwâtjimittew, ok, he collects wood, etc.
++ MITTIKOKKAN, a, (n. r.) underside of the shoulder
++ MITTIMEW, ok, (v. n.) he follows a path or a trail
+« MITTIMEYIMEW, etc., (v. a.) he attaches himself to his ideas
+« MITTIMEYITTAM, wok, (v. n.) he follows this idea, this thought
+« MITTITTEW, (v. a.) TAM, etc., he walks on his path, he follows in his footsteps
++ MITTOMOYEW, ok, (n. r.) old woman
++ MITTUT, a, (n. r.) raft
+
+MIT
+
+« MITTUTIKKEW, ok, (v. n.) he makes a raft
+« MITTOKIWÂP, a, (n. f.) wooden cabin
+MITTIKKÂN, a, (n. f.) a pile of wood
++ MITUS, a, (n. r.) tree, aspen, poplar
++ MIWAT, a, (n. f.) bag, niwat, a, my bag; wiwat, a, his bag
+« MIWATTIKEW, ok, (v. n.) he makes a bag
++ MIYÂMÂ, (ad.) without doubt, probably
+« MIYÂMAY, (ad.) idem
++ MIYÂMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he smells it, he feels its scent
+« MIYÂKUSIW, ok, (a. a.) he has a scent
+« MIYÂKWAN, wa, (a. in.) it has a scent
+« MIYÂKUSIWIN, a, (n. f.) scent
+« MIYAKUHUWIN, a, (or, miyakuhun, a, perfume
+« MIYÂSAMÂWEW, etc., (v. a.) he makes him burn, he censes it
+« MIYÂSIGAN, a, (n. f.) perfume which one burns (incense)
+« MIYÂMÂKUSIW, ok, (a. a.) he has an odour
+« MIYÂMÂKWAN, wa, (a. in.) it spreads an odour
+MIYÂMITTAW, see. mitchet
+MIYÂNÂKOTE! (ex.) can it be done? must it be, etc., is it possible! e.g. miyânâkotê awiyak kekebâtisit! must there be someone crazy enough? miyânâkotê piyetchâki! can it be so far!
+
+466
+
+MIY
+
++ MIYÂNAM, wok, (v. n.) he comes to pass, his tracks are fresh; e.g. oskenam, idem, The suffix nam, here, indicates paths, tracks, etc; e.g. kayâsenam, his tracks are old
+« MIYÂNIKWAN, wa, (a. in.) it is a fresh track, fresh path
+MIYÂSKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he exceeds him
++ MIYÂWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he is content, satisfied with it, he glorifies it
+« MIYÂWÂTAM, wok, (v. n.) he is joyful
+« MIYÂWÂTAMOWIN, a, (n. f.) joy, pleasure
+« MIYÂWÂSIW, ok, (a. a.) he is happy
+« MIYÂWÂTIKUSIW, ok, (a. a.) idem
+« MIYÂWÂTIKWAN, wa, (a. in.) it is pleasant, agreeable
+« MIYÂWÂTIKUSIWIN, a, (n. f.) contentment
+x MIYÂWESIW, ok, (a. a.) he has hair
+« MIYÂWEYAW, a, (a. in.) it is hairy
+MIYEW, (v. a.) YIWEW, he gives him
+x MIYAW, a, (n. r.) the body, n'iyaw, my body; miyaw, his body; owiyâwiw, he has a body; kinoyâwew, he has a long body, or, kinowâbekiyâwew, ok
+x MIYEY, ak, (n. r.) loach
++ MIYIY, a, (n. r.) pus
+« MIYIWIW, ok, (a. a.) he is pustulent
+
+MIY
+
+MIYOSKAMIW, (v. im.) it is spring; miyoskamik, last spring; ke miyoskamik, next spring
+x MIYISTOWEW, ok, (a. a.) he has a beard, he is bearded
+« MIYISTOWÂN, a, (n. f.) beard; ni miyistowân, my beard
+x MIYITTIP, a, (n. r.) brain; n'iyittip, my brain; wiyittip, his brain
+x MIYITCHIMIN, ak, (n. f.) pea
+« MIYITCHIMINÂTTIK, wa, (n. f.) pea stems
+x MIYO, (rac.) all that which relates to goodness, beauty, perfection, justice, etc.
+« MIYOSIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it beautiful, he makes it well
+« MIYOSITCHIGAN, a, (n. f.) beautiful creature
+« MIYOSIW, ok, (a. a.) he is beautiful
+« MIYOSIWIN, a, (n. f.) beauty
+« MIYWÂSIN, wa, (a. in.) it is beautiful
+« MIYOPAYIW, ok, a, (a. a. and in.) he (it) succeeds well, it goes well
+« MIYOPAYIWIN, a, (n. f.) success
+« MIYWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he loves him, he esteems him he thinks him beautiful
+« MIYWEYITTAM, wok, (v. n.) he is happy
+« MIYWEYITTAMOWIN, a, (n. f.) happiness, satisfaction
+« MIYONAWEW, (v. a.) NAM, NÂKEW, NÂTCHIKEW, he sees him as beautiful
+« MIYONAM, wok, (v. n.) he has a good foot, he walks well, this trail offers him good walking
+
+467
+
+MIY
+
+« MIYOAYAW, ok, (a. a.) he is well, he is going better
+« MIYOAYÂWIN, a, (n. f.) prosperity, wellbeing
+« MIYOAYIWIW, ok, (a. a.) he is good, he behaves well
+« MIYOAYIWIWIN, a, (n. f.) goodness, good behaviour
+« MIYOWÂTISIW, ok, (a. a.) he is good, he behaves well
+« MIYOWÂTISIWIN, a, (n. f.) goodness, good behaviour
+« MIYOW, ok, (v. n.) he does well in what he does
+« MIYOWIN, a, (n. f.) dexterity, skill
+« MIYOKIJIKAW, a, (v. im.) it is good weather, it is a nice day
+« MIYOTIBISKAW, a, (v. im.) it is a good night
+« MIYOKIJWÂTEW, etc., (v. a.) he speaks to him with goodness
+« MIYOKANAWÂBAMEW, (v. a.) TTAM, etc., he looks at him with goodness
+« MIYOKKWÂMIW, ok, (v. n.) he sleeps well
+« MIYOKKWÂMIWIN, a, (n. f.) good sleep
+« MIYOKÂMOW, ok, (a. a.) he is quite fat
+« MIYOTTAWEW, (v. a.) TTAM, TTÂKEW, TTÂTCHIKEW, he listens to him with pleasure
+« MIYONEW, etc., (v. a.) or better, minonew, he places it well
+« MIYOMEW, etc., (v. a.) or better minomew, he straightens it out by speech, he puts it right
+« MIYWÂSOMEW, etc., (v. a.) or minwâsomew, he gives him good advice
+
+MIY
+
+« MIYWÂTEW, or, minowâtew, idem
+« MIYOKKWEW, ok, (a. a.) he has a good face
+« MIYOKKWENÂKUSIW, ok, (a. a.) idem
+« MIYOMÂKUSIW, ok, (a. a.) he has a good odour
+« MIYOMÂKUSIWIN, a, (n. f.) good odour, fragrance
+« MIYOMÂKWAN, wa, (a. in.) it has a good odour
+« MIYOMÂTTEW, etc., (v. a.) he likes the smell
+« MIYOMOW, ok, a, (a. a. and in.) he (it) adjusts to himself well, e.g. two pieces of wood
+« MIYOMOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he adjusts it well
+« MIYOMUW, a, (a. in.) good, well traced trail
+« MIYOWATAMUW, a, (a. in.) idem
+« MIYOMUTCHIKEW, ok, (v. ind.) he traces the path well, he leads it
+« MIYOWATAMUTCHIKEW, ok, (v. ind.) idem
+« MIYOMATJIHUW, ok, (a. a.) he is well, he is in good health
+« MIYONÂKOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he adorns him, he gives him a beautiful appearance
+« MIYOPIMÂTISIW, ok, (a. a.) he is good, he lives well
+« MIYOPIMÂTISIWIN, a, (n. f.) goodness, good living
+« MIYONIKWAN, a, (v. im.) good walking, good trail
+« MIYOSIKWAW, (v. im.) the ice offers good walking
+
+468
+
+MIY
+
+« MIYOWATCHAW, a, (n. f.) good terrain
+« MIYOSKAMIKAW, (n. f.) idem
+« MIYWÂBEWIW, ok, (a. a.) he is handsome
+« MIYOSKWEWIW, ok, (a. a.) she is a beautiful woman
+« MIYOTTÂKUSIW, ok, (a. a.) he has a beautiful voice
+« MIYOWÂTÂMOW, ok, (a. a.) idem
+« MIYOTTÂKUSIWIN, a, (n. f.) beautiful voice, beautiful sound
+« MIYOWÂTÂMOWIN, a, (n. f.) beautiful song, harmony
+« MIYOTEHEW, ok, (a. a.) he has a good heart
+« MIYOTEHEWIN, a, (n. f.) goodness of the heart
+« MIYOTOTAWEW, (v. a.) TAM, TÂKEW, TÂTCHIKEW, he makes him well
+« MIYOTOTAMOWIN, a, (n. f.) good action
+« MIYOITTIW, ok, (a. a.) he acts well
+« MITOITTIWIN, a, (n. f.) a good act
+« MIYOTTWAW, ok, (a. a.) idem
+« MIYOTTWÂWIN, a, (n. f.)
+« MIYOHUW, ok, (a. a.) he is well-dressed
+« MIYOHUWIN, a, (n. f.) dressing well
+« MIYOWEW, ok, (a. a.) he has beautiful hair
+« MIYOWÂTJIMOW, ok, (v. in.) he tells good news
+« MIYOWÂTJIMOWIN, a, (n. f.) good news, e.g. Manito-miyowâtjimowin, the Gospel
+
+MIY
+
+« MIYOWÂGAMIW, (n. f.) good liquid
+« MIYOWÂBISKUSIW, ok, (a. a.) he is good, referring to metal
+« MIYOWÂBISKAW, a, (a. in.) idem
+« MIYOWÂSKUSIW, ok, (a. a.) he is good, referring to a tree, to wood
+« MIYOWÂSKWAN, wa, (a. in.) idem
+« MIYOWÂTTIK, wok, (n. f.) good tree
+« MIYOWÂTIKKEW, ok, (v. n.) he packs, he prepares his belongings to leave, break camp
+« MIYOWÂTIKKÂTEW, (v. a.) TAM, etc., he packs his things
+MIYWÂMEW, etc., (v. a.) he hunts it while biting it
+x MIYEYEPAMÂN, a, (n. r.) palate, the roof of the mouth
+x MIYÂPÂKKWAN, a, (n. r.) moss which clings to trees
+MIYÂWEMOTTEW, ok, (n. f.) caterpillar
+x MIYIMÂWISIW, ok, (a. a.) he is damp
+« MIYIMÂWISIWN, a, (n. f.) dampness
+« MIYIMÂWAW, a, (a. in.) it is damp
+« MIYIMÂWINEW, (v. a.) NAM, NIWEW, NIKEW, he dampens it
+« MIYIMÂWÂBAWAYEW, (v. a.) TAW, YIWEW, TCHIKEW, he moistens it
+« MIYIMÂWÂBÂWATEW, a, (a. in.) it is moist
+x MIWEHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he hunts it, he makes it flee
+
+469
+
+MON
+
+« MIWETISAHWEW, (v. a.) HAM, HUWEW, HIKEW, he expels him, he sends him to the side
+MOHEW, (v. a.) HITTAW, HIWEW, HIKEW, he makes him cry. See. Mâtuw
+x MOKÂSIW, ok, (n. r.) bittern, heron
+x MOKKU, cut, carve, sculpt, slice
+« MOKKUMAN, a, (n. f.) knife
+« MOKKUMÂNÂBISK, wa, (n. f.) knife blade
+« MOKKUMÂNATUS, a, (n. f.) iron of an arrow
+« MOKKUTEW, (v. a.) TAM, SIWEW, TCHIKEW, he cuts it off, he slices it
+« MOKKUTCHIGAN, a, (n. f.) instrument for slicing, planing
+« MOKKUTÂGAN, a, (n. f.) crooked knife
+« MOKKUTCHIKEWIYINIW, ok, (n. f.) carpenter, jointer
+« MOKKUTCHIKEWIKAMIK, wa, (v. a.) carpenter's shop
+MOMINEW, ok, (v. n.) he eats fruits
+x MONAHWEW, (v. a.) HAM, HUWEW, HIKEW, he digs it, he unearths it
+« MONATCHÂPIKAHWEW, (v. a.) HAM, etc., or, monahitchipikkwâhwew, he pulls up roots, or, monatchâpikkew
+« MONAJISKIWEW, ok, (v. n.) he digs the earth, he excavates the ground
+« MONÂTIKKÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he unearths it, he digs it
+
+MON
+
+« MONAHIKKÂKEW, ok, (v. ind.) he uses it to dig in the earth
+« MONAHIKKÂGAN, a, (n. f.) shovel, instrument for digging
+« MONAHIPÂN, a, (n. f.) well, dug-out hole, where there is water
+« MONAHIPEW, ok, (v. n.) he digs a well
+x MONIYÂ, Montreal, Canada, moniyâk otuttew, he comes from Canada
+« MONIYÂWIW, ok, (a. a.) he is Canadian, he is a strange in the country
+« MONIYANS, ak, (n. f.) stranger, man from Canada, new arrival
+« MONIYANISIWIW, ok, (a. a.) he is a new arrival, or, he is awkward, clumsy
+« MONIYÂWIYINIW, ok, (n. f.) Canadian
+« MONIYÂSKWEW, ok, (n. f.) Canadian woman
+x MONSWA, Monswok for the pl. (n. r.) moose
+« MONSWEGIN, wa, (n. f.) moose skin
+« MONSOMIN, a, (n. f.) moose seed
+« MONSASSINIY, a, (n. f.) bullet (moose stone)
+« MONSOPIYESIS, ak, (n. f.) small hummingbird
+MONJAK, (adv.) always (seldom used)
+MOJAKKINEW, (v. a.) NAM, NIWEW, NIKEW, he collects it, he gathers it
+x MOSAHWEW, (v. a.) HAM, HUWEW, HIKEW, he makes a prairie, clears, cleans
+
+470
+
+MOS
+
+« MOSWATAHWEW, etc., idem
+x MONSÂGAMIW, a, (a. in.) pure liquid
+MONSÂBUIY, a, (n. f.) idem
+« MONSÂBEW, ok, (n. f.) single man, widower
+« MONSISKWEW, ok, (n. f.) single woman, widow
+x MOSIS, (ad.) clearly, visibly
+« MOSISÉ (ad.) idem
+« MOSESKATEW, ok, (a. a.) he is nude
+« MOSESKATEWIN, a, (n. f.) nudity
+« MOSESKATENEW, (v. a.) NAM, NIWEW, NIKEW, he makes him nude, he strips him
+« MOSESKATEPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he tears off his clothes
+« MOSISEPITUNEW, ok, (a. a.) he has bare arms
+« MOSISESITEW, ok, (a. a.) he has bare feet
+« MOSISESTIKWÂNEW, ok, (a. a.) he has a bare head
+x MOSKIPAYIW, ok, (a. a. and in.) to float on, etc., to drift, it resolves, it appears, it leaves, e.g. like some illness of the body
+« MOSKIPEW, ok, (v. n.) he floats. See. Pekupew
+« MOSKAHIPEW, ok, (v. n.) idem
+« MOSKAPEPAYIW, ok, (a. a. and in.) idem
+« MOSKAHIPEPAYIW, ok, a, (a. a. and in.) idem
+« MOSKISTAWEW, (v. a.) TAM, TÂKEW, TÂTCHIKEW, he rushes at him, he throws himself at him
+
+MOS
+
+« MOSKUMEMOW, ok, (v. n.) he cries of hunger
+« MOSKUWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW
+« MOSKUWEYITTAM, wok, (v. n.) his pain flares, his grief comes around
+« MOSKUYÂWESIW, ok, (a. a.) idem
+« MOSKUHEW, MEW, (v. a.) he touches him, he affects him, he touches him to tears
+« MOSKITJIWAN, wa, (n. f.) a fountain, a source of water
+« MOSKITJIWANIPEK, wa, (n. f.) idem
+« MOSKINEW, (v. a.) NAM, NIWEW, NIKEW, he discovers it, he shows it uncovered
+« MOSKIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he pulls it up to date
+« MOSKIW, ok, (v. n.) he uncovers himself, he shows himself
+« MOSKINEW, ok, a, (a. a. and in.) he is filled until done
+x MONJIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he senses it, he feels it, (both physically and morally)
+« MONJIHUW, ok, (v. r.) he experiences a sensation
+« MONJITTOYUW, ok, (v. r.) idem
+« MONJITTÂWIN, a, (n. f.) sensation
+« MOJIHUWIN, a, (n. f.) idem
+MUSIWÂK, (ad.) not any time soon. See. Mayo (nama mayo) e.g. namawâtch musiwâk tchi miyoskamik, it will not be spring any time soon
+
+471
+
+MUT
+
++ MUSTCHI, (ad. and rac.) or, mutchi, naked, uncovered, unmixed, to the point, simply
+« MUSTAWÂN, it is unmixed
+« MUSTASKUSÂWEW, ok, (v. n.) he smokes without mixing, he smokes pure tobacco
+« MUSTAHWEW, (v. a.) HAM, HUWEW, HIKEW, he touches him naked, he grasps him naked
+« MUSTINEW, (v. a.) NAM, NIWEW, NIKEW, he seizes him with a bare hand
+« MUSTAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he makes it known, he puts it plainly
+« MUSTÂBUIY, a, (n. f.) pure, unmixed alcoholic liquid
+« MUSTÂGAMIW, a, (a. in.) idem
+« MUSTÂWEYIMEW, (v. a.) TAM, MIWEW, TCHIKEW, he desires it, he longs for him
+« MUSTAWINAWEW, (v. a.) NAM, NÂKEW, NÂTCHIKEW, he desires it by seeing it
+« MUSTAWEYITTAMÂWEW, etc., (v. a.) he desires him
+« MUSTAWINAMÂWEW, etc., he envies him
+« MUSTUTTEW, ok, (v. n.) he walks on foot, he goes on foot
+« MUTCHIK, (ad.) on the ground, on the bare ground
+« MUSTASKAMIK, (ad.) idem
+« MUSTASKAMIKISIN, wok, (a. a.) he is spread out on the bare ground
+« MUTCHITON, (ad.) in person
+« MUTCHIMIYEW, (v. a.) he simply gives everything, without any exchange
+
+MUS
+
++ MUSTUS, wok, (n. r.) cattle, buffalo
+« MUSTUSWEGIN, wa, (n. f.) tanned buffalo skin
+« MUSTUSWEYAN, ak, (n. f.) buffalo skin with hair, robe
+« MUSTUSUS, ak, (n. f.) calf, young bison
+« MUSTUSOKAMIK, wa, (n. f.) stable, shelter for cattle
++ MUTCHOWIW, ok, (a. a.) he is an imbecile, simpleton
+« MUTCHOWÂTISIW, ok, (a. a.) idem
+« MUTCHOWIWIN, a, (n. f.) idiocy
+« MUTCHOWÂTISIWIN, a, (n. f.) idem
+« MUTCHOWEYIMEW, (v. a.) TTAM, MIWEW, CHHIKEW, he thinks him to be an imbecile
+x MOTEYÂBISK, wa, (n. f.) bottle
+x MOTTEW, ok, (n. r.)worm, insect
+x MOYÂBITCH, (ad.) upside down, in the other direction
+« MOYÂBITASEKUW, ok, (v. n.) he wears his clothes inside out
+« MOYÂBITAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he places it inside out
+MOYAWEW, ok
+x MOYISIW, ok, (v. n.) he suspects, he doubts something
+« MOYEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he has suspicions about him
+« MOYISIWIN, a, (n. f.) suspicion
+« MOYEYITTAMOWIN, a, (n. f.) idem
+
+472
+
+NAH
+
+« MOYITTAWEW, TTAM, he believes he hears it, he is almost certain
+x MOWEW, WIWEW, (v. a.) he eats it (an animate being)
+« MITJIW, ok, (v. a.) he eats it (an inanimate being)
+« MOWÂKUNEW, ok, (v. n.) or better, mwâkunew, ok, he eats snow
+NÂ! (ex) to pay attention; hey! over here! e.g., nâ! ki mokkumân, hey! your knife is over here; nâ! otina, hey! take it
+NÂH? (interr.) when someone does not respond to the question right away; e.g. nametchi ki ki mitjisun? have you eaten? if he does not respond, I say to him: nâh? well? Also in this fasion: nametchi ki wi-ayamihân? don't you want to pray?
+NÂ? (interr.) like tchi? but seldom used; e.g. ki miyo ayân nâ? are you well?
+NÂ-NÂ! (ex.) expression of suprise, proper only for women
+x NAH, (rac.) to be skillful in, etc., to be apt at, etc., well
+« NAHIW, ok, (a. a.) he is skillful, he is adept
+« NAHIWIN, a, (n. f.) skillfulness, skill
+« NAHÂSIWEW, ok, (v. n.) he is skillful at shooting the bow
+« NAHÂSIWEWIN, a, (n. f.) skill at shooting the bow
+
+NAH
+
+« NAHÂSIW, ok, (a. a.) he is good at knowing, at finding out
+« NAHÂBAMINÂKUSIW, ok, (a. a.) he has a beautiful appearance
+« NAHÂBAMINÂKWAN, wa, (a. in.) idem
+« NAHAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he places it skillfully
+« NAHASTÂSUW, ok ,(v. n.) he arranges in order, he prepares, he readies
+« NAHASTÂSUWIN, a, (n. f.) preparation, readiness
+« NAHASTEW, a, (a. in.) it is well placed
+« NAHAWASAMEW, (v. a.) he gives him good food
+« NAHÂBIW, ok, (v. n.) he sees well, he has a good view
+« NAHAPIW, ok, (v. n.) he sits, he places himself well
+« NAHAPISTAWEW, (v. a.) he sits around him
+« NAHAPIWIN, a, (n. f.) seat
+« NAHÂBAMEW, (v. a.) TTAM, KKEW, TCHIKEW, he sees it well
+« NAHÂWISIE, ok, (a. a.) he is thin, slender, he is not big
+« NAHÂWAW, a, (a. in.) it is thin, etc.
+« NAHINEW, (v. a.) NAM, NIWEW, NIKEW, he places it well, he buries it, he inters it
+« NAHINOKEW, ok, (v. n.) he inters
+« NAHINOKEWIN, a, (n. f.) interment, burial
+« NAHINOKEWIKAMIK, sepulcre
+« NAHEYITTAM, wok, (v. n.) he is happy, satisfied
+
+473
+
+NAH
+
+« NAHEYITTAMOWIN, a, (n. f.) happiness
+« NAHEYITTUWOK, (v. m.) they come to an agreement together, they agree amicably
+« NAHEYITTUWIN, a, (n. f.) accord, agreement
+« NAHEYIMEW, (v. a.) he is happy with him
+« NAHEYIKOK, (ad.) it is enough, it is sufficient
+« NAHEKÂTCH, (ad.) passably, well enough. See. Eyiwek
+« NAHEKÂTWEW, ok, (v. n.) he speaks politely
+« NAHITTAWEW, (v. a.) TTAM, TÂKEW, TÂTCHIKEW, he listens to him well, he obeys him
+« NAHITTAM, wok, (v. n.) he has a good hear, he hears from far away. This also means, he is obedient
+« NAHITTAMOWIN, a (n. f.) obedience
+« NAHIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he satisfies him, he contents him
+« NAHIMEW, etc., (v. a.) idem, by his words
+« NAHINAWEW, (v. a.) NAM, NÂKEW, NÂTCHIKEW, he sees him well
+« NAHISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, it suits him; e.g. eoko miskutâkay ni nahiskâkun, this garment suits me; nahiskâtuwok, or, nahiskotâtuwok, they suit one another, they are well paired
+« NAHIPAYIW, ok, a, (a. a. and in.) it works out well
+
+NAH
+
+« NAHISIMEW, (v. a.) MIWEW, TITAW, etc, he puts it down well
+« NAHISIN, wok, (a. a.) he is well set down
+« NAHITTIN, wa, (a. in.) it is well set down
+« NAHIWEKINEW, (v. a.) NAM, NIWEW, NIKEW, he folds it with care, he wraps it well
+« NAHITIKITIW, ok, (a. a.) he is quite big
+« NAHISPITCHAW, a, (a. in.) it is quite big
+x NAHA, (pron.) this; e.g., naha k'istes, this is your brother; nahi ite! this here; nehi, (acc.); neki, that
+x NAHÂKISIM, ak, (n. r.) son-in-law; ni nahâkisim, my son-in-law; onahâkisima, his son-in-law
+« NAHÂGANISKWEW, ok, (n. f.)daughter-in-law, ni nahâganiskwem, ak, my daughter-in-law; onahâganiskwema, his daughter-in-law
+« NAHITÂK (adv.) by luck, by chance. See. Miskawi
+x NAHIM, (v. r.) wind from in front, headwind
+« NAHIMAN, (v. im.) there is a headwind
+« NAHIMISKAM, wok, (v. n.) he goes against the wind
+x NAKAMOW, ok, (v. n.) or, nikamow, he sings
+NAKAMOWIN, a, (n. f.) song, nikamowin, a
+NAKAMUN, a, (n. f.) idem, nikamun, a
+NAKAMUSTAWEW, (v. a.) he sings it, he sings to him, nikamustawew
+NAKAMOHEW, (v. a.) TTAW, TIWEW, TCHIKEW, he makes him sing, or nikamohew. N.B. More generally, one uses this form to say: he teaches him, e.g. the savages who teach the way to use medicines say: ni nakamohaw, I teach him, I let him know
+
+474
+
+NAK
+
+« NAKAMUTTAW, ok, (v. a. im.) e.g., a juggler; nakamuttaw, o maskikima, he sings, he enchants his medicines
+x NAKATCH, (rac.) accustomed to, to know thoroughly, etc.
+« NAKATCHIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he is accustomed to his ways, he knows him well
+x NAKAYA, (rac.) same meaning as Nakatch
+« NAKAYÂHEW, etc., (v. a.) he gets used to it, he masters it
+« NAKAYÂSKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he is used to him, he is made in his own way
+« NAKAYÂTTAWEW, (v. a.) TTAM, TTÂKEW, TTÂTCHIKEW, he is accustomed to hearing him
+« NAKAYÂNAWEW, (v. a.) NAM, NÂKEW, NÂTCHIKEW, he is accustomed to seeing him
+« NAKAYÂHUTTEW, ok, (v. n.) he is accustomed to walking
+« NAKAYÂSIW, ok, (a. a.) he is used to this
+« NAKAYÂSIWIN, a, (n. f.) habit
+« NAKAYÂSITCHIKÂSUW, ok, (a. a.) he is tamed, trained. N.B. And so on, placing nakaya before certain words, one can form a multitude of other words; e.g. nakayapittwaw, he is accustomed to smoking; nakayâ-atuskew, he is trained to work
+
+NÂK
+
+x NÂKÂTAWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he examines it internally, he reflects on it
+« NÂKATÂWÂBAMEW, (v. a.) TTAM, KKEW, TCHIKEW, he looks at it while examing it
+« NÂKATÂSUTTAWEW, (v. a.) TTAM, TTÂKEW, TTÂTCHIKEW, he listens to it while reflecting on what he is hearing
+« NÂKATÂWEYIMISUW, ok, (v. r.) he examines himself, he does his examination
+« NÂKATÂWEYIMISUWIN, a, (n. f.) self examination
+« NÂKATOKKEW, ok, (v. n.) he examines, he pays attention
+x NAKATEW, (v. a.) TAM, NIWEW, TCHIKEW, he lets it go, he abandons it
+« NAKATISIMEW, (v. a.) TTITAW, SIMIWEW, he forsakes it
+« NAKATASKATEW, (v. a.) TAM, etc., he abandons it in embarrassment
+« NAKATCHIPAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he lets it go on the run, while running
+« NAKATAHWEW, (v. a.) HAM, HUWEW, TCHIKEW, he lets it go on the water
+« NAKATÂMOW, ok, (v. n.) he lets it go, he leaves it out of fright
+« NAKATÂMOTOTÂWEW, (v. a.) TAM, TÂKEW, TÂTCHIKEW, he lets it go, he abandons it because of fear, of fright
+« NAKATASKEW, ok, he lets go of the earth, he dies
+« NAKATASKATEW, etc., he abadonds it, he leaves it in place
+
+475
+
+NAK
+
++ NAKKAWEWIYINIW, ok, (n. f.) Salteaux
+« NAKKAWEW, ok, (v. n.) he speaks Salteaux, otchipway, savages of the Red River
+« NAKKAWEMOW, ok, (v. n.) idem
+« NAKKAWEMOWIN, a, (n. f.) Salteaux language
+« NAKKAWEWIN, a, (n. f.) idem
++ NAK, (rac.) to meet, impact, repulse
+« NAKIW, ok, (v. n.) he stops, he makes an effort to stop himself
+« NAKIWIN, a, (n. f.) stop
+« NAKÂNEW, (v. a.) NAM, NIWEW, NIKEW, he holds it back, he stops it
+« NAKAHWEW, (v. a.) HAM, etc., he meets him on the water
+« NAKIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he holds him back, he represses him
+« NAKÂMEW, etc., (v. a.) idem, with his words
+« NAKIMEW, etc., idem
+« NAKINEW, (v. a.) NAM, NIWEW, he holds him back
+« NAKESTIW, ok, (v. n.) he stops, he does not want to go ahead
+« NAKIPAYIW, o, (a. a. and in.) it stops
+« NAKÂSIN, wok, (a. a.) he stops by hitting against, etc.
+« NAKÂTTIN, wa, (a. in.) idem
+« NAKAYÂSIW, ok, (a. a.) he stops against the wind, the wind stops him from going ahead
+« NAKISTAWEW, (v. a.) TAM, TÂKEW, TÂTCHIKEW, he repulses it, he loathes him, he stops before him, he does not dare advance against him, e.g. nama kekway nakistam, he does not back down from anything
+
+NAK
+
+« NAKISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he meets him
+« KAKISKÂTUWOK, (v. m.) they meet
+« NAKISKÂTUWIN, a, (n. f.) meeting
+« NAKISKÂTUMÂGAN, wa, (v. m. inan.) it meets
+NAKISKAMÂSUW, ok, (v. r.) he has found what he is looking for (in a bad way)
+« NAKÂSKAHWEW, etc., (v. a.) he stops him with something, he opposes his passing
+« NAKIPITEW, (v. a.) TAM, SIWEW, TCHKEW, he stops it, e.g. by pulling by the arm
+« NAKOWEW, ok, (v. n.) he stops talking, he stutters
+« NAKISK, (adv.) an instant, kanak
+« NAKWÂSUW, ok, (a. a.) he is taken in a trap, or, a net
+« NAKWÂTEW, a, (a. in.) it is taken in a trap, or, a net
+« NAKWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he takes it in a net, or a trap
+« NAKWÂKAN, a, (n. f.) net, trap
+« NAKWÂKANIKKAWEW, etc., (v. a.) he places a trap to get him, wanihikamâwew
+NAKE, (ad.) biased, more on one side than another, napate
+NÂKÉ, (ad.) See. Itâb, tcheskwa
+NAKKAW, ok, (v. n.) See. Nimiw, ok, he dances
+
+476
+
+NAM
+
+x NAMA, (adv.) or namawiya, no, sign of negation, before the verb, e.g. ki wi miyin tchi? do you want to give it to me? nama! no, namawiya ki kiskeyimitinâwaw, I do not know you
+« NAMAWÂTCH, (ad.) or, namawâwâtch, not at all, nothing at all
+« NAMAKEKWAY, a, (ad.) nothing
+« NAKAWIKKÂTCH, (ad.) never
+« NAMESKWA, (ad.) or, namawiya eskwa, not yet
+« NAMESÂNI! or namawiya esa âni (ex.) it does not appear, it is over! e.g. namesâni ni ka wâbamaw! I cannot see it then! there is no hope that I shall see it
+« NAMATEW, ok, (a. a.)it is not him, or, he is dead, he is no longer, he is no more
+« NAMATAKUN, wa, (a. in.) idem
+« NAMANIYÉ! or, namawiya aniye! (ex.) it's over! there is no more hope!
+« NAMANANDO, (ad.) nowhere
+« NAMAWIYAK, (pro.) nobody, or, namawiya awiyak
+« NAMAYEW, ok, (a. a. and in.) this is not him, this is not it, e.g. namayew n'ottâwiy, it is not him who is my father, nama yewa ni mokkumâna, these are not my knives
+« NAMAYEWIW, ok, (a. a.) it is not him
+« NAMAYEWAN, wa, (a. in.) it is not this
+
+NAM
+
+« NAMAYÂKAWEYIMOW, ok, (a. a.) he is impolite, cheeky
+« NAMAYÂKAWEYIMOWIN, a, (n. f.) cheekiness, impudence
+« NAMAYETUKE, (irony) See. Iyekama
+« NAMATCHATCHÂM, (ad.) or nama tchâtchik, for nothing, for a trifle, over nothing, e.g. namatchâtchik otchiyâwesiw, he is angry over nothing
++ NAMATCHIW, ok, (a. a.) he is left-handed
+« NAMATCHIWIN, a, (n. f.) the left
+« NAMATTIN, wa, (a. in.) it is left-handed
+« NAMATINISK, the left hand, arm, e.g. namattinisk iji, or, itekke, on the left, by the left, etc.
+« NAMANATTAM, (ad.) in great number, many, very
+« NAMANATAKEYETIWOK, they are in very great number
++ NAMEHEW, (v. a.) TTAW, HIWEW, TCHIKEW, all of the sudden, he finds his tracks, he sees his tracks after having followed his trail
+« NAMETTAW, ok, (v. n.) there are tracks, he leaves his trail where his has been, or where he stayed. See. Ayetiskiw
+« NAMETTÂWIN, a, (n. f.) track, trace
+« NAMESKANAWEW, ok, (v. n.) there is his trail, he leaves his prints, traces
+« NAMESIN, wok, (a. a.) there is are his traces, e.g. marks where an animal had slept
+
+477
+
+NÂM
+
++ NAMEW, ok, (n. r.) sturgeon
+« NAMEKUS, ak, (n. f.) trout
+« NAMEPIY, ak, (n. f.) carp
+« NAMESTEK, wa, (n. f.) dried fish (spared)
++ NÂMI, (rac.) to wobble, to rock
+« NÂMIW, ok, (v. n.) he wobbles, he sways
+« NÂMIWIN, a, (n. f.) wobbling
+« NÂMIKEYIW, ok, (v. n.) he bends at the knee, he bows
+« NÂMIKEYIWIN, a, (n. f.) bowing
+« NÂMIKEYISTAWEW, (v. a.) TAM, TÂKEW, TÂTCHIKEW, he bows to him
+« NÂMISKWEYIW, ok, (v. n.) greeting, nodding of the head
+« NÂMIKKWEYIW, ok, (v. n.) he bends his neck
+« NÂMIYAWEYIW, ok, (v. n.) he bends his body, he sways his body
+« NÂMIPAYIW, ok, a, (a. a. and in.) (more typically with reduplication) nânâmipayiw, he (it) trembles
+« NÂMIYÂWEPAYIW, ok, (v. n.) his whole body trembles
++ NÂMIWAN, (n. r.) downwind, favourable wind
+« NÂMIWANAW, (v. im.) there is a downwind
+« NÂMIWANÂSIW, ok, (a. a.) he goes by sail
+« NÂMIWANAHAM, wok, (v. n.) he goes with the wind
+
+NÂM
+
+« NÂMIWANISKAM, wok, (v. n.) he walks downwind
+« NÂMIWANUTTEW, ok, (v. n.) idem
++ NANAMÂHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he gets used to it, he becomes accustomed to it, e.g. matchi nanamâhew ot'awâsimissa, he gives bad habits to his children
+« NANAMÂHUW, ok, (v. r.) he accustoms himself (to it), he gets used to it
+« NANAMÂSIW, ok, (a. a.) idem
+« NANAMÂHUWIN, a, (n. f.) habit
++ NANÂPÂTCHIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he arranges it, he repairs it, he looks after it, he remakes it
+« NANÂPÂTCHITTOWEW, etc., he repairs it for him
++ NANÂNIS, (adv.) from all sides, in different places, e.g. nanânis, ayâwok, they are spread out. See Masanak
+« NANÂNISTAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he places it in different places
+« NANÂNISTCHIHEW, (v. a.) he shares it in many parts, pieces
+« NANÂNISTINEW, (v. a.) NAM, NIWEW, NIKEW, he divides it in many pieces
+« NANÂNISTISWEW, (v. a.) SAM, SUWEW, SIKEW, he cuts it in many pieces
+« NANÂNISTCHIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he tears it in pieces
+
+478
+
+NAN
+
+« NANÂNISTCHITUWOK, (v. m.) they disperse themselves
+« NANÂNISTCHITUWIN, a ,(n. f.) dispersion
++ NANÂSKOMEW, etc., (v. a.) he thanks him
+« NANÂSKOMOWOKEYIMEW, etc, idem
+« NANÂSKOMOWOKEYITTAM, wok, (v. n.) he thanks
+« NANÂSKOMOWOKEYIMOW, ok, (v. n.) idem
+« NANÂSKOMOW, ok, (v. n.) idem
+« NANÂSKOMOWIN, a, (n. f.) thanks
+x NANÂTTEW, (v. im.) there is a mirage, apparition of the weather
+« NANÂTTEWIN, a, (n. f.) mirage
+« NANÂTTEWEHIN, wa, (n. f.) red, scarlet sheet
+« NANÂTTENAWEW, (v. a.) NAM, NÂKEW, NÂTCHIKEW, he sees it in a mirage
+« NANÂTTEPAYIW, ok, a, (a. a. and in.) it is brilliant, it is glowing
+« NANÂTTEYÂBISKAW, a, (a. in.) shining metal
+« NANÂTTEPAYIWIN, a, (n. f.) shine
+x NANÂTAWIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he takes care of him, he administers remedies to him
+« NANÂTAWIHUW, ok, (v. r.) he takes care of himself, he takes medicine
+« NANÂTAWIHUWIN, (n. f.) remedy, medicine. One says: ayamihewi-nanatâwihuwin, sacrament, medicine of religion
+« NANÂTAWEYIMOW, ok, (v. r.) he looks after himself in a superstitious fashion
+
+NAN
+
+« NANÂTAWEYIMOWIN, a, (n. f.) superstitious belief in healing
+« NANÂTAWIHIWEWIYINIW, ok, (n. f.) doctor, healer
+x NANÂTOK, (adv.) of different manners, of different sorts
+« NANÂTOKOWISIW, ok, (a. a.) he belongs to different types, he acts in different manners
+« NANÂTOKOWAN, wa, (a. in.) idem
+« NANÂTOKUSIW, ok, (a. a.) he has different appearances, colours
+« NANÂTOKWASIW, ok, (a. a.) idem
+« NANÂTOKWAN, wa, (a. in.) idem
+« NANÂTOKONÂKUSIW, ok, (a. a.) he has different colours, he appears in different manners
+« NANÂTOKONÂKWAN, wa, (a. in.) idem
+« NANÂTOKOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he does it in various fashions
+« NANÂTOKOSKANESIW, ok, (a. a.) he belongs to different families, tribes, or nations
+« NANÂTOKOMEW, etc., (v. a.) he speaks in different manners
+« NANÂTOKWÂKKOMEW, etc, (v. a.) he is allied with him in various manners
+« NANÂTOKUNEW, (v. a.) NAM, NIWEW, NIKEW, he holds him in various ways
+« NANÂTOKWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he sews it in different manners
+« NANÂTOKKWÂSUW, ok, (v. n.) he sews it in various ways
+
+479
+
+NAN
+
+« NANÂKKAW, ok, (a. a.) like nanâtokowisiw
+« NANÂKKAÂWIYINIWOK, (n. f.) different tribes, nations
+« NANÂTOKWAPPINEW, ok, he has every sort of sickness
+« NANÂTOKKWAPPINEWIN, a, sickness, which contains within it many others
+« NANÂSTAKO, (adv.) this is the same meaning as nanâtok, with all of its derivations, e.g. nanâstakokwâtew, nanâstakokunew, nanâstakowisiw, etc.
+NANÂYO, (ad.) See. Mayo. nama nanâyo, liek nama mayo
+NÂNÂWEY, (adv.) from place to place, one after the other, e.g. nânâwey astâwok, they place them out along a distance, nânâwey takusinwok, they arrive one after the other
+x NANEKKÂTCH, (ad. and rac.) with pain, difficulty, with suffering
+« NANEKKÂTISIW, ok, (a. a.) he is in a state of suffering, he is languishing. See. Niyamisiw, ok
+« NANEKKÂTAN, wa, (a. in.) it is languishing
+« NANEKKÂTISIWIN, a, (n. f.) languour, languishing?
+« NANEKKÂTCHIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes him languish
+« NANKKÂTJIMEW, etc., (v. a.) he makes him languish, he annoys him with his speech
+
+NAN
+
+480
+
+« NANEKKÂTJIMOW, ok, (v. n.) he laments, he is sorry
+« NANEKKÂTJIMOWIN, a, (n. f.) lamentation, desolation
+« NANEKKÂTOWEW, ok, (v. n.) he speaks with languour
+« NANEKKÂTOWEWIN, a, (n. f.) difficulty speaking
+« NANEKKÂTEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he sympathises with his pain, he thinks him downtrodden
+« NANEKKÂTASPINEW, ok, (a. a.) he has a sickness which makes him sluggish
+« NANEKKÂTASPINEWIN, a, (n. f.) sluggish sickness
+« NANEKKÂTCHIPAYIW, ok, a, (a. a. and in.) it goes languidly
+x NÂNIKKIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he presses it, he hastens it. The root of this and the following words is nikk, but it is always used with reduplication
+« NÂNIKKIMEW, etc., (v. a.) he hastens him with his words
+« NÂNIKKISIW, ok, (a. a.) he is hurried, he hastens
+« NÂNIKKISIWIN, a, (n. f.) haste, hurry
+« NÂNIKKITISAHWEW, (v. a.) HAM, HUWEW, HIKEW, he makes him leave quickly, he sends him promptly
+« NÂNIKKOWEW, ok, (v. n.) he has a hastening tone of voice
+« NÂNIKKITTAWEW, (v. a.) he thinks that he is in a great hurry, according to his words
+
+480
+
+NAN
+
+« NÂNIKKIPAYIW, ok, a, it quickens, it is hurrying
+« NÂNIKKIPAYIWIN, a, (n. f.) great haste, hurrying
+x NÂNOSAM, (adv.) See. Nosam. N.B. Only through usage can the true meaning of this word be grasped; it ordinarily means that which lasts a long time which one did not believe would do so to begin with, e.g. nânosam wissakeyittam, he suffers for a long time, his sickness drags on languidly
+« NÂNOSAMÂTCH, (ad.) idem. See. Nosamâtch
+« NÂNOSAMÂTCHIPAYIW, ok, a, (a. a. and in.) it acts more than one initially thought, it goes on and on
+« NÂNOSAMÂTCHIWIYEW, etc., (v. a.) he takes him forever, though intially he seemed to leave with him only for a time
+« NÂNOSAWI, (ad.) like, nânosamâtch. See. Nosawi
+x NÂNÂMATCHIW, ok, (a. a.) he shivers from the cold
+« NÂNÂMÂPISKANEWATCHIW, ok, his teeth chatter from the cold
+« NÂNÂMASPINEW, ok, (a. a.) he is paralysed
+« NÂNÂMIPAYIW, ok, (v. n.) he trembles
+« NÂNÂMIPAYIWIN, a, (n. f.) trembling
+« NÂNÂMASKAMIKIPAYIW, (v. n. inan.) the ground trembles
+NANESAKKIW, ok, (v. n.) he acts without purpose, he does nothing (worthwhile)
+
+NÂN
+
+NÂNITO, (ad.) more used, nando, e.g. nama nando, in no place, or also, it does nothing, it results in nothing, nando kiteyitten tchi? do you think something? nama nando n't'eyitten, I don't think anything, nama nando abatisiw, he is of no use, nando ki wi-ituttân tchi? do you want to go somewhere? nama nando ni wâbamâwok, I have not seen them anywhere, nando mitâtato piponwew, he is about ten years old, nando ekute ayaw, he must be somewhere there
+NÂNOSATCHIKEW, ok, he has the rest of it, of his food
+NÂNOSATCHIGAN, rest of the food
+NÂNOSATTAM, he has some left, he cannot eat all of it
+x NANWEYAT, (rac.) to annoy, to weary, to tease
+« NANWEYATISIW, ok, (a. a.) he is intrusive, he is teasing, he is looking for a quarrel
+« NANWEYATAN, wa, (a. in.) idem
+« NANWEYATISIWIN, a, (n. f.) harassment, unjust attack
+« NANWEYATCHIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he annoys him, he teases him, he tries to quarrel with him
+« NANWEYATCHIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he annoys him, etc, with his words
+« NANWEYATWEW, ok, (v. n.) he tease with his words
+« NANWEYATWEWIN, a, (n. f.) annoying speech, teasing
+
+481
+
+NAP
+
+« NANWEYATCHIHITUWOK, (v. m.) they look to quarrel with one another, they attack one another
+« NANWEYATCHIHITUWIN, a, (n. f.) mutual attack
+x NAPAK and sometimes NABAK, (rac.) flat, to flatten
+« NAPAKISIW, ok, (a. a.) he is flat, smooth
+« NAPAKAW, a, (a. in.) it is flat, smooth
+« NAPAKISIWIN, a, (n. f.) platform
+« NAPAKIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he flattens it, he smooths it
+« NAPAKINEW, (v a.) NAM, NIWEW, NIKEW, idem
+« NAPAKITTAK, wa, (n. f.) board, plank
+« NAPAKÂBISKAW, a, (a. in.) it is flat, when speaking of metal
+« NAPAKÂSKISIW, ok, (a. a.) he is flat, when speaking of wood
+« NAPAKÂSKWAN, wa, (a. in.) idem
+« NAPAKITTAKISIW, ok, (a. a.) idem
+« NAPAKITTAKAW, a, (a. in.) idem
+« NAPAKASITTA, k, (n. f.) fir
+« NAPAKIYÂGAN, a, (n. f.) case, dish, plate
+« NAPAKASKIK, wok, (n. f.) flat boiler, cauldron
+« NAPAKITCHIKAHIGAN, a, (n. f.) flat axe, pickaxe
+« NAPAKITÂBÂNÂSK, wok, (n. f.) train, flat car
+« NAPAKIKKUTEW, (v. a.) TAM, SIWEW, TCHIKEW, he flattens it by slicing it
+
+NAP
+
+« NAPAKIKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he flattens it by squaring it
+x NAPAT, (rac.) on one side, only one edge
+« NAPATESIW, ok, (a. a.) he is only on one side
+« NAPATEYAW, a, (a. in.) it is only on one side
+« NAPATE, (adv.) only on one side; e.g. napate kakiyaw kita ahyâwok, they will all be placed on one side; napate iji nama pikupayiw, on one side, he isn't broken
+« NAPATEHWEW, (v. a.) HAM, HUWEW, HIKEW, he works on only one side
+« NAPATENEW, (v. a.) NAM, NIWEW, NIKEW, he holds it by only one side, he holds it in only one hand
+« NAPATENISKEW, ok, (v. n.) he holds only one side with his hand, or, his arm
+« NAPATEMUW, a, (a. in.) path which only goes on one side
+« NAPATEMOW, ok, a, (a. a. and in.) it only holds on one side
+« NAPATEKISIN, (n. f.) a single shoe, a shoe edge
+« NAPATESIN, wok, (a. a.) he only falls on one side, or, he is lying down on one side
+« NAPATETTIN, wa, (a. in.) idem
+« NAPATEYÂBIW, ok, (a. a.) he sees from only one eye
+« NAPATEKKÂBIW, ok, (a. a.) idem
+
+482
+
+NÂP
+
+« NAPATEKÂM, (ad.) on only one side of the river or lake
+« NAPATEKÂTEW, ok, (a. a.) he has only one leg
+« NAPATEPITUNEW, ok, (a. a.) he has only one arm
+« NAPATEPIW, ok, (v. a.) he is sitting on one side
+« NAPATESTEW, a, (a. in.) it is placed on one side
+« NAPATEKÂBAWIW, ok, (a. a.) he is standing on the side
+NAPÂWIS, and, NABÂWIS, and, NABÂWIS ITUKE, he is too late, (it is good time), e.g. nânabâwis ekwa e mitâtak, he is too late now, so that he regrets it, napâwis ituke ka pe-ituttet, he is too late for him to come, nanabawi, he is too late, afterwards
+NAPETCH, or, NABETCH, idem
+x NÂPEW, ok, (n. r.) man (vir.), the male
+« NÂPEWIW, ok, (a. a.) he is a man
+« NAPE AYAW, ok, (n. f.) a male
+« NÂPEMOW, ok, (v. n.) he speaks in a manly way
+« NÂPEWOKEYIMOW, ok, (v. r.) he believes himself to be a man, he thinks himself brave
+« NÂPEWOKEYIMEW, etc., (v. a.) he thinks him to be brave
+« NÂPEKKÂSUW, ok, (v. n.) he makes the man, but one more often uses this word to mean: he is brave
+« NÂPEKKÂSUWIN, a, (n. f.) bravery
+« NÂPEMEK, wok, (n. f.) male fish
+
+NÂP
+
+« NÂPEMIMAW, ok, (v. ind.) the husband
+« NÂPEMASKWA, ok, (n. f.) male bear
+« NÂPESTIM, wok, (n. f.) male horse, stallion, or male dog. N.B. And so on, by placing nâpe before different types of beings, apart from the moose, buffalo, and some others, for which one says: ayâbemonswa, ayâbe-mustus, etc.
+« NÂPESIB, ak, (n. f.) male duck
+« NÂPENISKA, k, (n. f.) male bustard, etc., etc.
+NÂPIKKWÂN, a (n. r.) large boat, vessel, ship
++ NAPO, (prep.) both together, e.g. napo ni miyikawin, one gives me both, napo nipiwok, they both died
+« NAPWAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he places them both, he doubles them
+« NAPONEW, (v. a.) NAM, NIWEW, NIKEW, he places them both together, etc.
+« NAPWÂKÂTEPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he attaches the legs together, he locks him up
+« NAPWÂPITEW, etc., (v. a.) idem
+« NAPWÂKÂTEPITCHIGAN, a, (n. f.) rope for tying people up
+« NAPWÂPITCHIGAN, a, (n .f.) idem
+« NAPOPAYIW, ok, a, (a. a. and in.) it doubles
+
+483
+
+NAS
+
+« NAPOTINEW, (v. a.) NAM, NIWEW, KIKEW, he takes both of them
+« NAPWEKINEW, (v. a.) he bends it in two
++ NASK, (rac.) to consent, to reply, to respond
+« NASKOMOW, ok, (v. n.) he consents, he gives his consent, e.g. naskomow kitchi ayamihât, he consents to pray
+« NASKOMOWIN, a, (n. f.) consent
+« NASKOMEW, etc., TTAM, (v. a.) he gives him a favourable response, e.g. ki naskomitin, ki ka miyitin, I consent to give it to you
+« NASKOMOTOTAWEW, etc. (v. a.) idem
+« NASKOTTUWOK, (v. m.) they listen to one another, they form an alliance, or naskomituwok
+« NASKOTTUWIN, a, (n. f.) alliance, agreement
+« NASKOMITUWIN, a, (n. f.) idem
+« NASKWAHAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he responds to him, e.g. someone who responds to another person by praying, or, by singing
+« NASKWAHÂTUWOK, (v. m.) they respond to one another
+« NASKWAHAMÂTUWIN, a, (n. f.) response in prayer, or in song
+« NASKWAHAM, wok, (v. n.) he accompanies, or, he repsonds in song
+« NASKWEWOSIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he resists him
+« NASKWEWOSIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, or, naskwemew, he retorts, e.g., a child reasoning with his parents
+
+NAS
+
+« NASKWEWOSIMOW, ok, (v. n.) he replies, he responds
+« NASKWEWOSIMOWIN, a, (n. f.) reply, response
+« NASKWÂW, ok, (v. n.) he resists, he opposes it, he gets back at it
+« NASKWÂWIN, a, (n. f.) opposition, vengeance
+« NASKOWEW, ok, (v. n.) he opposes, he speaks against, etc.
+« NASKWÂHWEW, (v. a.) HAM, HUWEW, HIKEW, he opposes him, he gets back at him, or he hits him in passing, e.g. he shoots an animal which passes by running away, naskwâhwew, a bit close too, nawatahwew, he shoots it flying
+« NASKWENEW, (v. a.) NAM, NIWEW, NIKEW, he seizes it while it passes
+« NASKWESKANAW, public place
+« NASKWE, (prep) while passing, while moving, e.g. naskwe pittukew, he enters while passing
+x NASPÂTCH, (adv.) bad, contrary to good, in the opposite direction, e.g. naspâtch itwew, he says bad things, or, he does not say it how he should say it, naspâtch totam, he does bad things, naspâtch ittiw, he behaves differently from how he should
+« NASPÂTAPIW, ok, (a. a.) he is seated, he is placed in the opposite direction
+« NASPÂTASTEW, a, (a. in.) it is placed backwards
+« NASPÂTAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he places it badly, in the opposite direction
+
+484
+
+NÂS
+
+« NASPÂTCHINÂKUSIW, ok, (a. a.) he has a bad appearance
+« NASPÂTCHINÂKWAN, wa, (a. in.) idem
+« NASPÂTCHINAWEW, etc., (v. a.) he looks at him badly
+« NASPÂTÂBAMEW, etc., (v. a.) he sees him in a bad light
+« NASPÂTISIW, ok, (a. a.) he has a crooked, spurious character
+« NASPÂTISIWIN, a, (n. f.) falsity
+« NASPÂTCHAYAMIHAW, ok, (v. n.) he follows a false religion
+« NASPÂTCHAYAMIHÂWIN, a, false religion
+« NASPÂTCHITEYIMEW, (v. a.) TTAM, etc., he thinks it falsely
+« NASPÂTCHITEYITTAM, wok, (v. n.) he thinks falsely, he fools himself
+« NASPÂTCHITEYITTAMOWIN, a, (n. f.) false though, false desire
+« NASPÂTCHITEYITCHIGAN, a, false wish
+« NASPÂTOWEW, ok, (v. n.) he speaks falsely, he says bad things
+« NASPÂTOWEWIN, a, (n. f.) false speech
+x NÂSPITCH, (ad.) nâspitchi, very, many, excessively, forever. One says: nânsitch as a sort of diminutive of nâspitch, e.g. nâspitch sâkihew, he loves him excessively; nâspitchi sipwettew, he has left for good; namawiya nâspitch, or, namawiya nânsitch, not a lot
+« NÂSPITISIN, wok, (v. r.) he kills himself stiffly by falling
+
+NÂS
+
+« NÂSPITISIMEW, etc., (v. a.) he kills him stiff, by throwing him to the ground
+« NÂSPITAHWEW, (v. a.) HAM, HUWEW, HIKEW, he kills him stiff, by a blow. N.B. Still so, by placing nâspitch before the word, or, nâspitchiyâwesiw, he is angry without return
+« NÂSPITABISINEW, (v. a.) NAM, NIWEW, NIKEW, he closes it forever
+« NÂSPITATÂMOW, ok, (v. n.) he breathes for the last time
+« NÂSPITATÂMOWIN, a, (n. f.) last breath
+« NÂSPITCHITWEW, ok, (v. n.) he says irrevocably
+« NÂSPITCHITWEWIN, a, (n. f.) irrevocable speech
+« NÂSPITCHIWIYASUWEWIN, a, (n. f.) judgement, sentence without appeal
+« NÂSPITCHITEYITTAM, wok, (v. n.) he has taken to his resolution irrevocably
+« NÂSPITCHITEYITTAMOWIN, a, (n. f.) irrevocable resolution
+« NÂSPITCHITEYITCHIGAN, a, (n. f.) absolute will
+« NÂSPITCHINIPIW, ok, (a. a.) he is completely dead, like an animal; e.g. ayisiyiniw namawiya nâspitchi nipiw, the man has not completely died
+« NÂSPITCHIPIKUPAYIW, ok, a, (a. a.) he is entirely broken, etc.
+x NASP, (rac.) to imitate, to ressemble, to do the same
+
+485
+
+NÂS
+
+« NASPIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he does it similarly
+« NASPISIHEW, etc., (v. a.) idem
+« NASPISIHISUW, ok, (v. r.) he looks like him
+« NASPISIHISUWIN, a, (n. f.) image, resemblance
+« NASPISIHIGAN, a, (n. f.) image
+« NASPISITCHIGAN, a, (n. f.) idem
+« NASPITAWEW, etc., (v. a.) he ressembles him
+« NASPITOTTAWEW, etc., (v. a.) he imitates his way of speaking, he says (it) like him
+« NASPITÂTUWOK, (v. m.) they ressemble one another
+« NASPITÂTUMAGAN, wa, (v. m. im.) it is similar, it resembles something
+« NASPABAMEW, etc., (v. a.) he imitates his look
+« NASPASINAHWEW, (v. a.) HAM, HUWEW, HIKEW, he writes it, or he paints it, imitating another piece of writing or painting
+« NASPASINAHIKEW, ok, (v. n.) he copies a writing, or a painting
+« NASPASINAHIGAN, ak ,a, (n. f.) image, portrait, copied writing
+« NASPASINAHIKEWIN, a, (n. f.) copy
+« NASPIPEHEW, (v. a.) HAW, HIWEW, HIKEW, he imitates him in painting
+« NASPIPEHIGAN, a, (n. a.) imitation of (a) painting
+« NASPIMOW, ok, (v. n.) he says, he speaks in imitation
+« NASPIMOWIN, a, (n. f.) repetition
++ NÂSIPEW, ok, (v. n.) he goes towards the water
+
+« NÂSIPEWIN, a, (n. f.) shore, edge of the water
+« NÂSIPETIMIK, (adv.) idem, at the edge of the water
+« NÂSIPESKANAW, a, (n. f.) path which leads to the water
+« NÂSIPEMUW, a, (v. im.) idem
+« NÂSIPETTAHEW, (v. a.) HAW, HIWEEN, TCHIKEW, he carries it to shore
+« NÂSIPETISAHWEW, etc., (v. a.) he sends it to the shore
+« NÂSIPEPATTAW, ak, (v. n.) he runs to the edge of the water
+« NASIWEW, ok, (v. n.) he goes to the feast
+x NÂT, (rac.) to go looking for, to search, to go after, etc.
+« NÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he goes looking for him, or, he goes towards him
+« NÂTITUWOK, (v. m.) they go towards one another
+« NÂTAHWEW, (v. a.) HAM, HUWEW, HIKEW, he goes looking for water
+« NÂTAHATTEW, etc., (v. a.) he searches for footprints
+« NÂTAKÂM, (adv.) on the side of the river, being on the water
+« NÂTAKÂMEHAM, wok, (v. n.) he gains ground, towards the shore
+« NÂTAKÂMEHÂSIW, ok, (v. a.) he gains ground thanks to the wind
+« NÂTAKÂMEYÂSTAN, wa, (a. in.) the wind pushes it towards the ground
+« NÂTAKÂSIW, ok, (v. n.) he leaves the open ground of the prairie to come to the side of the woods
+« NÂTAKÂMEPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he pulls it to the ground
+
+486
+
+NÂT
+
+« NÂTAKWEW, ok, (v. n.) he goes to check his traps
+« NÂTASKEW, ok, (v. n.) he goes looking for moss
+« NÂTASKUSIWEW, ok, (v. n.) he goes looking for hay
+« NÂTAMÂWEW, etc., (v. a.) he goes looking for him. Also: he takes his defense, he enters his party
+« NÂTAYAPEW, ok, (v. n.) he goes to check his nets
+« NÂTIPEW, ok, (v. n.) he goes looking for water
+« NÂTCHIMITTEW, ok, (v. n.) he goes looking for firewood
+« NÂTISKUTAWEW, ok, (v. n.) he goes looking for fire
+« NÂTOWATEW, ok, (v. n.) he goes looking on his back
+« NÂTOWATÂMEW, etc., (v. a.) he goes searching for it on his back
+« NÂTCHIYUSTAWEW, (v. a.) TAM, TÂKEW, TÂTCHIKEW, he approaches it while hiding, like someone who approaches an animal to shoot it
+« NÂTCHINEHAMÂWEW, etc., (v. a.) he goes to ask him for medicines to buy
+« NÂTCHINEHWEW, etc., (v. a.) he goes to buy it in the way that one buys medicines
+« NÂTCHINEHIKEW, ok, (v. n.) he goes to buy medicines
+« NÂTOWEW, ok, (n. f.) Iroquois
+« NÂTOWEMOW, ok, (v .n.) he speaks Iroquois
+« NÂTOWEMOWIN, a, (n. f.) the Iroquois language
+« NÂTÂTTÂMEW, etc., (v. a.) he borrows from him
+
+NÂT
+
+« NÂTÂTTÂMOW, ok, (v. n.) he borrows
+« NÂTÂTTÂMOWIN, a, (n. f.) loan
+x NATONEW, (v. a.) NAM, NIWEW, NIKEW, he searches for it. N.B. This word and its derivations appear to be pronounced nan rather than na
+« NATÂPENEW, (v. a.) NAM, NIWEW, NIKEW, he does research on him
+« NANATOTCHITCHAMEW, TTAM, he searches for it with his hand
+« NATONAWEW, (v. a.) NAM, NÂKEW, NÂTCHIKEW, he searches for it, looking everywhere
+« NATOMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he calls for him, he asks him, he makes him come
+« NATOTAMÂWEW, etc., (v. a.) he asks him something
+« NATOTAMAW, ok, (v. n.) he asks
+« NATOTAMÂWIN, a, (n. f.) question
+« NATOTTAWEW, (v. a.) TTAM, TTÂKEW, TTÂTCHIKEW, he listens to him, he pays attention to what he says. Also: he obeys him
+« NATOTTAM, wok, (v. n.) he is obedient
+« NATOTTAMOWIN, a, (n. f.) obedience
+« NATÂNÂWAMEW, etc., (v. a.) he goes to look for something to eat around him
+« NATÂNAWEW, ok, (v. n.) he goes to beg for something to eat
+« NATOKÂTEW, etc., (v. a.) he searches where he stays
+
+487
+
+NTA
+
+x N'TAWI, N'TAW, N'TA, root, or rather preposition which should be written as natawi, but I write it as n'tawi because the first a is not perceptible, this is an auxiliary which means: go towards
+« N'TAWÂBAMEW, (v. a.) TTAM, MIWEWKEW, TCHIKEW, he goes to see it
+« N'TAMINAHEW, (v. a.) he hunts for him, etc.
+« N'TAMINAHUSTAMÂWEW, etc., idem
+« N'TAMINAHUW, ok, (v. n.) he hunts, he goes on the hunt
+« N'TAMINAHUWIN, a, (n. f.) the hunt
+« N'TAWÂMISKWEW, ok, (v. n.) he goes on the hunt for beavers
+« N'TAWASKWEW, ok, (v. n.) he goes on the hunt for bears
+« N'TAWEYIMEW, (v. a.) TTAM, MIWEW, TCHIEW, he desires him, he desires his presence
+« N'TAWEYITTAMOWIN, a, (n. f.) desire
+« N'TAWEYITTAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he desires to obtain from him
+« N'TAWEYITTESTAMÂWEW, etc., (v. a.) he desires him, he wishes it for him
+« N'TAWITTEW, ok, (v. n.) he goes to look for firewood. See. Nâtchimittew
+« N'TAWIMUSTUSWEW, ok, (v. n.) he goes out in pursuit buffalo, for herds
+« N'TAWASTIMWEW, ok, (v. n.) he goes out in pursuit of horses
+
+NTA
+
+« N'TAWÂTTAW, ok, (v. n.) he goes on discovery
+« N'TAWÂTCHIKEW, ok, (v. n.) idem
+« N'TAWI-KISKEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he experiences it
+« N'TAWI-MITJISUW, ok, (v. n.) he goes to eat
+« N'TAWI-AYAMIHAW, ok, (v. n.) he goes to pray. N.B. One can continue in this way with many words by placing N'tawi, or, N'taw, or, N'ta, as an auxiliary before the verb
++ NATOPAYIW, ok, (v. n.) he goes to war
+« NATOPAYIWIN, a, (n. f.) the action of going to war
+« NATOPAYISTAWEW, etc., (v. a.) he goes to make war on him
+« NATOPAYIWOKIMAW, ok, (n. f.) warchief, captain, general, officer
+« NATOPAYIWIYINIW, ok, (n. f.) warrior
++ NÂTOSKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he uses him
+« NÂTOSKAMÂWEW, etc., (v. a.) he takes refuge around him
+« NÂTAMOTOTAWEW, etc., (v. a.) idem
++ NATAHAM, wok, (v. n.) he rides the current
+« NATAHUYEW, (v. a.) TAW, YIWEW, TCHIKEW, he goes looking for it by riding the current
+« NATAHUTTEW, ok, (v. n.) he goes up the river on the ground
+« NATAHISKAM, wok, (v. n.) idem
+
+488
+
+NÂT
+
+« NATIMIK, (ad.) at the top of the stream
+« NATIMITÂK, (ad.) from the side where the river is coming from
+NATAKA, or more often, n'taka, (ad.) by chance, by good fortune, e.g., n'taka ni takkune ni pâskisigan, by luck I had my rifle, n'taka maskawisiw, lucky for him, he is strong, n'taka namawiya kissinoban, ni ka ki âkwatchittân, luckily for us, it wasn't too cold out, we would have frozen 
+NATESSÉ, (ad.) in any case, as a precaution
+x NÂTWÂNEW, (a. a.) NAM, NIWEW, NIKEW, he cracks it in two, e.g. a tree
+« NÂTWÂPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he breaks it in two, e.g. a rope
+« NÂTWÂHWEW, (v. a.) HAM, HUWEW, HIKEW, he breaks it in two
+« NÂTWÂSKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he cracks it in two by walking on it
+« NÂTWÂSIMEW, (v. a.) TIMAW, etc., he breaks it in two by throwing it on the ground, e.g. a pipe
+« NÂTWÂSIN, wok, (a. a.) he cracks in two by falling
+« NÂTWÂTTIN, wa, (a. in.) idem
+« NÂTWÂPAYIW, ok, (a. a. and in.) idem
+« NÂTWÂYÂSIW, ok, (a. a.) he is broken in two by the wind
+« NÂTWÂYÂSTAN, wa, (a. in.) idem
+« NÂTWÂYÂSKUSIN, wok, (a. a.) he breaks in two by falling
+
+NÂT
+
+« NÂTWÂYÂSKUTTIN, wa, (a. in.) idem
++ NATWESIKEW, ok, (v. n.) he shoots his rifle as a warning, as a signal to warn of where one is
+« NATWEWESIKEW, ok, (v. n.) idem
+« NATWEWEMEW, etc., (v. a.) he cries for him, he calls him, thinking that he is lost, or apart
+« NATWEWEMOW, ok, (v. n.) he calls for help, being separated from the group
++ NAYEW, (v. a.) YATTAM, YIWEW, YATCHIKEW, he carries it on his back
+« NAYATCHIKEWIYINIW, ok, (n. f.) porter
+« NAYATCHIKEWIYINIW, ok, (n. f.) The Porters, savages of the Rocky Mountains
+« NAYOMEW, etc., (v. a.) like nayew
+« NAYÂWASUW, ok, (v. n.) she carries a child on her back
+« NAYÂWASUWIN, a, (n. f.) the action of carrying a child one one's back
+« NAYATTAHEW, (v. a.) TAW, HIWEW, TCHIKEW, he puts it on his back, he puts a burden on his back
+« NAYATCHIGAN, a, (n. f.) burden; also: small roll of sheet or cotton which the Indians wear on their backs, and in which are some remains of their deceased parents, e.g., hair, pieces of clothing, etc., etc.
+x NAYETTÂWISIW, ok, (a. a.) he is cantankerous, unco-operative, difficult, contrarian, annoying
+
+489
+
+NAY
+
+« NAYETTÂWAN, wa, (a. in,) idem
+« NAYETTÂWITTAWEW, (v. a.) TTAM, TTÂKEW, TTÂTCHIKEW, he is upset from listening to it
+« NAYETTÂWISIWIN, a, (n. f.) being upset, importunity
+« NAYETTÂWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he finds it upsetting, petulant
+« NAYETTÂWEYITTAM, wok, (v. n.) he is upset, unsatisfied
+« NAYETTÂWEYITTAMOWIN, a, (n. f.) discontentment, discomfort
+« NAYETTÂWIHEW, etc., (v. a.) idem
+« NAYETTÂWEYITTÂKUSIW, ok, (a. a.) his voice is upsetting, or, his voice, his speech is unpleasant
+« NAYETTÂWEYITTÂKWAN, wa, (a. in.) idem
+« NAYETTÂWINÂKUSIW, ok, (a. a.) he has a wicked appearance
+« NAYETTÂWINÂKWAN, wa, (a. in.) idem
+« NAYETTÂWIW, ok, (a. a.) he is uncomfortable, embarrassed by his action
+« NAYETTÂWIWIN, a, (n. f.) discomfort, embarrassment
+« NAYETTÂOWEW, ok, (v. n.) he speaks with discomfort, difficulty
+« NAYETTÂWI-PIKISKWEW, ok, (v. n.) idem
+x NAYESTOW, (adv.) nothing but this, purely, (e.g.) Nayestow nipiy, nothing but water, nayestow awâsissak kita pe-ituttewok, it is only the children who will come
+
+NAY
+
+« NAYESTOWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he finds it unique, belonging to only one type, or, he only thinks about him
+« NAYESTOWIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, it is always him that he uses. See. peyakuhew, or, he only does it this way
+« NAYESTOWISIW, ok, (a. a.) he is alone in his type, unmixed
+« NAYESTOWAN, wa,(a. in.) idem
+« NAYESTOWISIWIN, a, (n. f.) a unique thing
+« NAYESTOWIPAYIW, ok, a, (a. a. and in.) it only goes this way
+« NAYESTOWAPIW, ok, (a. a.) he is alone there
+« NAYESTOWAYAMIHAW, ok, (v. n.) he only prays, etc.
+x NAYIM, (v. im.) headwind
+« NAYIMAN, (v. im.) there is a headwind
+« NAYIMAHAM, wok, (v. n.) he goes against the wind, on the water
+« NAYIMISKAM, wok, (v. n.) idem, on the ground
+« NAYIMIHUTTEW, ok, (v. n.) idem
+x NAYO, (adv.) without purpose, uselessly
+« NAYOWÂTCH, or better, nayawâs, idem, e.g. nayawâs pe-kiwew, he returns without having done anything, after having made a journey for nothing
+
+490
+
+NAY
+
+« NAYOSIW, ok, (a. a.) he acts uselessly, without success
+« NAYOYUW, ok, (a. a.) idem
+« NAYOWISIW, ok, (a. a.) idem
+« NAYOSIWIN, a, (n. f.) failure
+« NAYOYUWIN, a, (n. f.) idem
+« NAYOWISIWIN, a, (n. f.) idem
+« NAYOMEW, etc., (v. a.) he speaks to him uselessly, that is to say, he speaks to him out of time, also; he says words to him that he does not deserve
+« NAYAWIW, ok, (v. a.) he is tired, weary
+« NAYOWAPIW, ok, (a. a.) he is completely out of breath, like someone after a race
+« NAYAWISIW, ok, (a. a.) like Nayawiw
+NAYEKIKKÂWISIW, ok, (a. a.) he is prompt, quick to do something
+x NAYEYÂWISIW, ok, (a. a.) he is lethal, disastrous, dangerous
+« NAYEYÂWAN, wam (a. in.) idem
+« NAYEYÂWISIWIN, a, (n. f.) lethality, woe, danger
+« NAYEYÂWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks it lethal, disastrous, dangerous
+x NAYEWATCH, (ad.) between, in the space, e.g. nayewatch pimiyaw, he flies in the air, nayewatch akotchin pisim, the sun is suspended in space, nayewatch nakatam, he leaves it at a certain distance
+« NAYEWATCH KIJIKAW, (ad.) during the day; e.g. nayewatch tibiskaw takusin, he arrives while it is still night, or, before the end of the night
+
+NAW
+
+NAWATCH, (ad.) more, in addition; e.g. nawatch ni ka miweyitten, I will be more content; nawatch mitchetiwok, they are more numerous; nawatch kisiwâk, closer
+x NAWASU, (rac.) to choose
+« NAWASUNEW, (v. a.) NAM, NIWEW, NIKEW, he chooses it
+« NAWASUWÂBAMEW, (v. a.) TTAM, KKEW, TCHIKEW, he chooses it after having considered it
+« NAWASUWÂBAMOW, ok, (v. n.) he makes a choice
+« NAWASUWÂBAMOWIN, a, (n. f.) choice
+« NAWASO, (adv.) of choice; e.g. nawaso mistatim, the horse of coice; nawaso miyo-pimâtisiw, he has an exemplary life among all everyone
++ NÂWEY, (adv.) at a certain distance, behind, following far off; e.g., nâwey petchâstamuttew, he comes in behind; nâwey pittukew, he enters after. See. Nânâwey
+« NAWEYIMEW, ok, (v. n.) he pursues the others who already left camp on the trail
+« NÂWEYIMÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he goes after him on the trail
+x NAWASWEW, ok, (v. n.) he runs after. N.B. This word and its derivations almost always mean: to pursue someone, to hunt by chasing, especially chasing buffalo
+« NAWASWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he hunts it, he pursues it
+
+491
+
+NAW
+
+« NAWASWEWIN, a, (n. f.) chasing on a hunt
+« NAWIPÂTEW, etc., (v. a.) he pursues it, by running, in the water
+« NAWAHWEW, etc., (v. a.) he pursues it in a canoe
+« NAWASWÂTITUWOK, (v. m.) they hunt after one another
+« NAWATAHWEW, (v. a.) HAM, HUWEW, HIKEW, he shoots it in flight
+« NAWATAHIKEW, ok, (v. ind.) he shoots (something) flying
+« NAWATAHIKEWIN, a, (n. f.) shooting things which are flying
+« NAWATAMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he seizes it in his jaws, his mouth, or his beak, while pursuing it
+« NAWATINEW, (v. a.) TTAM, NIWEW, NIKEW, he catches it with his hand, e.g., something which one throws
+x NAW, (rac.) leaning, sloping
+« NAWESIW, (ok, (a. a.) he is leaning
+« NAWEMOW, ok, (a. a.) idem
+« NAWEYAW, a, (a. in.) it is leaning
+« NAWENEW, (v. a.) NAM, NIWEW, NIKEW, he leans it with his hand
+« NAWEPITEW, etc., (v. a.) idem, with his arm
+« NAWEHYEW, etc., (v. a.) he makes it lean
+« NAWESKITEW, (v. a.) TAM, SIWEW, TCHIKEW, he sets it to slope
+« NAWESKISUW, ok, (a. a.) he is leaning, e.g. a tree
+
+NAW
+
+« NAWESKITEW, a, (a. in.) idem, e.g., a tower
+« NAWOKIW, ok, (v. r.) he leans
+« NAWOKIWIN, a, (n. f.) leaning
+« NAWOKISTAWEW, (v. a.) TAM, TÂKEW, TÂTCHIKEW, he leans in front of him
+« NAWOKINEW, (v. a.) NAM, NIWEW, NIKEW, he leans it, he curves it
+« NAWOKIPAYIW, ok, a, (a. a. and in,) it curves, it leans
+« NAWOKISKWEYIW, ok, (v. n.) he does a greeting, he nods his head
+« NAWESKWEYIW, ok, (v. n.) idem
+« NAWOKISKWEYISTAWEW, etc., (v. a.) he nods his head at him
+« NAWESKWEYISTAWEW, etc., idem
+« NAWOKISKWEYIWIN, a, (n. f.) nod of the head
+« NAWESKWEYIWIN, a, (n. f.) idem
+« NAWOKIKÂBÂWIW, ok, (v. n.) he bends over, while standing
+« NAWEKÂBÂWIW, ok, (v. n.) idem
+« NAWEKAPIW, ok, (v. n.) he bends over, while sitting
+« NAWEYÂSKUSIN, wok, (a. a.) he bars the path, e.g. a tree, which, being half fallen over, obstructs the trail
+« NAWEYÂSKUTTIN, wa, (a. in.) idem
+« NAWEYÂSKOMOW, ok, a, (a. a. and in.) idem
+
+492
+
+NEK
+
++ NAWATJIW, ok, (v. n.) he roasts, he fries
+« NAWATJIWIN, a, (n. f.) frying, roasting
+« NAWATJIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he roasts it. Also, he roasts it, though seldom used in the active form for this last fashion (Translator's Note: LaCombe is distinguishing here between 'il le fait rôtir' [literally: 'He makes it roast'] and 'il le rôti' [literally: 'He roasts it'], although in English, these sentences would both be interpreted as 'He roasts it', with no contrast)
+NÊH! (ex) expression of surprise, of shock, of disapproval, proper only for women
+x NEHIYAW, ok, (n. r.) Cree, savage of this name
+« NEHIYÂWIW, ok, (a. a.) he is Cree
+« NEHIYÂWEW, ok, (v. n.) he speaks Cree
+« NEHIYÂWEMOW, ok, (v. n.) idem
+« NEHIYÂWEWIN, a, (n. f.) the Cree language
+« NEHIYÂWEMOWIN, a, (n. f.) idem
+« NEHIYÂWEMOTOTAWEW, etc., (v. a.) he speaks Cree to him
+« NEHIYÂWETOTAWEW, etc., (v. a.) idem
+« NEHIYÂWETTITOWEW, etc., (v. a.) he translates it into Cree for him
+« NEHIYÂWIMASINAHIGAN, a, (n. f.) Cree book
+« NEHIYÂWASKIY, a, (n. f.) Cree country, land
+x NEKÂMISIW, ok, (a. a.) he is the first, he heads. See. Nikânisiw, Nekâman, (ina.)
+« NEKÂMAN, wa, (a. in.) idem
+
+NEK
+
+« NEKÂMINEW, (v. a.) NAM, NIWEW, NIKEW, he takes it first
+« NEKÂMEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he sees it as the first
+« NEKÂMEYIMISUW, ok, (v. r.) he sees himself as the first
+« NEKÂMEYIMOW, ok, (v. r.) idem
+« NEKÂMISIWIN, a, (n. f.) pre-eminence
++ NEKI, (pron. an.) that (over there)
+« NEMA, (pron. in.) that thing there
+« NEHI, (pron. plr. in.) those things there
++ NEMINEW, (v. a.) NAM, NIWEW, NIKEW, he presents it, he offers it, e.g. taking something in his hands, like a priest at the Offfertory, he raises it to, etc.
+« NEMINAMÂWEW, etc., (v. a.) he presents (it) to him, he lifts it towards him
+x NEMOW, ok, (v. n.) he snarls, he growls, the dog
+« NEMOWIN, a, (n. f.) growling of the dog
+« NEMOHEW, etc., (v. a.) he makes him growl
++ NEMITANO, forty
+« NEMITANOWEWOK, (a. a.) they are forty
+« NEMITANOWAW, forty times
+x NENOWINEW, (v. a.) NAM, NIWEW, NIKEW, he divides it in many parts
+« NANOWIHEW, etc., (v. a.) idem
+x NEPEWISIW, ok, (a. a.) he is ashamed
+« NEPEWISIWIN, a, (n. f.) shame
+« NEPEWIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he shames him
+
+493
+
+NES
+
+« NEPEWIHIWEWIN, a, (n. f.) blame, shame
+« NEPEWIMEW, etc., (v. a.) he makes him ashamed by his words
+« NEPEWOKEYIMEW, etc., (v. a.) he is ashamed of him. Also: he judges him to be ashamed
+« NEPEWOKEYIMOW, ok, (v. n.) he thinks he should be ashamed
+« NEPEWOKEYIMOWIN, a, (n. f.) shame in oneself
+« NEPEWINÂKUSIW, ok, (a. a.) he seems shameful
+« NEPEWINÂKWAN, wa, (a. in.) it is shameful
+« NEPEWOKEYITTÂKWAN, wa, (a. in.) idem
+« NEPEWÂKÂTCH, (adv.) shamefulness
+« NEPEWISISTAWEW, (v. a.) TAM, TÂKEW, TÂTCHIKEW, he is ashamed of him
+x NEPPEM, (adv.) on hand, prepared ahead of time, all ready
+« NEPPEMAPIW, ok, (a. a.) he is prepared in advance
+« NEPPEMASTEW, a, (a. in.) it is prepared in advance
+« NEPPEMAHYEW, STAW, YIWEW, TCHIKEW, he readies it in advance
+« NEPPEMIW, ok, (a. a.) he is ready
+« NEPPEMIWIN, a, (n. f.) preparation
+« NEPPEMISTAWEW, etc., (v. a.) he places himself around him, he prepares himself to receive him
+x NESOWISIW, ok, (a. a.) he is weak, without strength
+« NESOWAN, wa, (a. in.) it is weak, incapable
+
+NES
+
+« NESOWISIWIN, a, (n. f.) weakness, incapacity
+« NESOWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he judges it weak, incapable
+« NESOWEYIMISUW, ok, or, MOW, ok, (v. r.) he believes himself to be incapable
+« NESOWÂTISIW, ok, (a. a.) he has a weak, unenergetic character
+« NESOWÂTISIWIN, a, (n. f.) lack of energy
+« NESOWITEHEW, ok, (a. a.) he has a weak heart, he has no courage
+« NESOWITEHEWIN, a, (n. f.) lack of heart, courage
+x NEST, (rac.) indicates weariness, fatigue, being overwhelmed
+« NESTUSIW, ok, (a. a.) he is weary, tired
+« NESTUSIWIN, a, (n. f.) fatigue
+« NESTUHEW, etc., (v. a.) he tires him
+« NESTUMOW, ok, (a. a.) he is tired of talking
+« NESTWEYIMOW, ok, (a. a.) he is tired of laughing or crying
+« NESTUW, ok, (a. a.) like, Nestusiw
+« NESTUTTEW, ok, (a. a.) he is tired of walking
+« NESTUTTEWIN, a, (n. f.) a tiring walk
+« NESTUWÂTISIW, ok, (a. a.) he has no vigour, no strength
+« NESTWEYIMEW, etc., (v. a.) he thinks him to be tired
+« NESTUKKWEKAWIW, ok, (a. a.) he is stricken from having lost too much blood
+« NESTWÂTAKAW, ok, (a. a.) he is tired from walking in the water
+
+494
+
+NES
+
+« NESTWÂKUNÂMOW, ok, (a. a.) he is tired from having walked in the snow
+« NESTUSKIWEW, ok, (a. a.) he is tired from walking in the mud
+« NESTWÂSUW, ok, (a. a.) he is overwhelmed by the heat
+« NESTUPINATEW, etc., (v. a.) he makes him succumb to his blows
+« NESTUYAWEW, ok, (a. a.) he has a tired body
+« NESTUPITUNEW, ok, (a. a.) he has tired arms
+« NESTUKÂTEW, ok, (a. a.) he has tired legs
+« NESKAMIKAW, (v. im.) point where a lake or a river comes forward
+« NESTCH! coarse expression of denial, proper only for men
+« NETE, (ad.) over there
+x NÉ (rac.) that which is pointed, at a peak
+« NETINAW, (n. f.) pointed knife, hill
+« NEYAW, (n. f.) peak of earth in a lake, or river
+« NEWÂTIM, (n. f.) idem
+« NEYÂBISKAW, (n. f.) peaked rock
+« NEYÂSKWEYAW, point of wood, the end of the forest
+« NEYSKWAW, idem
+« NEYÂTTAKAW, (n. f.) pointed wood, pinion of a building
+« NEYEGAN, a, (n. f.) pointed cloth, etc.
+« NESKUTEWEYA, pointed field
++NEWO, four
+« NEWIW, ok, (a. a.) he is four
+
+NEW
+
+« NEWAW, four times
+« NEWIN, wa, (a. in.) it is four
+« NEWIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he divides it in four
+« NEWAPIWOK, (a. a.) there are four seated there
+« NEWEYAK, in four ways
+« NEWEYAKISIW, ok, (a. a.) there are four different ways
+« NEWEYAKAN, wa, (a. in.) idem
+NI, before a consonant, and n't, or, n'int, or n', before a vowel. This is the pronoun of the first person singular and plural, in verbs as well as before nouns, being also the sign of the first third person plural, e.g. ni kiwânân, we return, ni mitjisun, I wat, n'istesinân, our older brother, n'otinânânak, we take it, n't'em, my horse, ni mokkumân, my knife. N.B. It is always n' when the word begins with o and n't or n'it when it begins with one of the other vowels
+x NIKAMUW, ok, (v. n.) he sings. See. Nakamuw
+« NIKAMUWIN, a, (n. f.) singing
+« NIKAMUSTAWEW, (v. a.) TAM, TÂKEW, TÂTCHIKEW, he sings it, he glorifies it
+« NIKAMOHEW, etc., (v. a.) he makes him sing, also, he instructs him on how to do something, he teaches him
+« NIKAMUTTAW, ok, (v. a. in.) he sings it, e.g. a juggler who sings, or does his tricks with his medicines
+
+495
+
+NIK
+
+x NIKÂN, (ad.) before, ahead of, first, firstly, e.g. nikân pikiskwew, he speaks first, nikân pittukewok, they enter first, nikân ni ki wittamâwaw, I said it to him beforehand, nikân ayamiham, pray first, kekway nikân ki wi-itwâ? what did you want to say first?
+« NIKANEYITTÂKUSIW, ok, (a. a.) he is the superior, the first, he is judged to be the first
+« NIKÂNEYITTÂKWAN, wa, (a. in.) it is the principal thing
+« NIKÂNEYITTÂKUSIWIN, a, (n. f.) superiority, priority
+« NIKÂNIW, ok, (a. a.) he is the first, he walks first, he is at the head
+« NIKÂNISIW, ok, (a. a.) idem, nikanan, (in.)
+« NIKÂNIWIN, a, (n. f.) presidency
+« NIKÂNISIWIN, a, (n. f.) idem
+« NIKÂNEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he sees it as the first, he puts it in first place in his mind
+« NIKÂNIKÂT, a, (n. f.) front paw
+« NIKÂNIKISKEYIMEW, etc., (v. a.) he knows it beforehand (præscivit (he has foreknowlege)), he has a premonition of him
+« NIKÂNIMIK, (ad.) in the future, e.g. ni nikânimik, in my future
+« NIKÂNIPAYIW, ok, a, (a. a. and in.) he goes before, it is the first
+« NIKÂNIPAYISTAWEW, etc., (v. a.) he goes ahead of him
+
+NIK
+
+« NIKÂNIHEW, etc., (v. a.) he makes him go before
+« NIKÂNITISAHWEW, (v. a.) he sents him ahead
+« NIKÂNUTTEW, ok, (v. n.) he walks in front
+« NIKÂNUTTAWEW, etc., (v. a.) he walks in front of him
+« NIKÂNAHUW, ok, (v. n.) he goes in front on the water
+« NIKÂNAPIW, ok, (a. a.) he is seated first
+« NIKÂNAPIWIN, a, (n. f.) seat of honour
+« NIKÂNAPIHEW, etc., (v. a.) he seats him first
+NIKIHIKUMAW, ok, (v. in.) parent, father, or mother, e.g. ni nikihik, the author of my days (my parent)
++ NIKIK, wok, (n. r.) otter
+« NIKIKWEYÂN, ak, (n. f.) otterskin with hair
+NIKUTIS, (ad.) apart, outside of dwellings
+NIKUT, certain (quidam (something))
+NIKUTITA, (ad.) one day, there will come a time, or, nikutik, in quodam loco ()
+NIKUTONIK, or, NIKUTONIKKA, (adv.) idem
++ NIKUTTEW, ok, (v. n.) he chops down firewood
+« NIKUTTAWEW, etc., (v. a.) he logs for him
+NIKUTON, (adv.) formerly
+NIKUT, See. Nando, e.g. nama nikut ni totâk, he does nothing to me, ketchina nikut n't'ik, he is definitely saying something about me
+
+496
+
+NIM
+
+x NIKOTOWA, (pron.) one or the other, e.g. kiyawaw nikotowa peyak kita ituttew, there is one of you who is going to go, namawiya nikotowik ni witjehiwân, I am not in that category
+« NIKOTWÂWISIW, ok, (a. a.) he is of that type, of that sort
+« NIKOTWÂWAN, wa, (a. in.) idem
++ NIKOTWÂSIK, six
+« NIKOTOWÂSIW, ok, (a. a.) he is six
+« NIKOTOWÂSIN, wa, (a. in.) idem
+« NIKOTOWÂSIKOWIKIJIKAW, (n. f.) the sixth day, Saturday
+« NIKOTOWÂSIKWAW, six times
+« NIKOTOWÂSOSÂB, sixteen
+« NIKOTOWÂSOMITANOWM sixty
+NIKWATISIW, ok, (v. n.) See. Nakwatisuw, he goes to look for meat on the hunt
+NIMÂHWEW, etc., (v. a.) he threatens to hit him, he lifts his hand at him
++ NIMÂSKUSIN, wok, (a. a.) he is raised from the ground, he does not touch
+« NIMÂSKUTTIN, wa, (a. in.) idem
+« NIMÂSKWAHWEW, (v. a.) HAM, HUWEW, HIKEW, he lifts it in the air, on the end of a piece of wood, or a rod
+« NIMÂSKWEW, ok, (v. n.) he is armed, he has his weapons with him
+« NIMÂSKWEWIN, a, (n. f.) armour, defense
+« NIMÂSKWÂGAN, a, (n. f.) defensive weapon
+« NIMÂSKWÂHEW, etc., (v. a.) he arms him, he gives him weapons
+
+NIM
+
+x NIM, (rac.) to carry with oneself, to have provisions of food, he is provisioned with foodstuffs
+« NIMÂWIN, a, (n. f.) provisions of foodstuffs, provisions for a journey
+« NIMÂHEW, etc., (v. a.) he gives him provisions for the journey
+« NIMÂKISTEW, etc., (v. a.) idem
+« NIMAPPITEW, ok, (v. n.) he has a smoking bag with him
+« NIMAKUPPEW, ok, (v. n.) he has his blanket
+« NIMASKISINEW, ok, (v. n.) he has his shoes
+« NIMIPÂSKISIGANEW, ok, (v. n.) he has his rifle with him
+« NIMIKKUMÂNEW, ok, (v. n.) he has a knife with him
+« NIMOKKUMÂNEW, ok, (v. n.) idem. N.B. By placing the root nim as an affix, and giving a verbal suffix to a noun, your form a multitude of other words like those above; e.g., nimaskikkwew, nimitchikahiganew, nimopew, nimastimwew, he has with him, for the journey, a boiler, an axe, water, a horse, etc.
+x NIMIW, ok, (v. n.) he dances
+« NIMIHITUW, ok, (v. m. used like v. n.) he accompanies the dance
+« NIMIWIN, a, (n. f.) dance
+« NIMIHITUWIN, a, (n. f.) idem
+« NIMIHITUWINIKKEW, ok, (v. n.) he does a dance
+« NIMIHITUWIKANIK, wa, (v. n.) dancing lodge, hall. N.B. Simow is a suffix which indicates dance; e.g. nittâwisimow, he dances well; ponisimow, he stops dancing
+
+497
+
+NIP
+
+x NIMITAW, (adv.) the faraway, off of the prairie, and on the water; nimitaw ayâwok, they are off
+« NIMITÂSIW, ok, (v. n.) he gains (distance) at sea, he gains (distance) in the prairie
+« NIMITÂSIPAYIW, ok, a, (a. a. and in.) he gains towards the prairie
+« NIMITÂSIPATTAW, ok, (v. n.) he runs out to sea
+« NIMITÂHAM, wok, (v. n.) One says this word when certain animals, like the deer, the moose, etc., leave the forest and the heavily wooded areas in autumn to run after females
+« NIMITÂWAHAM, wok, (v. n.) he gains (ground) towards the sea on the water
+« NIMITÂWEYÂSKWEYAW, a, (n. f.) point of the woods which sticks out into the prairies
+x NINIKKOWEW, ok, (v. n.) he speaks with an urgent tone, a tone to hurry. See. Nanikkowew
+« NINIKKISIW, ok, (a. a.) he is in a great hurry
+« NINIKKISIWIN, a, (n. f.) hurry
+« NINIKKIMEW, etc., (v. a.) he urges him, he hurries him
+« NINIKKATÂMOW, ok, (v. n.) he speaks trembling, he speaks in a tone of voice to hurry, or, nanikkatâmow
+x NIP, (rac.) to kill
+« NIPAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he kills him
+
+NIP
+
+« NIPATTOWEW, (v. a.) TTÂKEW, etc., he kills him for him
+« NIPATTÂKEW, ok, (v. ind.) he commits murder
+« NIPAHIWEW, ok, (v. ind.) idem
+« NIPATTÂKEWIN, a, (n. f.) murder
+« NIPAHIWEWIN, a, (n. f.) idem
+« NIPAHIMOW, ok, (v. r.) he dies from crying, laughing, or speaking
+« NIPAHÂBÂKWEW, ok, (v. n.) he dies of thirst
+« NIPAHÂBÂKWEWIN, a, (n. f.) death of thirst
+« NIPAHÂBÂKWAHEW, etc., (v. a.) he makes him die of thirst
+« NIPAHISIMEW, (v. a.) TITAW, SIMIWEW, etc., he kills him by throwing him to the ground
+« NIPAHISIN, wok, (v. r.) he kills himself by falling
+« NIPAHIKOSISSEW, ok, (v. n.) she kills that which she carries in her bosom. For a woman, one generally says Osikohuw
+« NIPAHOSEW, ok, (v. n.) idem
+« NIPAHISUW, ok, (v. r.) he kills himself, he gives himself to death
+« NIPAHISUWIN, a, (n. f.) suicide
+« NIPAHISKOYUW, ok, (v. r.) he kills himself by overeating
+« NIPAHISKOYEW, etc., (v. a.) he kills him by overfeeding him
+« NIPAHISKAWEW, etc., (v. a.) he kills him by placing himself on him
+« NIPÂKWESIMOW, ok, (v. n.) he experiences a great thirst while dancing
+
+498
+
+NIP
+
+« NIPÂKWESIMOWIN, a, (n. f.) great festival of the infidel savages, where, for three or four days, they occupy themselves with dancing, without eating or drinking
+« NIPEKKOHUW, he is hunting
+« NIPIW, ok, (a. a.) or, Nipuw, ok, he is dead
+« NIPIWIN, a, (n. f.) or, Nipuwin, a, death
+« NIPUKKAWEW, etc., (v. a.) he pretends to be dead, in front of him
+« NIPUKKÂSOTOTAWEW, etc., (v. a.) idem
+« NIPAHEYITTAM, wok, (v. n.) he dies of grief, or of boredom
+« NIPAHEYITTAMOWIN, a, (n. f.) mortal grief
+« NIPUWÂTISIW, ok, (a. a.) he is as if dead, indolent, moribund
+« NIPUWIW, ok, (a. a.) he is paralysed
+« NIPUWISIW, ok, (a. a.) idem
+« NIPUWAN, wa, (a. in.) it is paralysed
+« NIPUWISIWIN, a, (n. f.) paralysis
+« NIPWÂTEW, etc., (v. a.) he kills him with his spells, his medicines. N.B. Continuation of the same root
+« NIPAW, ok, (v. n.) he sleeps
+« NIPÂWIN, a, (n. f.) sleep
+« NIPA-TIBISK, (ad.) during the night
+« NIPÂYÂSTEW, (v. im.) there is moonlight
+« NIPÂHUW, ok, (v. n.) he goes by canoe in the nighttime
+
+NIP
+
+« NIPEHEW, etc., (v. a.) he makes him sleep
+« NIPEWÂBUIY, a, (n.f .) sleeping water, opium
+« NIPEPPIW, ok, (v. n.) he stays on watch a long time during the night, he stays a long time without sleeping
+« NIPEWIN, a, (n. f.) bed, place for sleeping
+« NIPEWINIKKEW, ok, (v. n.) he makes a bed
+« NIPÂWIKAMIK, wa, (n. f.) dormitory
+« NIPÂTTEW, ok, (v. n.) he walks at night, or, the night comes while he is walking
+« NIPÂTTEWIN, a, (n. f.) walking at night
+« NIPÂSKAW, ok, (v. n.) he prowls at night
++ NIPÂWIW, ok, and, NIBÂWIW, (v. n.) he stands upright
+« NIPÂWIWIN, a, (n. f.) the action of standing upright
+« NIPÂWIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes him stand upright
+« NIPÂWISTAWEW, (v. a.) TAM, TÂKEW, TÂTCHIKEW, he stands upright in front of him
+« NIPASKUW, ok, (v. n.) he is standing on his knees
+« NIPASKUPIW, ok, (a. a.) he is sitting on his knees
++ NIPIN, wa, (n. r.) summer; nipinôk, last summer; ke nipîk, next summer; ekwa niso nipin aspin ka wâbamak, two summers ago, I saw him
+« NIPIN, (v. im.) it is summer
+« NIPINAPIW, ok, (a. a.) he stays in his house during the summer, he does not want to go journeying at this time
+
+499
+
+NIP
+
+« NIPINISIW, ok, (a. a.) he spends the summer, he spends the summer there
+« NIPINÂYAW, plur. nipinâyak and, nipinâyinssak, (n. f.) summer bird, game
+« NIPINASKAMIKAW, (v. m.) the land of summer, as it is in summer
++ NIPIY, a, (n. r.) leaf, (pronounced nîpiy)
+« NIPISKAW, (v. im.) there are many leaves. N.B. The suffix pakaw indicates leaves; e.g. kisipakaw, the leaves are finished sprouting
+x NIPIY, a, (n. r.) water. N.B. The suffix abuiy, a, in nouns indicates; e.g., iskutewâbuiy, fire water, siwâbuiy, vinegar; bâwew and pew, in verbs; e.g. kâssiyâbawew, it washes away with the water; nâtipew, he goes looking for water
+« NIPIMINÂN, a, (n. r.) red seed, pembina
+« NIPIWIW, ok, (a. a.) he is wet, there is water on him
+« NIPIWAN, wa, (a. in.) idem
+« NIPIWIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it water, he puts water in it
+« NIPIKKATTEW, (v. a.) TTAM, etc., he prepares it, he arranges it with water
+« NIPISKAW, (v. im.) there is lots of water
+« NIPIWASPINEW, ok, (a. a.) he is dropsical
+
+NIP
+
+« NIPIWASPINEWIN, a, (n. f.) dropsy
+x NIPISIY, a, (n. r.) willow
+« NIPISIYÂTTIK, wok, (n. f.) willow wood
+« NIPISIKKUBAW, (v. im.) there are many willows, or, sakikkubaw. N.B. The suffix kkubaw indicates clusters of willows, or other branches which are simply brush; mikokkubaw, there, or there are red branches
++ NIPISKEW, ok, (v. n.) he breathes. This is one of the magics of the jugglers, who breathe sicknesses, and make believe that they tear all sorts of objects from the body, iron, bone, etc.
+« NIPISKEWIN, a, (n. f.) the operation of the jugglers on sicknesses, accompanied with breathing and chanting
+« NIPISKÂTEW, etc., (v. a.) he breathes it
+x NIPITE, (ad.) in line, head on
+« NIPITESIN, wok, (a. a.) he is spread out, lying down in line
+« NIPITETTIN, wa, (a. in.) idem
+« NIPITESIMEW, (v. .a) TITTAW, SIMIWEW, etc., he spreads it out on the ground, he lies it out in line
+« NIPITEKÂBÂWIWOK, (a. a.) they are standing in line, head on
+« NIPITEPIWOK, (a. a.) they are seated in line
+« NIPITESKAWEW, etc., (v. a.) he goes along the rows. See. Akineskawew
+« NIPITEHYEW, (a. a.) STAW, YIWEW, TCHIKEW, he places it in line
+x NISIK, (ad.) calmly, e.g. nisik pikiskwe, speak calmly, nisik pimuttew, he walks slowly
+
+500
+
+NIS
+
+« NISIKKÂTCH, (ad.) idem, carefully
+« NISIKKÂTISIW, ok, (a. a.) he has a calm character
+« NISIKKÂTISIWIN, a, calmness of character
+« NISIKKEPAYIWIN, a, (n. f.) gallop
++ NISI! (ex.) See! Ostikwân nisi! what a head! oskijikwa nisi! what eyes! k'etwewitak nisi! what verbiage, see!
++ NISIKKATCH, (ad.) solitarily, e.g. nisikkatch taki ayâwok, they are always alone
+« NISIKKATISIW, ok, (a. a.) he is alone outside, with his family
+« NISIKKATISIWIN, a, (n. f.) solitude, e.g. nisikkatisiwin sâkittaw, he likes solitude
++ NISK, (n. r.) the right. This word is not said without a pronoun, e.g. ni kitchi-nisk, my right; okitchi-nisk, his right
++ NISKÂ, pl, niskak, (n. r.) bustard
+« NISKIKWAN, ak, (n. f.) feather of a bustard
+« NISKIPISIM, (n. f.) month of the bustard, March
+« NISKASINIY, a, (n. f.) bustard stone, lead
+« NISKIKKÂN, ak, (n. f.) dummy bustard, decoy
+« NISKIMIN, a, (n. f.) bustard seed, a type of blueberries
+NISK, wok, (n. r.) a cut of meat under the ear, e.g. ni nisk, ki nisk, oniskwa
+
+NIS
+
+x NISO, two
+« NISIWOK, (a. a.) they are two, e.g. on the same horse
+« NISOKÂBÂWIWOK, (a. a.) they are two standing
+« NISWAW, (ad.) twice
+« NISOSÂB, (a. c.) twelve
+« NISOSÂBIWOK, (a. a.) they are twelve
+« NISITANOW, (a. c.) twenty
+« NISITANOWAW, (ad.) twenty times
+« NISOSTAWEW, (v. a.) he kills both of them in a single blow
+« NISOKKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he comes to him to help
+« NISOKKAMOK, (v. n.) they are both in the same canoe. The suffix skam indicates: to go on the water, e.g. peyakuskam, he is alone on his boat
+« NISOKKAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he helps him out. See. Otchikkamâwew
+« NISOKKAMÂTUWOK, (v. m.) they help one another
+« NISOKKAMÂTUWIN, a, (n. f.) mutual help
+« NISOKKAMÂKEWIN, a, (n. f.) help, e.g. Manitowinisokkamâkewin, divine grace
+« NISWAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he couples him
+« NISOKKWÂMIWOK, (v. n.) they both sleep together
+« NISOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he divides it in two
+« NISOKKAMIKISIWOK, (a. a.) they are two tents, two lodges together
+
+501
+
+NIS
+
+« NISONISK, (n. f.) two fathoms
+« NISOSITEW, ok, (a. a.) he has two feet
+« NISOSKÂN, (n. f.) two bands, two tribes
+« NISOSKÂNISIW, ok, (a. a.) they are two nations
+« NISOSKÂNEKAMIKISIWOK, (a. a.) idem
+« NISOSKISIN, (n. f.) two pairs of shoes
+« NISOSKWEWEW, ok, (a. a.) he has two wives
+« NISOTEW, ok, (n. f.) twin
+« NISOTEWIWOK, (a. a.) they are twins
+« NISOTIBISKWEW, ok, (a. a.) he is two nights absent
+« NISOTESKAWEW, ok, (a. a.) he has two horns
+« NISOWITEW, ok, (a. a.) idem
+« NISOTTOWEW, etc., (v. a.) they share it in two
+« NISOTTAK, (v. n.) two canoes, barges, etc.
+« NISOTTAKISIWOK, (a. a.) they are two canoes together
+« NISWEYAKAMUW, a, (a. in.) double trail, two trails
+« NISOMOW, a, (a. in.) double, e.g. double-barrelled rifle
+« NISOMOWITTAK, (n. f.) rifle with two shots
+« NISWÂBISKAW, (a. in.) idem
+« NISWEYAK, (ad.) in two manners
+
+NIS
+
+« NIWEYAKISIW, ok, (a. a.) it is in two ways
+« NISWEYAKIHUW, ok, (a. a.) idem
+« NISWEYAKAN, wa, (a. in.) it is in two ways
++ NISOWISIW, ok, (a. a.) he is nonchalant, weak, incapable, powerless, etc.
+« NISOWISIWIN, a, (n. f.) incapacity
+« NISOWAN, wa, (a. in.) it is weak, without vigour
+« NISOWÂTISIW, ok, (a. a.) indolent character
+« NISOWÂTISIWIN, a, (n. f.) indolence, moral incapacity
+« NISOWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks him incapable, he thinks him to be without strength
+« NISOWEYIMISUW, ok, (v. r.) he lowers himself, he humiliates himself
++ NISIT, (rac.) to understand, to recognise
+« NISSITAW, (ad.) This word seems to be used only with negation, e.g. nama nissitaw, it does not concur, nama nissitaw kitchi pâppiyan anotch, it does not fit that you are laughing right now
+« NISSITAWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he understands it, he recognises it in his mind
+« NISSITÂWINAWEW, (v. a.) NÂKEW, NAM, NÂTCHIKEW, he recognises it by seeing it
+« NISITOTTAWEW, (v. a.) TTAM, TTÂKEW, TTÂTCHIKEW, he understands it, he hears what he says
+« NISSITOTTAM, wok, (v. n.) he understands
+
+502
+
+NIS
+
+« NISSITOTTAMOWIN, a, (n. f.) intelligence
+« NISSITOMATJIHUW, ok, (v. r.) he knows what he is feeling
+« NISSITOMEW, etc., (v. a.) he makes him understand, or better, he makes him remember. See. Miskawâsomew, kiskisomew
+« NISSITOSIW, ok, (a. a.) he has a delicate sense of smell. However, the word is taken to mean, he is fat, he is in good condition, he is quite fat
+« NISSITWAW, a, it is quite fat, it has quite a good taste
+« NISSITOSPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he recognises the taste
+« NISSITOSPWEW, (v. a.) idem
+« NISSITOTTÂKUSIW, ok, (a. a.) he is comprehensible, intelligible
+« NISSITOTTÂKWAN, wa, (a. in.) idem
+« NISSITÂWÂKÂTISIW, ok, (a. a.) only with negation, e.g. nama nissitâwâkâtisiw, he is an idiot, incomprehensible
+« NISSITÂWEYITTÂKUSIW, ok, (a. a.) he is recognisable
+« NISSITÂWEYITTÂKWAN, wa, (a. in.) idem
+« NISSITOTTAMOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes him understand
++ NISTA, (ad.) also, as well, similarly, e.g. nista matchipimâtisiw, he also lives badly, nista ki ka nipin, you will also die
++ NISTA, (pron.) me too, kista, you too, wista, him too
+
+NIS
+
+« NISTÂKAWIYA, k'istâkawiya, etc., e.g. n'istâkawiya kitimâkisiw, he resembles me, he is like me, he takes mercy, k'istâkawiya nama iyinisiw, like you, he is not wise
+x NISTAM, (ad.) in the first place, firstly, e.g. nistam takusin, he arrives first, nistam otittew, he arrives around him first. See. Nikân
+« NISTAMAYISIYINIW, ok, (n. f.) the first man
+« NISTAMOSÂN, ak, (n. f.) firstborn
+« NISTAMOKOSISSÂN, ak, (n. f.) idem
+« NISTAMOSÂNIWIW, ok, (a.a .) he is the eldest
+« NISTAMOSÂNIWIWIN, a, (n. f.) birthright
+« NISTAMIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he places it first, he places it in first
+« NISTAMIK, (ad.) in first place, to begin
+« NISTAMOKKEW, ok, (v. n.) he is in front of the canoe, etc.
+« NISTAMOKKEWIYINIW, ok, (n. f.) pilot, he who watches out of the front of the vessel
+« NISTAMISIW, ok, (a. a.) he is the first
+« NISTAMAN, wa, (a. in.) idem
+« NISTAMISIWIN, a, (n. f.) first place
+« NISTAMAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he places it first
+« NISTAMAPIW, ok, (a. a.) he is the first seated
+
+503
+
+NIS
+
+« NISTAMASTEW, a, (a. in.) it is placed in first place
+« NISTAMAPIWIN, a, (n. f.) first place
+« NISTAMUTTEW, ok, (v. n.) he walks to the head/front
+« NISTÂBÂWEW, ok, (v. r.) he drowns
+« NISTÂBÂWEWIN, a, (n. f.) drowning
+« NISTÂBÂWAYEW, (v. a.) TAW, YIWEW, TCHIKEW, he drowns him
+« NISTÂBÂWAYISUW, ok, (v. r.) he deliberately drowns himself
++ NISTÂSEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he consoles himself, he distracts himself by thinking of him, or, by staying with him
+« NISTÂSEYIMOW, ok, (v. r.) he consoles himself, he distracts himself
+« NISTÂSEYIMOWIN, a, (n. f.) satisfaction, consolation
+« NISTÂSISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he consoles him, he distracts him
+x NISTÂWÂYAW, (a. in.) confluence of two rivers
+« NISTÂWITTIN, wa, (a. in.) idem
+« NISTÂWAMUW, a, (a. in.) junction of two paths
++ NISTOTEW, ok, (v. n.) he travels alone with his family
+« NISTOTEWIN, a, (n. f.) a family, travelling alone
++ NISTO, (a. c.) three, 3
+« NISTIWOK, (a. a.) they are three
+« NISTINWA, (a. in.) idem
+« NISTWAW, (adv.) thrice
+« NISTOSÂB, (a. c.) thirteen
+« NISTOSÂBIWOK, (a. a.) they are thirteen
+
+NIS
+
+« NISTOSÂBWAW, (adv.) thirteen times
+« NISTOMITANOW, (a. c.) thirty
+« NISTOSÂBOMITANOW, (a. c.) one hundred and thirty
+« NISTOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he shares it in three
+« NISTWAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he puts it in three places
+« NISTWEYAK, (ad.) in three ways
+« NISTWEYAKISIW, ok, (a. a.) he is trine (divided in three)
+« NISTWEYAKIHUW, ok, (a. a.) idem, he is in three ways; e.g., Kijemanito nistweyakihuw, God is trine (a trinity)
+« NISTWEYAKAN, wa, (a. in.) it exists in three ways
+« NISTWEYAKIKUWIN, a, (n. f.) trinity; Kitchitwa-Nistweyakihuwin, the Holy Trinity
+« NISTOKÂTEW, ok, (a. a.) he has three legs, or paws
+« NISTOKAWEWOK, (v. a.) they are three against one
+« NISTOKAMOK, (v. n.) they are three in the same canoe
+« NISTOKAMIKISIWOK, (a. a.) they are three lodges, they form a camp of three lodges
++ NITTA, (rac.) suitable for, able to, etc., adept at, etc.,; e.g., nittapikiskwew, he knows how to speak well; nitta-atuskew, he works well; nitta-peyaku-mitjisuw, he knows how to eat alone; nitta-kisiwâsiw, he is angry; nitta-pittwaw, he is already a big smoker
+« NITTÂWIKIW, ok, (a. a.) he was born
+
+504
+
+NIT
+
+« NITTÂWIKIN, wa, (a. in.) idem
+« NITTÂWIKIWIN, a, (n. f.) birth
+« NITTÂWIKIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he gives birth to him, she brings him into the word
+« NITTÂWIKINÂWASUW, ok, (v. n.) she gives birth
+« NITTÂWIKINÂWASUWIN, a, (n. f.) childbirth
+« NITTÂWIKITCHIKEW, ok, (v. n.) he sows the earth
+« NITTÂWIKITCHIKEWIN, a, (n. f.) agriculture, sowing
+« NITTÂWIKITCHIGAN, a, (n. f.) seeded field, garden
+« NITTÂWEW, ok, (a. a.) he knows how to speak, e.g. a child who already knows how to speak. Also: he is an orator, a good speaker
+« NITTÂWEYIMEW, etc., (v. a.) he thinks him to be capable of it
+« NITTÂWHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he is capable of it, he can do it; e.g. Kijemanito kakiyaw kekway nittâwittaw, God knows how to do everything, or can do everything
+« NITTÂHUTTEW, ok, (v. n.) he is a good walker
+« NITTÂSINAHIKEW, ok, (v. n.) he writes well
+« NITTÂNIKAMUW, ok, (v. n.) he is skillful at singing
+« NITTÂWISIMOW, ok, (v. n.) he dances well
+« NITTÂWÂTÂKAW, ok, (v. n.) he swims skillfully
+« NITTÂWOSEW, ok, (v. n.) she is fertile, she is not sterile
+
+NIT
+
+x NITT, (rac.) to descend, to throw to the ground
+« NITTINEW, (v. a.) NAM, NIWEW, NIKEW, he lowers it, he takes it down
+« NITTÂSIW, ok, (a. a.) he falls, he sags under the wind
+« NITTÂSTAN, wa, (a. in.) idem
+« NITTAKUSIW, ok, or, SEW, ok, (v. n.) he descends
+« NITTATCHIWEW, ok, (v. n.) he descends one side
+« NITTATCHIWEPAYIW, ok, a, (v. n.) idem, by running
+« NITTATCHIWEWIN, a, (n. f.) descent
+« NITCHÂYIK, (adv.) at the bottom
+« NITTÂMATIN, (ad.) at the bottom of a side, hill, or mountain
+« NITTÂWIHEW, TTAW, he is skillful at doing it
+« NITTÂWITJITCHIKEWIN, a, skillfulness at doing, etc.
+« NITCHIPAYIW, ok, a, (v. n.) he falls to the ground
+« NITCHIWEBINEW, (v. a.) NAM, NIWEW, NIKEW, he throws it to the ground
+« NITCHIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he pulls it from high up to make it fall to the ground
+« NITCHIWEPAHWEW, (v. a.) HAM, HUWEW, HIKEW, he pushes him to the bottom by shaking him
++ NITCHIKISIW, ok, (a. a.) he appears as a point in the distance
+« NITCHIKAW, a, (a. in.) it appears as a point in the distance
+O NITCHIKISKWAPIWIN, a, (n. f.) place where it appears as a points in the distance. (Informally, Lac Laselle)
+
+505
+
+NIY
+
++ NIYA, (pron.) me; nista, me too
+« NIYÂNÂN, or, NIYÂN, (pron.) we, (me and him, 1st-3rd pers.)
+« NIYA WIYA, as for me
+« NIYÂNAN, (a. c.) five
+« NIYÂNANIW, ok, (a. a.) they are five
+« NIYÂNANIN, wa, (a. in.) idem
+« NIYÂNANOSÂB, (a. c.) fifteen
+« NIYÂNANWAW, (adv.) five times
+« NIYÂNANOMITANOW, (a. c.) fifty
+« NIYÂNANOSÂBOMITANOW, (a. c.) one hundred and fifty
+« NIYÂNANOSÂBIWM ok, (a. a.) they are fifteen
+« NIYÂNANOSÂBIN, wa, (a. in.) idem
++ NIYASKUTCH, in my turn; kiyaskutch, in your turn; wiyaskutch, in his turn
+« NIYASKWATAM, kiyaskwatam, etc., idem
+« NIYASKWATAMINÂN, etc., idem
++ NIYÂK, (ad.) in advance, before; e.g. niyâk wittam, he predicts it; niyâk kiskeyittam, he knows it in advance
+NIYÂN, (v. n. imp.) go, leave; niyânk, go, leave. N.B. This verb has on these two persons (2P singular and 2P plural) in the imperative
+x NIYAMISIW, ok, (a. a.) he is weak, powerless
+« NIYAMAN, wa, (a. in.) idem
+« NIYAMAW, a, (a. in.) idem
+
+NIY
+
+« NIYAMÂTISIW, ok, (a. a.) idem
+« NIYAMASIN, wa, (a. in.) idem
+« NIYAMATAN, wa, (a. in.) idem
+N'TAWÂTCH, or, NITAWÂTCH, (adv.) it doesn't matter. N.B. To abandon a plan, an idea, a thing, despite the regret that one experiences. Examples of usage are more illustrative; e.g., n'tawâtch namawiya ni wi-ituttân, I will not go despite the desire that I had; n'tawâtch ka pe-ayamihât, (irony) now that he doesn't know what to do, he's coming to pray; n'tawâtch wa-kimiwak, it finally rains, it should have happened a long time ago; n'tawâtch ekawiya nando itwe, it is better for you to say nothing, etc.
+x NOK, (rac.) to appear in view, to appear, to show
+« NOKUHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it appear, he makes it manifest
+« NOKUSIW, ok, (a. a.) he appears in view, he is visible, he is born
+« NOKWAN, wa, (a. in.) idem
+« NOKUSIWIN, a, (n. f.) view, presence
+« NOKUTTOWEW, etc., (v. a.) he shows him, he demonstrates to him
+« NOKUTTÂWIN, a, (n. f. ) demonstration
+« NOKUHUW, ok, (v. r.) he appears in such a form
+« NOKUHUSTAWEW, etc., (v. a.) he appears to him
+« NOKUHUSUSTAWEW, etc., (v. a.) idem
+
+506
+
+NOM
+
+« NOKUHÂWASUW, ok, (v. n.) she delivers (a child)
+« NOKUHÂWASUWIN, a, (n. f.) delivery (of a child)
+« NOKUSISTAWEW, etc., (v. a.) he appears before him
+« NOKUSISTAMÂWEW, etc., (v. a.) idem, or, he presents it before him
+« NOKWANÂTIKUSIW, ok, (a. a.) his footprints appear, his traces are visible
+« NOKWANÂTIKWAN, wa, (a. in.) the traces are visible
+x NOKKWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he licks it
+« NOKKWÂTCHIKEW, ok, (v. n.) he licks the dishes
+x NOMANAK, (ad.) an instant, e.g. kanak
+« NOMANAKÊS, (ad.) or nomakês, for a while, for a time; e.g. nomanakês pimâtisiyani; if I still live for some time; nomanakês ki miyo ayaw, he has been well for some time
++ NOMI, (prep.) for a while, e.g. ni nomi witjiwaw, I will go the the end of the trail with him; nomisipwettew, he leaves only a little, he only comes a long way
+« NOMIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he does it a little, he only does a part
+« NOMISIHEW, etc., (v. a.) idem
+« NOMIKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he is only starting to chop it down
+« NOMIKKUTEW, (v. a.) TAM, SIWEW, TCHIKEW, he slices it a bit
+
+NON
+
++ NONÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he suckles her, he sucks her
+« NONIW, ok, (v. n.) he suckles, he sucks the breast
+« NONIHEW, (v. a.) etc., she makes him suckle
+« NOYEW, etc., (v. a.) she breast-feeds
+« NOYÂWASUWIN, a, (n. f.) breast-feeding
++ NOSATTAM, wok, (v. n.) he cannot eat everything that one has given him
+« NOSATCHIKEW, ok, (v. n.) he cannot eat everything
+NOSAWI, (adv.) following, e.g. nosawi nit itwewân, I said after him, I follow him
+x NOSÉS, ak, (n. r.) female. N.B. nosé before the noun indicates the female type of the animal, e.g.
+« NOSEMASKWA, ok, (n. f.) female beat
+« NOSEMUSTUS, wok, (n. f.) cow, or better, onitjâniw, ok
+« NOSEMEK, wok, (n. f.) female fish
+« NOSÉSIB, ak, (n. f.) female duck
+« NOSÉNISKÂ, ak, (n. f.) female bustard
++ NOSOSKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he pursues him. he attaches himself to him
+« NOSAM, (ad.) e.g. nosam n't'ituttân, I am going further than I initially though to go
+« NOSAMÂTCH, (ad.) idem, e.g. nosamâtch nama ki pe-kiwew, he is already so far out that he cannot return, nosamâtch witjewew, he accompanies him farther than he thought. See. Nanosamâtch
+
+
+
+
+
+« NOSAWÂBAMEW, etc, (v. a.) he watches him go away
+NOSPEYAW, (ad.) there are many places, mistahi tawaw
++ NOTT, (rac.) less, defectively
+« NOTTOW, (ad.) below, before ending, e.g. nottow ni pe-kiwân, I come back before arriving (where I wanted to go), nottow ni ponittân, I abandon it before finishing it, nottow ni kiispun, I stop eating before being full, nottow ni nakatik, he abandoned me before the time
+« NOTTESIN, wok, (a. a.) he is weary, needing rest
+« NOTTESIMEW, etc., (v. a.) he wearies him, he makes him rest
+« NOTTEYEYIMEW, etc., (v. a.) he thinks that it is all over with him
+« NOTTEWEYIMEW, etc., (v. a.) he thinks he is weary
+« NOTTOWITEYIMEW, etc., (v. a.) idem, he thinks him lesser
+« NOTTÂSKOYUW, ok, (a. a.) he has not eaten enough, he is not full
+« NOTTÂSKOYEW, etc., (v. a.) he does not satiate him
+« NOTTEKINEW, (v. a.) NAM, NIWEW, NIKEW, he lacks enough to wrap it
+« NOTTEKIW, ok, (a. a.) he lacks enough of to wrap himself up
+« NOTTASKINEW, ok, (a. a.) he is not full
+« NOTTASKINAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he does not fill it
+
+NOT
+
+« NOTTEPAYIW, ok, a, (a. a. and in.) he lacks it, he does not have enough of it
+« NOTTEHWEW, (v. a.) HAM, HUWEW, HIKEW, the blow (which he wanted to give him) does not reach him
++ NOTTÉ, (ad.) to need to, to wish to, e.g. notte-mâtuw, he wants to cry; ni notté pitukân, I want to enter, kekway ka notte ayâyan? what do you want to have?
+« NOTTEKATEW, ok, (a. a.) he is hungry, he needs to eat
+« NOTTEKWÂMIW, ok, (a. a.) he is forced to set up camp, to sleep before arriving
+« NOTTEKWASIW, ok, (a. a.) he is falling asleep
+« NOTTEKWASIWIN, a, (n. f.) desire to sleep
+« NOTTEKWASTIMEW, etc., (v. a.) he makes him experience the desire to sleep, he tires him to the point that he makes him sleep
+« NOTTEKATEHEW, etc., (v. a.) he starves him
+« NOTTEYÂBÂKWEW, ok, (a. a.) he is thirsty
+« NOTTEYÂBÂKWAHEW, etc., (v. a.) he alters him
+« NOTTEKATEWIN, a, (n. f.) hunger
+« NOTTEYÂBÂKWEWIN, a, (n. f.) thirst
+« NOTTEYÂBÂKWETOTAM, wok, (v. a. im.) he is thirsty for it
+
+508
+
+NOT
+
+x NOT, (rac.) to torment, to work, to not give rest
+« NOTCHIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he works him, he punishes him, he torments him
+« NOTCHITCHIKEW, ok, (v. ind.) he unts, he works pelts
+« NOTCHITCHIKEWIN, a, (n. f.) the hunt, work
+« NOTCHIHITUWOK, (v. n.) they court each other, they are in heat
+« NOTCHIKKAWEW, (v. a.) KKAM, KKÂKEW, etc., he is after her, he frequents her (in a bad way)
+« NOTCHIHISKWEWEW, ok, (v. n.) he courts women
+« NOTCHIHISKWEWEWIN, a, (n. f.) passion for women
+« NOTCHIHISKWEWÂTEW, etc., (v. a.) he does bad things with her
+« NOTCHIKINUSEWEW, ok, (v. n.) he fishes
+« NOTISIBEW, ok, (v. n.) he hunts for ducks
+« NOTAMISKWEW, ok, (v. n.) he hunts for beavers
+« NOTASKWEW, ok, (v. n.) he hunts for bears
+« NOTINIKEW, ok, (v. n.) he beats himself
+« NOTINIKEWIN, a, (n. f.) combat
+« NOTINEW, (v. a.) NAM, NIWEW, NIKEW, he beats him (up)
+« NOTINITUWOK, (v. m.) they beat one another (up)
+« NOTINITUWIN, a, (n. f.) battle, combat
+« NOTINÂGAN, (n. f.) enemy
+« NOTINITUMEW, (v. a.) he beats himself (up) with him
+
+NOT
+
+« NOTINITUMÂGAN, ak, (n. f.) fighter
+« NOTINASTIMWEW, ok, (v. n.) he beats, he whips his dogs, or his horses
+« NOTASTIMWEW, ok, (v. n.) idem
+« NOTCHIMIK, (adv.) apart from, faraway, at the extremity; e.g. notchimik tabasiwok, they run far away, into the woods, out of the dwellings; notchimik astew, it is found out of the way, like something which would be at the bottom of a room, in a corner
++ NOTIMISIW, ok, (a. a.) he is round, he is cylindrical
+« NOTIMAW, a, (a. in.) idem
+« NOTIMÂBISKUSIW, ok, (a. a.) metal formed into a cylinder
+« NOTIMÂBISKWAW, wa, (a. in.) idem
+« NOTIMÂSKUSIW, ok, (a. a.) he is round, a piece of wood
+« NOTIMÂSKWAN, wa, (a. in.) idem
+« NOTIMÂTTIK, wok, (n. f.) cylindrical piece of wood
+« NOTIMEW, ok, (v. n.) he walks without snowshows, he removes his snowshoes
+x NOTUKEW, ok, (n. r.) old woman
+« NOTUKESIW, ok, (n. f.) idem
+« NOTUKEWIW, ok, (a. a.) she is an old woman
+N'TASKÂTCH, (adv.) however
+N'TÊH! (ex.) to deny, only proper for women
+N'TOK, (adv.) many, absolutely; nama n'tôk, not many. See. Iyenato, Nâspitch
+
+509
+
+OKI
+
+O! (ex.) expression of pain, only proper for women
+O, OT, pron. of the 3rd person before the noun, and of the verb in the imperfect; e.g. o wâskâhigan, his house; ot'ema, his horse; o miyosittay, he was handsome; ot âkkusî, he was sick
+OHI, OHO, (pron. dem.) these things here
+OHUW, ok, (n. r.) owl
+OKAW, ok, (n. r.) perch, fish which one calls here: doré
++ OKÂWIW, ok, (a. a.) he has a mother
+« OKÂWIMEW, etc., (v. a.) he has her as a mother
+x OKÂMINAKASIY, a, (n. r.) bramble, thorn
+« OKÂMINAKASIWÂTTIK, wa, (n. f.) piece of wood, branch, covered in thorns
+OKÂSAKIMIW, ok, (n. f.) a glutton, a gourmand
+OKASKIPÂSIWEW, ok, (n. f.) barber
+OKI, (pron. dem.) these here
+OKIK, wa, (n. r.) fish gills
+OKIISKWEW, ok, (n. .) a madman, a lunatic
+x OKIMAW, ok, (n. r.) chief, bourgeois
+« OKITCHIOKIMAW, ok, (n. f.) the great chief, the king
+« OKIMÂWIWIN, a, (n. f.) dignity of the chief, the king
+« OKIMÂWIW, ok, (a. a.) he is chief
+
+OKI
+
+« OKIMÂKKÂTEW, (v. a.) he makes him chief
+« OKIMÂWOKOSISSÂN, ak, (n. f.) the son of the chief
+« OKIMÂWEYIMEW, (v. a.) he thinks him chief
+« OKIMÂWEYITTÂKUSIW, ok, (a. a.) he deserves to be chief, he has the qualities of a chief
+« OKIMÂSKWEW, ok, (n. f.) the chief's wife
+« OKITCHIOKIMÂSKWEW, ok, (n. f.) queen
+« OKIMÂWIKAMIK, wa, (n. f.) palace, house of the chief
+« OKIMÂWASTOTIN, wa, (n. f.) crown, chief's cap
+OKINÂN, (n. r.) group of stars
+OKITCHINISK, (n. f.) his right, his right hand
+« OKITCHITAW, ok, (n. f.) a brave, a soldier
+OKISIKOW, ok, (n. f.) heavenly being, angel
+OKITCHI KISIKOW, ok, (n. f.) archangel
++ OKOKKEW, ok, (v. n.) he barks. See. Mikisimow
+« OKOKKEWIN, a, (n. f.) barking
+« OKOKKÂTEW, etc., (v. a.) he barks after him
++ OKINIY, ak, (n. r.) wild rose seed, rosebud
+« OKINIWÂTTIK, wok, (n. f.) wild rose
+OKIPAHUWEW, ok, (n. f.) jailor
+OKISEWÂTISIW, ok, (n. f.) benefactor
+OKISKIWÂHIKEW, ok, (n. f.) prophet
+
+510
+
+OKA
+
+ONIYÂNKISKEYITCHIKEW, (n. f.) idem
+x OKISKINOHAMÂKEW, ok, (n. f.) tutor, schoolmaster
+« OKISKINOHAMÂWÂGANIW, ok, (n. f.) he has disciples
+« OKISKINOHAMÂWÂGANIMEW, (v. a.) he has him as his disciple
+« OKISKINOTTAHIWEW, ok, (n. f.) a guide
+OKISTAKÊ, (adv.) many
+OKISTAKEAYISIYINIWOK, (n. f.) a great multitude of men
+OKISTATOWÂN, ak, (n. f.) grey bear, mistahi-ayaw
+OKITIMÂKISIW, ok, (n. f.) the poor
+OKITOTCHIKEW, ok, (n. f.) musician
+OKUMIMAW, ok, (n. f.) a grandmother
+OKKOMISSIMAW, ok, (n. f.) paternal uncle
+OKOSÂBATCHIKEW, ok, (n. f.) sorcerer
+OKOSISSIMEW, etc., (v. a.) he sees him as his son
+OKOSISIMÂGAN, ak, (n. f.) youngling who is still in the shell of his egg
+OKAWATCHIS, ak, (n. f.) thin, dying buffalo
+OKAKESKIMIWEW, ok, (n. f.) preacher
+OKANÂWEPISISKIWEW, ok, (n. f.) shepherd
+OKANOWISKWÂTTOWEW, ok, (n. f.) gatekeeper
+OKANOWISKWÂTEMIWEW, ok, (n. f.) idem
+
+OKK
+
+x OKKUSIW, ok, (a. a.) he is red
+« OKKUSIWIN, a, (n. f.) redness
+« OKKWAW, a, (a. in.) it is red
+OKANÂWASTIMWEW, ok, (n. f.) guardian of the horses
+OMA, (pron. dem. in.) this, this thing
+OMAITÊ, (pron. dem.) this here
+OMATOWAW, it is of this type, of this sort
+OMATOWIK, (ad.) in this part, in this way
+OMÂTJIW, ok, (n. f.) a hunter
+OMÂMIKKWEW, ok, (n. f.) Assiniboine woman, of the Assiniboine tribe
+OMIKIW, ok, he has scabies
+OMIKIWIN, a, the action of having scabies
+OMIKIY, a, scabies
+OMIKIWASPINEWIN, leprosy
+OMITJIMIW, ok, (v. n.) he has food
+OMISIKKEMOW, ok, (n. f.) a traitor
+OMISIMIWEW, ok, (n. f.) idem
+OMISIMAW, ok, (n. f.) elder sister
+OMISIMAWIW, ok, (a. a.) she is an elder sister
+OMISIMEW, (v. a.) he has her as an elder sister
+OMISINAWEW, ok, (v. n.) he shares food
+OMISI, (ad.) thus, it is in this way. See. ekusi
+OMASINAHIKEW, ok, (n. f.) writer, scribe
+OMASINAHIKESIS, ak, (n. f.) clerk
+
+511
+
+OPP
+
+OMASINAHIKESISIWIW, ok, (a. a.) he is a clerk
+ONÂBEMIW, ok, (n. f.) she has a husband
+ONÂTAMÂKEW, ok, (n. f.) defender
+ONITJÂNIW, ok, (v. r.) cow. One also says: onitjâniwimoswa, female moose, onitjâniwâwaskesiw, doe; this is also the expression used for the females of some other quadrupeds
+ONIKIHIKUW, ok, (v. n.) he has his father, or his mother
+ONISTÂMOKKEW, ok, (n. f.) pilot, the one who is at the front of the boat
+ONIKEW, ok, (v. n.) he carries (it) on his shoulders, also, he portages
+ONIKEWIN, a, (n. f.) portage, the action of portaging
+ONIKÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he carries it on his shoulder
+ONIKAP, a, (n. f.) portage, distance between the two waters
+ONIPATTAKEW, ok, (n. f.) murderer
+x OPP, (rac.) to lift in the air
+« OPPAHUW, ok, (v. r.) he lifts himself in the air, e.g. a bird which takes flight
+« OPPAHUWIPISIM, (n. f.) August, month where the birds take their flight, their feathers having come out
+« OPPÂPEKIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he hoists it in the air
+« OPPÂBIW, ok, (v. n.) he lifts his eyes in the air
+« OPPÂPITEW, etc, (v. a.) he lifts it in the air
+
+OPP
+
+« OPPÂSIW, ok, (a. a.) he is lifted up by the wind
+« OPPÂSTAN, wa, (a. in.) idem
+« OPPÂSKWAHWEW, (v. a.) HAM, HUWEW, HIKEW, he lifts it up, he raises it using a piece of wood
+« OPPÂSKWEYAW, (n. f.) forest, woods which are on elevated ground
+« OPPINEW, (v. a.) NAM, NIWEW, NIKEW, he lifts it up, he raises it
+« OPPIW, ok, (v. n.) he lifts himself on his feet, he raises himself up
+« OPPIPAYIW, ok, a, (a. a. and in.) it lifts itself
+« OPPISKAW, ok, (n. n.) he lifts himself in the air, he makes his ascent
+« OPPISKÂWIKIJIKAW, (n. f.) Day of Ascension
+« OPPIKIW, ok, (a. a.) he believes, he grows
+« OPPIKIWIN, a, (n. f.) belief, growth
+OPPIKIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes him believe, he makes him grow, he takes care of him, he raises him, e.g. a child
+« OPPIKIHÂWASUW, ok, (v .n.) he raises children
+« OPPIKIHÂWASUWIN, a, (n. f.) care, education of children
+« OPPINISKEYIW, ok, (v. n.) he raises his hand
+« OPPISKWEYIEW, ok, (v. n.) he raises his head
+« OPPISISGAN, a, (n. f.) leavening
+« OPPAHWEW, (v. a.) HAM, HUWEW, HIKEW, he opens it by raising it
+« OPPAHIKEW, ok, (v. n.) he opens a trap, he lifts the trap
+
+512
+
+OSÂ
+
+« OPPWEHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he excites him, he pushes him into doing something
+« OPPWEMEW, etc., (v. a.) idem
+« OPPWEPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he pulls it by raising it
+OPÂSKÂWEHUWIPISIM, (n. f.) month where the younglings leave the shell, June
+OPASKUWIPISIM, (n. f.) month where the birds shed their feathers, July
+OPIMÂTCHIHIWEW, ok, (n. f.) savior, liberator
+OPIME, (adv.) beside, next to, apart (from)
+OPIMESKANAW, (ad.) next to the path
+OPIMUTAKKWEW, ok, (n. f.) archer
+OPIMUTTAHIWEW, ok, (n. f.) guide, conductor
+OPIMEPAYIW, ok, a, (a. a. and in.) it goes to the side
+OPITOTOWEW, ok, (n. f.) he who speaks differently, the Scottish
+OPPAN, a, (n. r.) lung, soft
+OPAPÂMUTTEW, ok, (n. f.) a voyager
++ OPPWÂM, a, (n. f.) his thigh, his buttock
+« OPPWÂMEWOK, wa, (n. f.) thigh meat
+« OPPWÂMIKEGAN, a, (n. f.) thigh bone
+« OPPWÂMIKÂTEW, a, (n. f.) butt of a rifle, breech
+x OSÂM, (ad.) too much, especially, or, ososâm
+
+OSÂ
+
+« OSÂMPIKO, (ad.) principally, especially
+« OSÂM MITCHET, (ad.) many, too many
+« OSÂM APISIS, (ad.) too little
+« OSÂMI, (ad.) it's too much
+« OSÂMEYATIW, ok, (a. a.) they are too numerous
+« OSÂMEYATIN, wa, (a. in.) idem
+« OSÂMISIW, ok, (a. a.) he acts excessively, he does too much
+« OSÂMISIWIN, a, (n. f.) excess
+« OSÂMIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he acts excessively against him, he does too much to him, he pushes him to the end
+« OSÂMIHUW, or, HISUW, (v. r.) he does bad things to himself, he acts very badly towards himself
+« OSÂMIHUWIN, a, (n. f.) excess towards oneself
+« OSÂMIHISUWIN, a, (n. f.) idem
+« OSÂMIPEW, ok, (v. n.) he drinks in excess
+« OSÂMITON, (n. f.) babbler, blabbermouth
+« OSÂMITONEW, ok, (a. a.) he is a blabbermouth, a big talker
+« OSÂMITONEWIN, a, (n. f.) babbling, prattling
+« OSÂMISKOYUW, ok, (a. a.) he has eaten too much
+« OSÂMIPUW, ok, (a. a.) idem
+« OSÂMIPAYIW, ok, a, (a. a. and in.) it is done excessively, it goes too far, it is pushed too far
+« OSÂMAKKAMIKISIW, ok, (a. a.) like osâmisiw
+« OSÂMAKKAMIKAN, wa, (a. in.) there is a great trouble, a great disturbance
+
+513
+
+OSÂ
+
+« OSÂMEYIMEW, etc., (v. a.) he is exasperated with him
+« OSÂMEYITTAM, wok, (v. n.) he is in despair, he cannot endure this affliction
+« OSÂMEYITTAMOWIN, a, (n. f.) despair
+« OSÂMIMEW, etc., (v. a.) he says too much to him
+« OSÂMEYITTÂKWAN, wa, (a. in.) it surpasses, it is hopeless
+« OSÂMAKKAMIK! many, excessively
+« OSÂSIKANEW, ok, (n. r.) old woman
+x OSÂSÂKUNÂSIN, wok, (v. n.) he slides on the snow
+« OSÂSISIN, wok, (v. n.) he slides
+« OSÂSISKIWAKISIN, wok, (v. n.) he slides in the mud
+« OSÂSISKUSIN, wok, (v. n.) he slides on the ice
+« OSÂSISKWAKISIN, wok, (v. n.) idem
+« OSÂSISKUSIMEW, (v. a.) TITAW, SIMIWEW, etc., he makes him slide on the ice
+« OSÂSITAKISIN, wok, (v. n.) he slides on the wood
+« OSÂSUW, ok, (n. r.) new, soft snow
++ OSAW, (rac.) yellow
+« OSÂWISIW, ok, (a. a.) he is yellow
+« OSÂWISIWIN, a, (n. f.) the colour yellow
+« OSÂWASONIYAW, ok, (n. f.) gold
+« OSÂWÂBISK, wok, (n. f.) yellow metal, copper
+
+OSÂ
+
+« OSÂWÂBISKISIW, ok, (a. a.) he is yellow, (made of) metal
+« OSÂWÂBISKAW, wa, (a. in.) idem
+« OSÂWÂBÂN, ak, (n. f.) bile
+« OSÂWÂBEW, ok, (a. a.) he has bile, he is bilious
+« OSÂWÂBUIY, a, (n. f.) yellow liquid
+« OSÂWEGIN, wa, (n. f.) yellow cloth, Indian yellow
+« OSÂWEKAN, wa, (a. in.) he is yellow, when speaking of cloth, Indian cloth
+« OSÂWISKUSIW, ok, (a. a.) he shines, he gleams yellow
+« OSÂWISKWAN, wa, (a. in.) idem
+« OSÂWISKWAW, (v. im.) sulphur in stone
+« OSÂWAKKESIW, ok, (n. f.) yellow fox
+« OSÂWAKKWANEW, (v. im.) yellow flame
+« OSÂWASK, wok, (n. f.) yellow bear
+x OSEYAW, a, (a. in.) it is a hill, it is a height
+« OSESIW, ok, (a. a.) he is in the form of a convex elevation, a hill
+« OSESKAMIKAW, (v. im.) elevated terrain
+« OSETCHAW, (v. im.) land in the form of a hill
+« OSETINAW, (v. im.) hill, elevation
+« OSEYÂBISKAW, (v. im.) rock in the shape of hill
+« OSETTUY, a, (n. r.) the tale of a snowshoe
+« OSI, pl. osa, (n. r.) canoe; mistikosi, wooden canoe; waskway osi, birchbark canoe; n't'os, my canoe; ot'os, his canoe; misottakaw, big canoe
+
+514
+
+OSI
+
+x OSAHWEW, (v. a.) HAM, HUWEW, HIKEW, he lifts it, he makes it flee
+« OSISKAWEW, (v. a.) idem
+« OSAHIKEW, ok, (v. ind.) he makes (it) flee, e.g. someone who is going hunting, and who, by making a noise, causes all of the animals that he approaches or watches to flee
+OSIPIW, ok, (v. n.) he stirs the water, e.g. a beaver which swims between two bodies of water
++ OSI, and  OJI, (rac.) to make, to create, to manufacture
+« OJIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it, he creates it
+« OJIHUMAGAN, (v. r. in.) it forms
+« OSITCHIKEW, ok, (v. ind.) he creates, he operates
+« OSITCHIKEWIN, a, (n. f.) creation, operation
+« OSITCHIGAN, ak, a, (n. f.) creature
+« OT OJIHIWEW, ok, (n. f.) the creator
+« OSITTOWEW, (v. a.) he makes it for him
+« OSITTAMÂWEW, he makes it in its place
+« OSIKKIPIMIW, ok, (v. n.) he has a boil, swelling, a carbuncle
++ OSIKAMISK, wok, (n. f.) spread out and dried beaver. From the root osik, that which shrinks, e.g. someone which, by drying, becomes lesser
+« OSIKÂKATOSUW, ok, (a. a.) he shrinks from drying
+« OSIKÂKATOTEW, a, (a. in.) idem
+
+NIP
+
+« OSIKÂSAKEW, ok, (a. a.) he has shrunken skin
+« OSIKASEW, ok, (a. a.) idem
+x OSIMIMEW, etc., (v. a.) he has him as his younger brother, or younger sister
+« OSIMIMÂW, ok, (n. f.) the younger brother, or, younger sister
+« OSIMIMÂWIW, ok, (a. a.) he is a younger brother, or, younger sister
+OSIKIYÂS, ak, (n. r.) lizard
+OSIMISK, wa, (n. r.) bud
++ OSIKOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he spoils it, he ruins it, he does great damage to it
+« OSIKUSIMEW, (v. a.) TITAW, SIMIWEW, etc., he spoils it, he ruins it, by throwing it on the ground
+« OSIKUW, ok, (v. r.) he harms himself, he gives himself a bad strike
+« OSIKUHUW, ok, (v. r.) idem., e.g. a woman who has an abortion, etc.
+« OSIKUWIN, a, (n. f.) exertion, a violent blow
+« OSIKUHUWIN, a, (n. f.) idem
+« OSIKUSIN, wok, (a. a.) he breaks himself into pieces by falling
+« OSIKUTTIN, wa, (a. in.) idem
+« OSIKWANAY, a, (n. r.) a fish's tail
++ OSIKUSIW, ok, (v. n.) he has a step-mother
+« OSIKUSIMAW, ok , (n. f.) a step-mother
+« OSITAMAW, ok, (v. n.) he falls on his track, but he goes back another time to pursue it
+x OSIMOW, ok, (v. n.) he flees, he runs away. See Tabasiw
+« OSIMOWIN, a, (n. f.) flight (fleeing)
+« OSIMEW, etc., (v. a.) he flees it
+
+515
+
+NIP
+
+« OSIMOHEW, etc., (v. a.) he makes it flee
+« OSIMOSTAWEW, etc., (v. a.) he runs away from him
++ OSISIW, ok, (v. n.) he has a step-father
+« OSISIMAW, ok, (n. f.) a step-father
+« OSISIMÂWIW, ok, (a. a.) he is a step-father
+x OSKÂTCHIK, wa, (n. r.) awl
+« OSKÂTCHIKUW, ok, (v. n.) he has an awl
++ OSKAN, a, (n. r.) bone
+« OSKANIWIW, ok, (a. a.) he is bony
+« OSKANIPIMIY, a, (n. f.) bone marrow fat
+OSKATCH, (adv.) to begin, firstly
++ OSKITJIY, a, (n. r.) handle of a smoking pipe, of a peace pipe
+« OSKITJIYÂTTIK, wa, (n. f.) idem
+OSKITTEKUM, a, (n. r.) white material which is in the ears; ni'skittekum, a, ki'skitteum, a, oskittekum, a, ma, etc., ta, etc., sa, etc.
++ OSK, (rac.) new, fresh, unused, young
+« OSKÂYI, ak, a, (n. f.) new, unused
+« OSKÂYIS, ak, (n. f.) young of an animal, still in the belly of its mother, or newly born. One also uses this word for the young of birds which have only just hatched
+« OSKÂYIWIW, ok, (a. a.) he is young, new
+« OSKÂYIWAN, wa, (a. in.) idem
+
+OSK
+
+« OSKÂYIWIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it new, he rejuvenates it
+« OSKÂBWASKITEW, (v. im.) burned ground where the grass is beginning to sprout
+« OSKÂTTIK, wok, (n. f.) young tree
+« OSKÂTTAK, wok, (n. f.) cypress, savannah spruce
+« OSKÂTTAKAW, (v. im.) there is savannah
+« OSKISK, ak, (n. f.) young red spruce
+« OSKÂTÂSK, wok, (n. f.) carrot; manito-oskâtâsk, Moreau carrot, poison carrot
+« OSKÂTISIW, ok, (a. a.) he is young
+« OSKÂTISIWIN, a, (n. f.) youth
+OSKASTIM, wok, (n. f.) young horse, or dog
+« OSKANASKUSIY, a, (n. f.) large swamp grass
+« OSKAKUTCHIN, wok, (a. a.) he is new; e.g., oskakutchin pisim, new moon
+« OSKAKUTTIN, wa, (a. in.) newly suspended
+« OSKINIKIW, ok, (n. f.) young girl
+« OSKÂBEW, ok, (n. f.) young man
+« OSKISKWEW, ok, (n. f.) young woman
+« OSKINIKIWIW, ok, (a. a.) he is a young man
+« OSKINIKISKWEWIW, ok, (a. a.) she is a young woman
+
+516
+
+OSP
+
+« OSKENAM, wok, (v. n.) his footprints are fresh there
+« OSKIHUW, ok, (a. a.) he is dressed in new (clothes)
+« OSKIHUWIN, a, (n. f.) new clothing
+« OSKUTÂKAW, ok, (v. n.) he has a piece of clothing
+OSKUTAKAY, a, his clothing; niskutâkay, my clothing
+« OSKIWISIW, ok, (a. a.) he is new, young
+« OSKIWAN, wa, (a. in.) idem
+« OSKASÂKAY, a, (n. f.) new clothing
+« OSKASKUSIY, a, (n. f.) young grass of the springtime
+« OSKIWIYÂS, a, (n. f.) fresh meat. N.B. One can place oski before a great number of words, which will take the idea or quality of new, novel, young; e.g., oskiwâskâhigan, new house; oskegin, new skin (leather); oski kona, new snow
+OSKUN, a, (n. r.) liver
+OSKUTIM, a, (n. r.) beaver dam
++ OSUW, ok, (a. a.) he boils, e.g., a boiler
+« OTTEW, a, (a. in.) idem
+« OSWEW, (v. a.) SAM, SUWEW, SIKEW, he boils it
+« OSUHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it boil
+« OSUTCHIKÂSUW, ok, (a. a.) he is boiled
+« OSUTCHIKÂTEW, a, (a. in.) idem
+« OSIKÂSUW, ok, (a. a.) idem
+« OSIKÂTEW, a, (a. in.) idem
+OSPASEW, a, (n. r.) the pointed bone of the chests of birds
+
+OSP
+
++ OSPWÂGAN, ak, (n. r.) pipe, smoking pipe
+« OSPWÂGANASSINIY, ak, (n. f.) stone for making pipes, or smoking pipes
+OSTIKWÂNISÂBONIGAN, a, (n. f.) pin
+OSTIKWÂNIGAN, a, (n. f.) the skull
+OSTIMIMAW, ok, (n. f.) a niece
+OSTUSTUTAM, wok, (v. n.) he coughs
+OSTUSTUTAMOWIN, a, (n. f.) cough
+OSUY, a, (n. r.) tail
+OTA, (adv.) here
+OTÊ, (adv.) there
+x OTÂK, (ad.) behind, in the back
+« OTÂKISIW, ok, (a. a.) he is behind, or, otâk ayaw
+« OTÂSKANAW, (n. f.) behind on the trail
+« OTÂKETTAK, (n. f.) behind in the canoe, the barge, etc.
+« OTÂKINÂSKWEW, ok, (v. n.) he bends his bow
+« OTÂKINEW, (v. a.) NAM, NIWEW, NIKEW, he fires behind him
+« OTÂKIPITEW, etc., (v. a.) idem
+« OTÂKAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he places it behind
+« OTÂKEKÂT, a, (n. f.) back leg, paw
+« OTÂKEMIK, (adv.) in his past; n'otâkemik, in my past
+« OTÂKUSIK, (ad.) yesterday
+« OTÂKUSIN, (v. imp) it is evening
+« OTÂKWÂSAN, (v. im.) idem
+« OTÂKWANISIW, ok, (a. a.) he is taken by the night
+
+517
+
+OTÂ
+
+« OTÂKWANUTTEW, ok, (v. n.) he walks in the evening
+« OTÂKWANUTTEWIN, a, (n. f.) a walk during the evening
+« OTÂKUSIMITJISUW, ok, (v. n.) he dines (on his dinner)
+« OTÂKUSIMITJISUWIN, a, (n. f.) dinner
++ OTAM, (rac.) to hit, to strike
+« OTÂMAHWEW, (v. a.) HAM, HUWEW, HIKEW, he hits it
+« OTÂMISIN, wok, (a. a.) he hits himself by falling
+« OTÂMITTIN, wa, (a. in.) idem
+« OTÂMISIMEW, TITAW, SIMIWEW, etc., (v. a.) he makes him hit it by throwing it at the ground
+« OTÂMISKUSIN, wok, (a. a.) he hits himself by falling on ice
+« OTÂMISKUSIMEW, etc., (v. a.) he hits it by throwing it on the ice
+« OTÂMIKKWESIN, wok, (a. a.) he gets hit in the face by falling
+OTAKWAHAMOW, ok, (n. f.) he who holds the rudder, helmsman
+x OTTAHIPÂN, a, (n. f.) hole in the ice, well
+« OTTAHIPEW, ok, (v. n.) that is where he takes the water from, he makes a hole to draw water
+x OTAMEW, (v. a.) TAM, MIWEW, TCHIKEW, he pulls it in with his mouth, he sucks it
+« OTATTAMEW, (v. a.) TTAM, etc., he suck it, e.g. a child who suckles his mother
+« OTÂTCHIKEWIMASKIKIY, a, medicine for sucking, cantharide
+
+OTA
+
+« OTAHWEW, (v. a.) HAM, HUWEW, HIKEW, he wins it in a game
+« OTAKAWÂHWEW, etc., (v. a.) he pulls it, he removes it from there, with a stick
+« OTÂSKUHWEW, etc., (v. a.) he pulls it from the water, or from the fire, with a piece of wood
+« OTASKUNEW, (v. a.) NAM, NIWEW, NIKEW, idem
+« OTÂSKWAHWEW, etc., (v. a.) idem
+x OTAMI, (adv.) to be busy with, etc., e.g. otami ayamihaw, he is busy with praying, otami metawew, or, metawew otami, he is busy with playing
+« OTAMIYUW, ok, (a. a.) he is busy
+« OTAMIYUWIN, a, (n. f.) occupation, being busy
+« OTAMIHEW, he busies him, he takes up his time, he hinders him, he hampers him
+« OTAMIMEW, etc., (v. a.) he retains it by his words
+« OTAMAKATOSUW, ok, (a. a.) he is stopped, hindered by shortage(s)
+« OTAMEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he is preoccupied with him, his mind is not here
+« OTAMEYITTAMOWIN, a, (n. f.) preoccupation
+« OTAMINISTAWEW, (v. a.) TAM, TÂKEW, TÂTCHIKEW, he is busy with him
+« OTAMEYITTÂKWAN, wa, (a. in.) he who must be busy
+« OTAMISIPWETTEW, ok, (a. a.) he is absent
+
+518
+
+OTÂ
+
+« OTAMAPISTAWEW, etc., (v. a.) he is retained around him
+x OTÂNISIW, ok, (v. n.) he has a daughter
+« OTÂNISIMAW, ok, (n. f.) a daughter
+« OTÂNISIMEW, etc., (v. a.) he has her as a daughter
+« OTÂNISIKKAWEW, etc., (v. a.) idem
++ OTÂPÂHÂGAN, ak, (n. f.) animal which one harnesses
+« OTÂBÂNÂSK, wok, (n. f.) car, train, cart
+« OTOTÂBÂNÂSKUW, ok, (v. n.) he has a car
+« OTÂBÂNEYÂBIY, a, (n. f.) harness, hitch
+« OTÂBÂNIKKEW, ok, (v. n.) he prepares his train, he attaches it
+« OTÂBÂNIKKÂTEW, (v. a.) TAM, etc., he prepares it, he arranges it on the 
+« OTÂPEW, ok, (v. n.) he drags, he hauls behind him
+« OTÂPÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he drags it behind him
+« OTÂPEWIN, a, (n. f.) the action of pulling, dragging behind oneself
+« OTÂBÂSUW, ok, (a. a.) he goes in a car, he is seated in a train, carriage, or cart
+« OTÂSIW, ok, (v. n.) he has trousers, breeches
+« OTÂSIWIYEW, (v. a.) TTAW, YIWEW, TCHIKEW, he brings it after him
+x OTÂPÂNIHUW, ok, (v. r.) he lives by means of this, e.g. nama kekway n'otâpânihun, I have nothing to live for, kekway k'otâpânihuyan? what do you live with?
+
+OTÂ
+
+« OTÂPÂNIHEW, etc., (v. a.) he makes him live, he supports him
+x OTÂSIW, ok, (a. a.) he is carried to the side, by the wind
+« OTÂSTAN, wa, (a. in.) idem
+x OTASTAMAPIW, ok, (a. a.) he is seated in front
+« OTASTAMAPISTAWEW, etc., (v. a.) he is seated in front of him
+OTASKIW, ok, (v. n.) it is his country, e.g. tande k'otaskiyan? where is your country?
+OTASINÂKKEW, ok, (v. r.) the chest bone, chest
+x OTASTENAM, wok, (v. a. in.) he bends it, a rifle
+« OTASTEHITAM, wok, (v. a. in.) idem
+OTAHWEW, HAM, he takes it, e.g. fish in a net
+OTASTISEWOK, wa, (n. f.) kidney meat, tenderloin
+x OTTÂWIW, ok, (v. n.) he has a father
+« OTTÂWIMAW, ok, (n. f.) the father, a father
+« OTTÂWIKKAWEW, etc., (v. a.) he gives it to him as a father
+« OTTÂWIMISKAWEW, etc., (v. a.) he has him as a father
+« OTTÂWISKAWEW, etc., (v. a.)
++ OTAYAMIHAW, ok, (n. f.) a praying person, a Christian
+« OTAYAMITCHIKEW, ok, (n. f.) idem
+« OTAYAMIHESTAMÂKEW, ok, (n. f.) an intercessor, a mediator
+
+519
+
+OTC
+
++ OTEHIW, ok, (v. n.) he has a heart, he has courage, a good heart
+« OTEHIWIN, a, (n. f.) compassion, goodness of heart
+OT'EMIW, ok, (v. n.) he has horses, or, dogs
+x OTENAW, a, (n. r.) large camp, town, city
+« OTENÂWIWIN, a, (n. f.) kingdom
+« OTENÂWITTAW, ok, (v. a. in.) he makes it a city
+« OTENAPIW, ok, (a. a.) they stay together in a large camp, they are established in a city
+OTATÂWEWIYINIW, ok, (n. f.) merchant, trader
+OTATTAW, ok, (v. n.) he has pelts
+OTCHITCHÂK, wok, (n. r.) crane
+OTCHEK, wok, (n. r.) fisher
+x OTCHEMEW, (v. a.) TTAM, MIWEW, etc., he kisses him
+« OTCHETTUWOK, (v. m.) they kiss one another
+« OTCHETUWIN, a, (n. f.) kissing
+« OTCHETUWIKIJIKAW, (n. f.) day of the year where we kiss one another
+OTCHEPPIW, ok, (a. a.) he is alert, lively
++ OTCHEPIK, wa, (n. r.) root
+« OTCHEBIKOWIW, ok, (a. a.) he has roots
+« OTCHEBIKOWAN, wa, (a. in.) idem
+OTCHEW, ok, (n. r.) fly, insect, worm
+OTCHESTIW, ok, (v. n.) he places one leg in front of the other, he makes a path
+
+OTC
+
+OTCHESTATAY, a, (n. r.) nerve, muscle
+« OTCHESTATAYÂPIY, a, (n. f.) idem
+x OTCHI, (prep.) compared with, with, from, since, e.g. kiya otchi, compared with you, ayamihewikamik otchi, (I come) from the church, mokkumân otchi, with a knife, soniyaw otchi, for money, kayâs otchi, for a long time, eok'otchi, for that, that's why, kekway otchi? for what? why? otchi-sânikkawew, he descends from his race
+« OTCHITCHIKUM, a, (n. f.) wart
+« OTCHITCHIKUMIW, ok, (v. n.) he has a wart
+« OTCHITCHIPAYIW, ok, a, (a. a. and in.) it happens that, etc., it takes place, an event
+« OTCHITCHIPAYIHUW, ok, (v. r.) it takes place, it happens
+« OTCHITCHIPAYIHUWIN, a, (n. f.) event
+« OTCHIPAYIW, ok, (a. a. and in.) it comes from there, it is from there that it originates
+« OTCHIHEW, etc., (v. a.) he wins it, he seduces it, he wins to do that
+« OTCHIWIYEW, (v. a.) TAW, YIWEW, idem
+« OTCHIHEW, (v. a.) etc., he forbids him, he stops him from doing that
+« OTCHIMEW, etc., (v. a.) that's why he told him
+« OTCHIYÂWESIW, ok, (a. a.) that's why he is angry
+
+520
+
+OTC
+
+« OTCHIKAWIW, ok, (v. v.) it pours, it sprinkles the liquid that it contains, e.g. mistikwok otchikawiwok, the trees pour down water, eoko askik otchikawiw, this boiler leaks
+« OTCHIKAWÂBIW, ok, (v. n.) he weeps
+« OTCHIKAWÂBUIY, a, (n. f.) tear, teardrop
+« OTCHIKKAWEW, (v. a.) KAM, KÂKEW, etc., he helps him, he rescues him
+« OTCHIKKAMÂWEW, (v. a.) TAM, KEW,, idem
+« OTCHINATEW, (v. a.) TAM, SIWEW, etc., that is why he mistreates him, he kills him, e.g. ayamihâwin otchinataw, he is put to death for religion
+« OTCHIPÂSUW, ok, (v. r.) he buttons himself
+« OTCHIPÂSUN, a, (n. f.) button, clip
+« OTCHIPÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he buttons it
+« OTCHISIHIWEW, ok, (n. f.) trickster, traitor
+« OTCHIMIWEW, ok, (n. f.) idem
+« OTCHISIW, ok, (a. a.) he has a scar
+« OTCHISIKKWEW, ok, (a. a.) idem, on the face
+« OTCHISIWIN, a, (n. f.) scar
+« OTCHISIKKWEWIN, a, (n. f.) idem, on the face
+« OTCHITCHIWAN, (v. im.) the current runs from there
+« OTCHIKWANAPIW, ok, (v. n.) he kneels down
+« OTCHIKKWANAPIWIN, a, (n. f.) kneeling
+
+OTC
+
+« OTCHIKWANAPISTAWEW, (v. a.) TAM, TÂKEW, TÂTCHIKEW, he kneels down before him
+OTCHINEW, NAM, with difficulty, he joins it with his hands
+« OTCHIKKANA, (n. f.) provisions which beavers make for winter
+« OTCHIKWÂTEW, TAM, SIWEW, he hooks it, he hangs it
+« OTCHIKWÂTCHIGAN, a, (n. f.) hook for joining, clipping (things)
+« OTCHIPITEW, (v. a.) TAM, SISWEW, TCHIKEW, he pulls it, he hauls it towards him
+« OTCHIPITCHIGAN, a, (n. f.) drawbar
+« OTCHIPITIKUW, ok, (a. a.) he has cramos
+« OTCHIPITIKUWIN, a, (n. f.) cramp
+« OTCHIPAKKWEW, ok, (v. n.) he breathes smoke from the pipe
+« OTCHISTAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he obtains him, he makes him get (it)
+« OTCHISTAMÂKEW, (v. ind.) he obtains (it) for others, he does a favour
+« OTCHISTAMÂKEWIN, a, (n. f.) favour, gift, donation
+« OTCHISTIKUSIW, ok, (a. a.) he is in shelter from bad weather
+« OTCHISTIKWAN, (v. im.) there is shelter
+« OTCHISTIN, wa, (a. in.) it makes water, water penetrates within
+« OTCHIW, or, OTJIW, ok, (a. a.) he comes from, his origin lies in, he proceeds forth from
+« OTCHIWIN, a, (n. f.) origin, beginning
+
+521
+
+OTI
+
+« OTCHIPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it begin from there, he starts it from this date, from this moment
+« OTCHINEW, ok, (a. a.) that's why he is sick, that is where his sickness originated
+« OTCHINEWIN, a, (n. f.) sickness caused by, etc.
+« OTCHIWÂMIMAW, ok, (n. f.) a friend, a brother
+« OTCHIWÂMITTUWOK, (v. m.) they are friends, brothers
+« OTCHIWÂMITTUWIN, (n. f.) brotherhood, friendship
+« OTCHISKAW, (v. m.) he just wears, e.g. a rifle
++ OTCHITCHÊK, (ad.) by chance, by luck
+« OTCHITCHEKIPAYIW, a, (v. im.) it happens by chance
+OTJITAW, (adv.) on purpose, deliberately, opportunely, e.g. otjitaw nama ni wi mitjisun: I am deliberately not eating, otjitaw totam, he does it on purpose, otjitaw nama nittâwew: he does, by nature, not speak very much, otjitaw ispayiw, it must happen, namawiya otjitaw ki totatin, I did not do that to you deliberately
+OTEHEPAK, wa, (n. f.) cabbage
+OTEHYIY, a, (n. p.) chuck, the flat of the shoulder
+OTEYIMEW, he desires his arrival
+OTI, (ad.) that is to say, for example. N.B. This is always placed after the word, e.g. ni ka miyaw, kispin oti kwayask totaki: I will give it to him, that is, if he does well, kiya oti: you, for example
+
+OTI
+
+x OTINEW, (v. a.) NIWEW, NIKEW, he takes it, he grabs it
+« OTINAMÂSUW, ok, (v. p.) he appropriates that which does not belong to him
+« OTINAMÂSUWIN, a, (n. f.) unjust appropriation
+« OTINAMÂWEW, etc., (v. a.) he procures him, he makes him possess
+OTIBEYIMISUW, ok, (n. f.) free man
+OTISÂBAMEW, (v. a.) TTAM, KKEW, TCHIKEW, he perceives it from far away, he manages to see it, it happens until this time
+OTINÂSTAN, (v. im.) view, in a river
+OTISIKKÂN, a, (n. p.) turnip
+OTISKAW, ok, (v. n.) he walks for this
+x OTTISKAW, (adv.) facing, face to face
+« OTTISKÂWISKAWEW, etc., (v. a.) he is facing him, he meets with him face to face
+« OTTISKÂWIKÂBAWIW, ok, (v. n.) he is standing, facing
+« OTTISKÂWIKÂBAWISTAWEW, (v. n.) TAM, etc., he is standing in front of him
+« OTTISKÂWAPIW, ok, (a. a.) he is seated facing
+« OTTISKÂWASTEW, a, (ad. ina.)
+« OTITTEW, (v. a.) TTAM, SIWEW, TCHIKEW, he reaches him, he joins him
+« OTITTINEW, (v. a.) NAM, MIWEW, NIKEW, he seizes him, he assaults him
+« OTITTINIWEWIN, a, (n. f.) assault
+
+522
+
+OWI
+
+« OTITTINITUWOK, (v. m.) they seize one another, they grab one another, they launch an assault
+« OTITTINITUWIN, a, (n. f.) mutual assault
+x OTISISIN, wok, (a. n.) he is lying face down
+« OTITTAPISIN, wok, (a. a.) he is turned facing downwards, towards the ground
+« OTITTAPITTIN, wa, (a. in.) idem
+« OTITTAPIW, ok, (a. a.) he is sitting facing towards the ground
+« OTITTAPISTAWEW, (v. a.) TAM, etc., he prostrates himself before him
+OTITWESTAMÂKEW, ok, (n. f.) an interpreter
+OTTAHIPÂN, a, fountain, spring
+OTTAHIPEW, ok, he is drawing over there
+OTUTTEW, ok, (v. n.) he comes from such a place
+OTTIN, wok, (n. p.) the wind
+OTTIN, (v. imp.) it is windy
+OTTINIKEW, ok, to collect, to receive from there
+x OTOTEMIKKAWEW, etc. (v. a.) he reconciles it with him
+« OTOTEMIMEW, etc., he sees him as his parent
+« OTOTEMIW, ok, (v. n.) he has parents, friends
+« OTOTEMITTUWIN, a, (n. f.) kinship, reconciliation
+« OTOTEMIWEWIN, a, (n. f.) idem
+OTTEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he is jealous of him
+OWÂBASPINEW, ok, (n. f.) a leper
+x OWITJEWÂGANIW, ok, (v. n.) he has companions, disciples
+
+OWI
+
+« OWITJEWÂGÂNIMEW, etc., (v. a.) he makes him his disciple, he takes him as a companion
+x OWIKIMÂGANIW, ok, (v. n.) he has a spouse, or, she has a spouse
+OWIKIMÂGANIMEW, etc., (v.) he has her as a spouse, or, she has him as a spouse
+OWIKIW, ok, (v. n.) he has a house, a dwelling
++ OYÂBAMEW, (v. a.) TTAM, KKEW, TCHIKEW, he aims at it, he takes aim
+« OYÂBATCHIGAN, a, (n. f.) sights of a rifle
+x OYAHYEW, (v. a.) STAW, KKEW, TCHIKEW, he places it well, he takes a good shot
+« OYAHISUW, ok, (n. f.) blacksmith
+« OYAHISUWIKAMIK, wa, (n. f.) blacksmith's shop
+OYAHWEW, (v. a.) HAM, HUWEW, HIKEW, he forges it
+« OYÂHEW, (v. a.) TTAM, HIWEW, TCHIKEW, he gives him the example, he incites him to, etc.,
+« OYÂMEW, etc., idem, with his words
+« OYÂSIW, ok, (a. a.) he is roused to act, for example by others
+« OYÂHUW, ok, (v. p.) he accustoms himself to it, he gets used to it. See. Nânâmahuw
+« OYÂGAN, a, (n. f.) dish, vase
+« OYÂGANIKKEW, ok, (v. n.) he makes vases, dishes
+« OYAKIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he examines it, he appraises what it is worth
+« OYAPPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he harnesses it, he carefully attaches it
+
+523
+
+OYE
+
+« OYASUWATEW, (v. a.) TAM, SIWEW, TCHIKEW, he carries his judgement on him. See wiyasuwâtew
+« OYASUWEW, ok, (v. a.) he judges
+« OYASUWEWIN, a, (n. f.) judgement
+« OYASUWEWIYINIW, ok, (n. f.) judge
+« OYASUWEWIKAMIK, wa, (n. f.) court of justice
+« OYAKINEW, (v. a.) NAM, NIWEW, NIKEW, he arranges it well, carefully
+« OYAKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he polishes it with an axe
+« OYAKIKKUTEW, (v. a.) TAM, etc., he polishes it with a knife, or, a plane
+« OYASKINAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he fills it carefully. Note. This word is always used for: he fills up his pipe
+« OYASKINATTOWEW, etc., (v. a.) he fills his pipe up, he prepares him to smoke
+« OYINEW, (v. a.) NAM, NIWEW, NIKEW, he arranges it carefully, he lays it out with caution
+« OYIMEW, etc., (v. a.) or, OYOMEW, he intends it for such a purpose, he gives him such a burden, task
+« OYEYIMEW, etc., (v. a.) he reflects, he meditates, to see what he is going to do, what he will intend to do
+
+OYE
+
+« OYEYITTAM, wok, (v. n.) he draws up his plans, he takes his resolutions
+« OYEYITTAMOWIN, a, (n. f.) reflection, premeditation
+« OYEYIMOW, ok, (v. n.) he meditates on what he is going to do
+« OYWÂSTAWEW, etc., (v. a.) he makes predictions about him. N.B. This word and the following mean, when someone experiencing certain sensations in their body believes that they know the future
+« OYWÂTCHIKEW, ok, (v. n.) he claims to know the future, he experiences sensations which uncover the future for him
+« OYWÂTCHIKEWIN, a, (n. f.) prediction of the future according to certain bodily sensations
+OYIK, wa, (n. p.) gland
+OYUW, ok, (v. n.) he yells
+OYUWIN, a, (n. f.) yelling
+OYÉ- (adv.) oyekka, so, at that time
+PA, sign of the conditional; e.g., pa miwâsin, it would be good; ni pa ki ituttân, I would have gone there; ki pa miyo toten, you would do well
+PAHUSIMEW, TITTAW, he sees it, he perceives it with difficulty; e.g. etatow ni pahuttitân, I can hardly see
+x PAKA, (rac.) to hit, to give against
+« PAKAHAMÂW, ok, (v. n.) he hits. This word is used for: to hit, to beat the drum
+
+524
+
+PAK
+
+« PAKAHAMÂWIN, a, (n. f.) the action of beating the drum
+« PAKAHAMÂWEW, etc., (v. a.) he hits it for him
+« PAKAMÂHWEW, (v. a.) HAM, HUWEW, HIKEW, he hits it
+« PAKAMIMEW, etc., (v. a.) idem, with his words
+« PAKAMEKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he hits it, he shakes it to make the dust fall out
+« PAKAMÂGAN, a, (n. f.) hammer, mallet
+« PAKAMISIMEW, (v. a.) TITAW, SIMIWEW, TCHIKEW, he hits it, he knocks it against, etc., by throwing it on the ground
+« PAKAMISIN, wok, (a. a.) he hits himself against, by falling
+« PAKAMITTIN, wa, (a. in.) idem
+« PAKAMISKUSIMEW, (v. a.) TITAW, SIMIWEW, etc., he hits it, he knocks it against the ice
+« PAKAMISKUSIN, wok, (a. a.) he knocks himself on the ice
+« PAKAKAMISKUTTIN, wa, (a. in.) idem
+« PAKAMÂPAHWEW, etc., (v. a.) he hits him in the face
+« PAKAMIKKWEHWEW, etc., (v. a.) idem
+« PAKAMIKKWENEW, etc., (v. a.) idem
+« PAKAMITONEHWEW, he hits him in the mouth
+« PAKAMIYOWEW, (v. im.) sudden, violent wind
+« PAKAMIPAYIW, ok, a, (a. a. and in.) it gives a blow, shake
+
+PAK
+
+« PAKAMISKAWEW, (v. a.) KAM, KÂKEW, KATCHIKEW, he knocks it
+« PAKAMAHIKÂSUW, ok, (a. a.) he is beaten, crushed, e.g. by a gang
+« PAKAMAHIKÂTEW, a, (a. in.) idme
+« PAKAMAHIKEW, ok, (v. n.) he hits, he crushes
+« PAKAMAHIKEWIN, a, (n. f.) hitting
+« PAKAMAHWÂWASUW, ok, (v. n.) he beats his children
+« PAKAMASKUSIWAKAHIKEW, ok, (v. n.) he beats seeds, grains, etc.
+x PAKÂN, ak, (n. r.) nut
+« PAKÂNÂTTIK, wok, (n. f.) hazel tree, nut tree
++ PAKAKKAMISIW, ok, (a. a.) he has his wits about him, he is thoughtful; namawiya pakakkamisiw, he does not have his wits about him
+« PAKAKKAMEYIMEW, etc., (v. a.) he thinks him to be in a sound state of mind, or, pakakkeyimew, ttam
+« PAKAKKAMEYITTAM, wok, (v. n.) he comes back to his senses, he recovers his wits
+PAKAKKAM, (ad.) probably, without doubt
+PAKATTÂHAN, (v. im.) it is exposed to the wind
++ PÂK, (rac.) swollen
+« PÂKISIW, ok, (a. a.) he is swollen
+« PÂKAW, a, (a. in.) idem
+« PÂKISIWIN, a, (n. f.) swelling
+« PÂKIPAYIW, ok, a, (a. a. and in.) he (it) is swollen
+« PÂKIPAYIWIN, a, (n. f.) swelling
+« PÂKIPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it swell
+
+
+525
+
+PAK
+
+« PÂKINEW, (v. a.) NAM, NIWEW, NIKEW, he makes it swell by touching it
+« PÂKIKKWEPAYIW, ok, a, (a. a.) he has a swollen face
+« PÂKITONEW, ok, (a. a.) he has a swollen mouth
+« PÂKÂBIW, ok, (a. a.) he has swollen eyes
+« PÂKITCHITCHEW, ok, (a. a.) he has swollen hands
+« PÂKIKÂTEW, ok, (a. a.) he has swollen legs
+« PÂKISITEW, ok, (a. a.) he has swollen feet
+« PÂKIYÂWEW, ok, (a. a.) he has a swollen body
+x PAKASK, (rac.) clearly, that which is seen, heard, clearly distinguished
+« PAKASKISIW, ok, (a. a.) he appears clearly
+« PAKASKAW, a, (a. in.) idem
+« PAKASKISIWIN, a, (n. f.) clarity, intelligence
+« PAKASKINAWEW, (v. a.) NAM, NIWEW, NIKEW, he sees it clearly
+« PAKASKINÂKUSIW, ok, (a. a.) he is quite visible
+« PAKASKINÂKWAN, wa, (a. in.) idem
+« PAKASKINÂKUSIWIN, a, (n. f.) visibility, clear view of someone
+« PAKASKÂBAMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he looks at it, he sees it visibly
+« PAKASKITTAWEW, (v. a.) TTAM, TTÂKEW, TTÂTCHIKEW, he hears it, he understands it perfectly
+« PAKASKITTÂKUSIW, ok, (a. a.) he is quite intelligible
+
+PAK
+
+« PAKASKITTÂKWAN, wa, (a. in.) idem
+« PAKASKEYIMEW, etc., (v. a.) he has a clear and visible knowledge/familiarity
+« PAKASKEYITTAM, wok, (v. n.) he has a just and clear idea
+« PAKASKEYITTAMOWIN, a, (n. f.) clear knowledge/familiarity with something
+« PAKASKOWEW, ok, (v. n.) he speaks quite clearly
+« PAKASKOWEWIN, a, (n. f.) clear, intelligible speech
+« PAKASKIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it clear and visible
+« PAKASKÂSIW, ok, (a. a.) he is intelligent
+« PAKASKÂSIWIN, a, (n. f.) intelligent character
+« PAKASKAMUW, a, (a. in.) trail which appears well
+x PAKÂSIMOW, ok, (v. r.) he bathes
+« PAKÂSIMOWIN, a, (n. f.) bathing
+« PAKÂSIMEW, etc., (v. a.) he puts it in water, he boils it, he cooks it in water
+« PAKÂTTAW, ok, (v. a. in.) he cooks it in water
+« PAKÂTTÂWIN, a, (n. f.) cooking, in water
+« PAKÂTTÂKOKKEW, ok, (v. n.) he boils (things), he cooks in water
+« PAKÂTTÂKOKKEWIN, a, (n. f.) the action of cooking in water
+« PAKÂSUW, ok, (a. a.) he is cooked, he is boiled
+
+PAK
+
+« PAKÂTTEW, a, (a. in.) idem
+« PAKÂSUWIN, a, (n. f.) cooking in water
+« PAKASTAWEHWEW, (v. a.) HAM, HUWEW, HIKEW, he hurls it in the water, he throws it in the water
+« PAKASTAWEWEBINEW, (v. a.) NAM, NIWEW, NIKEW, idem
+« PAKASTAWEPAYIW, ok, a, (a. a. and in.) he falls in the water
+x PAKKÂN, (adv.) differently, otherwise
+« PAKKÂNISIW, ok, (a. a.) he is different, of another type
+« PAKKÂNAN, wa, (a. in.) idem
+« PAKKÂNISIWIN, a, (n. f.) difference
+« PAKKÂNEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he finds it different, he thinks it to be of another type
+« PAKKÂNAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he puts it apart, he places it differently
+« PAKKÂNIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he separates it
+x PÂKKAHAN, (v. m.) there is a pulse
+« PÂKKAHUKUW, ok, (v. pass.) he experiences a pulsing
+« PÂKKAHUKUWIN, a, (n. f.) beating pulse
+« PÂKKAHUKUHEW, etc., he makes him beat a pulse
+x PAKI, (rac.) to fall, to go below, to drop
+« PAKIKAWIW, ok, a, (a. a. and in.) it falls in drops, it drips
+« PAKIKAWIWIN, a, (n. f.) drip
+
+PAK
+
+« PAKIKÂKOWINEW, (v. a.) NAM, NIWEW, NIKEW, he makes it drip
+« PAKIKAWINEW, etc., (v. a.) idem
+« PAKIKAWIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, idem
+« PAKIPESTAW, (v. im.) only a few raindrops are falling
+« PAKIPESTAN, (v. im.) idem
+« PAKISIMEW, (v. a.) TITAW, SIMIWEW, TCHIKEW, he lets it drop to the ground
+« PAKISIN, wok, (a. a.) he falls to the ground
+« PAKITTIN, wa, (a. in.) idem
+« PAKISINOWIN, a, (n. f.) fall
+« PAKISIMOW, (v. im.) the Sun or Moon sets
+« PAKISIMÂN, a, (n. f.) cross-bream, piece of wood which is the cross-beam in a wooden trap
+x PAKIT, (rac.) to leave, to abandon, to let go, to sacrifice
+« PAKITÂPEKINEW, (v. a.) NAM, NIWEW, NIKEW, he descends with a rope
+« PAKITÂPEKIPITEW, etc., (v. a.) idem
+« PAKITATÂMOW, ok, (v. n.) he breathes his last
+« PAKITATÂMOWIN, a, (n. f.) last breath
+« PAKITAWAW, ok, (v. n.) he fishes with nets, he tends to his nets
+« PAKITAWÂWIN, a, (n. f.) fishing
+« PAKITAWESTAMÂWEW, (v. a.) he fishes for him
+« PAKITASINÂPÂN, a, (n. f.) anchor
+
+527
+
+PAK
+
+« PAKITEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he despairs, he hands it over, he sacrifices it
+« PAKITEYITTAM, wok, (v. n.) he sacrifices, e.g., pakiteyittam opimâtisiwin, he sacrifices his life
+« PAKITEYITTAMOWIN, a, (n. f.) sacrifice, abandonment
+« PAKITEYIMOW, ok, (v. r.) he despaires, he hands himself over in despair
+« PAKITEYIMISUW, ok, (v. r.) idem
+« PAKITEYIMISUWIN, a, (n. f.) abandonment of oneself
+« PAKITEYIMOWIN, a, (n. f.) idem
+« PAKITEYITTAMÂWEW, (v. a.) TAM, KEW, TCHIKEW, he abandons it to him, he delivers him, he gives him
+« PAKITEYITTAMÂKEWIN, a, (n. f.) abandonment, remission
+« PAKITEYIMISUSTAWEW, etc., (v. a.) he delivers himself to him, he abandons himself in his hands
+« PAKITINÂSUW, ok, (v. n.) he offers a sacrifice
+« PAKITINÂSUWIN, a, (n. f.) sacrifice
+« KITCHI PAKITINÂSUWIN, Holy Sacrifice of the Mass
+« PAKITINÂSUWINÂTTIK, wok, wood of sacrifice, (n. f.) kitchitwapakitinâsuwinâttik, altar
+« PAKITINÂSUSTAWEW, etc., he offers him a sacrifice
+« PAKITINASUSTAMÂWEW, etc., (v. a.) he offers a sacrifice for him
+« PAKITINEW, (v. a.) NAM, NIWEW, NIKEW, he lets go, he lets it go, he unties it
+« PAKITCHIWEBINEW, etc., he unties the bridle
+
+PAK
+
+« PAKITINISUW, ok, (v. r.) he gives himself as a sacrifice, he delivers himself, he resigns himself
+« PAKITINISUWIN, a, (n. f.) sacrifice of oneself
+« PAKITINISUSTAWEW, (v. a.) he delivers himself to him
+« PAKITINAMÂWEW, etc., (v. a.) he offers him, he abandons it to him
+« PAKITINAMÂKEW, ok, (v. n.) he offers
+« PAKITINAMÂKEWIN, a (n. f.) offering
+« PAKITINIKEW, ok, (v. n.) he sows
+« PAKITINIKEWIN, a, (n. f.) the action of sowing
+« PAKITINIGAN, a, (n. f.) seed
+« PAKITISKWEYIW, ok, (v. n.) he lowers his head
+« PAKITCHIMEW, (v. a.) MIWEW, etc., maledicit ei (he curses him), he wishes him harm
+« PAKITCHIMOW, ok, (n. n.) maledicit (he curses) he makes curses
+« PAKITCHIMOWIN, a, (n. f.) curse
+« PAKITASUWÂTEW, etc., (v. a.) he wishes him harm
+« PAKITATÂMEW, (v. a.) TTAM, etc, he stops breathing it
+« PAKITATÂTTAM, wok, (v. n.) he releases, lets go his breath
+« PAKITATATTÂMOWIN, a, (n. f.) abandoning one's breathing
+« PAKITCHIW, ok, (v. n.) he lets go. One also says this word of a bird which thrusts downwards from high in the air
+« PAKITCHIWIN, a, (n. f.) the action of letting go
+
+528
+
+PAK
+
+x PAKESSEW, ok, (v. n.) he plays a game of chance, (the clapping game)
+« PAKESSEWIN, a, (n. f.) game of chance
+PÂKKATCHI, (adv.) without coming back, forever, e.g. pâkkatchi sipwettew, he has left forever, pâkkatchi itwew, he does not go back on what he said. See. Nâspitchi
+x PAKKEGIN, wa, (n. r.) leather, tanned skin(s), e.g. moswegin, moose leather, mususwegin, buffalo skin. N.B. The suffix wegin indicates leather, sheet, Indian cloth, something thin, etc.
+« PAKKEGINOKKEW, ok, (v. n.) he tans, he prepares leather
+« PAKKEGINOKKEWIN, a, (n. f.) preparation of leather. See Kesinikuw
+x PAKK, (rac.) a part, to detach a smaller part of something larger
+« PAKKI, (adv.) a part, a portion, e.g. pakki ki ka miyitin, e.g. pakki ki ka miyitin, I will give you a part, pakki nama miwâsin, he has a part that isn't good
+« PAKKUNEW, (v. a.) NAM, NIWEW, NIKEW, he flays it, he removes the skin from him
+« PAKKUTCHENEW, (v. a.) he removes his entrails, he takes out the tripe
+« PAKKWEPAYIW, ok, a, (a. a. and in.) a piece which detaches
+« PAKKWEHWEW, (v. a.) HAM, HUWEW, HIKEW, he detaches a part by hitting it from above
+
+PAK
+
+« PAKKWENEW, (v. a.) NAM, NIWEW, NIKEW, he detaches a piece with his hand
+« PAKKWENIGAN, a, (n. f.) a detached piece
+« PAKKWATCHIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he removes it with effort
+« PAKKWEPITEW, etc., (v. a._ he detaches a piece violently, he tears off a piece
+« PAKKWEPITCHIGAN, a, (n. f.) detached, torn off piece
+« PAKKUYAWEW, (v. a.) YAM, YÂKEW, he strikes him, he injures him
+« PAKKWANIPEKIW, ok, (a. a.) he has a blister on his hand, he has a sprained hand
+« PAKKWANIPEKIWIN, a, (n. f.) blister, spraining of the hand
+« PAKKWÂTIHPEHWEW, etc., (v. a.) he lifts up his hair
+« PAKKWÂTIPENEW, etc., (v. a.) idem
+« PAKKWESWEW, (v. a.) SAM, SUWEW, SIKEW, he cuts (off) a part with scissors, or, a knife
+« PAKKWEKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he detaches a piece with an axe
+« PAKKWESIW, ok, (a. .a) he only has a part, he is detached from the rest, one removes a piece for him. One says: pakkwesiw pisim, the Moon is in its quarters, or, pakkweyâsikew
+« PAKKEYAW, a, (a. in.) he is missing a part
+« PAKKWESIN, wok, (a. a.) a part of him comes off by falling
+
+529
+
+PAK
+
+« PÂKKWETTIN, wa, (a. in.) idem
+« PAKKWESIMEW, (v. a.) TITAW, SIMIWEW, TCHIKEW, he makes a piece come off, by throwing it on the ground
+« PAKKWESIGAN, ak, (n. f.) bread, flour, wheat
+« PAKKWESIGANIKKEW, ok, (v. n.) he makes bread
+« PAKKWESIGANÂBUIY, a, (n. f.) porridge
+« PAKKWESIGANIMIN, a, (n. f.) wheat grain
+« PAKKWESIGANASKUSIY, a, (n. f.) wheat straw
+« PAKKWESIGANÂTTIK, wa, (n. f.) idem
+« PAKKWESKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he detaches a piece with his food
+« PAKKWESOWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he cuts off a slice, an edge
+« PAKKWESOWÂTCHIGAN, a, (n. f.) slice
+x PÂKKWEHWEW, (v. a.) HAM, HUWEW, HIKEW, he makes a noise by hitting it, or, by touching it
+« PÂKKWESTEHWEW, etc., (v. a.) idem, he cracks his whip on him
+« PÂKKWESTEHIKEW, ok, (v. n.) he cracks his whip
+« PÂKKWESTEHIKEWIN, a, (n. f.) cracking of the whip
+x PAKKUPEW, ok, (v. n.) he goes in the water, he puts himself in the water
+« PAKKUPEWIN, a, (n. f.) the action of going to the water
+« PAKKUPEPATTAW, ok, (v. n.) he runs to the water
+
+PAK
+
+PAKKWANIW, (v. n. and v. im.) when the trees are in sap and the bark detaches easily, e.g. sâsay pakkwaniwok mistikwok, the trees are already in sap
+PÂKKÂHÂKKWÂN, a, (n. r.) shield, parchment skin held together by glue which becomes impenetrable on the trails
+PÂKKÂHÂKKÂWN, ak, (n. r.) rooster, chicken
+x PAKKISWEW, (v. a.) SAM, SUWEW, SIKEW, he makes him explode, he blows him up with powder
+« PAKKISUW, ok, (a. a.) he explodes
+« PAKKITTEW, a, (a. in.) idem
+« PAKKISUWIN, a, (n. f.) explosion
+« PAKKISAMÂW, ok, (v. n.) he jumps from the (gun)powder, he is hit by a powder explosion
+« PAKKISAMÂWIN, a, (n. f.) accident by an explosion
+x PÂKK, (rac.) dried out, where there is little water, dried up
+« PÂKKWAW, (v. im.) there is little water
+« PÂKKUSIW, ok, (a. a.) he is dried out
+« PÂKKWÂYAW, (v. im.) it is flat, there is little water
+« PÂKKUTEW, a, (a. in.) it is dried up
+« PÂKKWÂHWEW, (v. a.) HAM, HUWEW, HIKEW, he dries it up
+« PÂKKUTCHITCHEHUSUW, ok, (v. r.) he wipes his own hands
+« PÂKKUTCHITCHENEW, (v. a.) he wipes his hands (somebody else's)
+
+530
+
+PÂK
+
+« PÂKKUTCHITCHEHWEW, etc, (v. a.) idem, he dries off his hands (somebody else's)
+« PÂKKUTCHITCHEW, ok, (a. a.) he has dry hands
+« PÂKKUKKWEHUW, ok, (v. r.) he wipes his face
+« PÂKKUKKWEHUN, a, (n. f.) towel
+« PÂKKUKKWEW, etc., (v. a.) he wipes his face
+« PÂKKUPAYIW, ok, a, (a. a. and in.) he becomes dry
+« PÂKKWATCHAW, (v. im.) dry terrain
+« PÂKKWATASKAMIKAW, (v. im.) idem
+« PÂKKUSITEHUWUW, ok, (v. r.) he wipes his own feet
+« PÂKKUSITEHWEW, etc., (v. a.) he wipes his feet (somebody else's)
+« PÂKKWASKAMIKAW, (v. im.) dry terrain
+« PÂKKWATASKAMIK, (n. f.) desert
+« PÂKKWATÂMOW, ok, (v. n.) he has 'burning' breath, being distorted by exercise
+« PÂKKWATÂTTAM, wok, (v. n.) idem
+« PÂKKWATÂMOWIN, a, (n. f.) 'burning' breath from thirst
+x PÂKOMOW, ok, (v. n.) he vomits
+« PÂKOMOWIN, a, (n. f.) vomitting
+« PÂKOMOKKWEW, ok, (v. n.) he vomits blood
+« PÂKOMOKKWEWIN, a, (n. f.) vomitting blood
+« PÂKOMOHEW, etc., (v. a.) he makes him vomit
+
+PÂK
+
+PÂKOMOSWEW, etc., idem
+PÂKOMOSIGAN, a, (n. f.) vomitive, emetic
+« PÂKOMOTOTAM, etc., he vomits it. See. Pâpayihew
++ PAKKWANOW, (adv.) haphazardly, without knowing, blindly, by heart, e.g. pakkwanow pimuttew, he walks by feeling out (his surroundings), pakkwanow wittam, he tells (a story) randomly, pakkwanow kiskeyittam, he knows it by heart
+« PAKKWANOMEW, etc., (v. a.) he speaks about it randomly, without knowing
+« PAKKWANÂWISIW, ok, (a. a.) he acts randomly
+« PAKKWANÂWISIWIN, a, (n. f.) the action of feeling around
+« PAKKWANOWAYIMOWEW, etc., (v. a.) he speaks of it randomly, he slanders it, without knowing what he is saying
+« PAKKWANOWEYIMEW, etc., (v. a.) he knows nothing on his account, he ignores him
+« PAKKWANOWEYITTAM, wok, (v. n.) he is ignorant of it
+« PAKKWANOWEYITTAMOWIN, a, (n. f.) ignorance
+x PAKWÂTTEHWEW, (v. a.) HAM, HUWEW, HIKEW, he belts it
+« PAKWÂTTEHUN, ak, (n. f) belt
+« PAKWÂTTEHUNIKKEW, ok, (v. n.) he makes a belt
+« PAKWÂTTEHUNISKAWEW, (v. a.) CAM, he belts himself in
+« PAKWÂTTEHUSKAWEW, etc., (v. a.) idem
+« PAKWÂTTEHUTOTAWEW, (v. a.) TAM, he uses it like a belt
+
+531
+
+PAK
+
++ PAKWATASKIY, a, (n. f.) desert land
+« PAKWATASKAMIK, (n. f.) desert. See. pikwataskamik
++ PAKUSEYITTÂKUSIW, ok, (a. v.) he gives hope
+« PAKUSEYITTÂKWAN, wa, (a. in.) there is reason to hope
+« PAKUSEYIMEW, etc., (v. a.) he expects something from him
+« PAKUSEYITTÂM, wok, (v.n .) he hopes, and, he desires it
+« PAKUSEYITTAMOWIN, a, (n. f.) desire, hope
+« PAKUSEYIMOW, ok, (v. n.) he has hope
+« PAKUSEYIMOWIN, a, (n. f.) hope, desire
+« PAKUSIHEW, etc., (v. a.) he begs from him
+« PAKUSITTAW, ok, (v. n.) he begs, he scrounges
+« PAKUSITTÂWIYINIW, ok, (n. f.) beggar
+« PAKUSIHIWEW, ok, (v. ind.) he begs
++ PÂKKISIW, ok, (a. a.) he is hardened, massive
+« PÂKKAW, a, (a. in.) idem
+« PÂKKAK, wok, (n. f.) or, PÂKKAKKUS, ak, imaginary being, which has neither skin nor bone, and which contents itself to whistle and cry during the night to terrify the living
++ PAKUNE, (rac.) to drill, to bore a hole
+« PAKUNESIW, ok, (a. a.) he is dug into, drilled
+« PAKUNEYAW, a, (a. in.) idem
+« PAKUNEHWEW, (v. a.) HAM, HUWEW, HIKEW, he drills it, he makes an opening in it
+
+PAK
+
+« PAKUNENEW, (v. a.) NAM, NIWEW, NIKEW, he makes a hole in him with his hand
+« PAKUNESIN, wok ,(a. a.) he is holed
+« PAKUNESIMEW, etc., (v. a.) he makes a hole in him by throwing him to the ground
+PAKUSKWAHAN, (v. im.) the lake ice begins to break up in the springtime
+x PAKWÂ, (rac.) to hate, to detest
+« PAKWÂTCHIGAN, ak, (n. f.) enemy, he who one hates
+« PAKWÂSIWEW, ok, (v. ind.) he hates
+« PAKWÂSIWEWIN, a, (n. f.) hatred
+« PAKWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he hates it
+« PAKWÂTIKUSIW, ok, (a. a.) he is abominable, detestable
+« PAKWÂTIKWAN, wa, (a. in.) it is abominable, etc.
+« PAKWÂTIKUSIWIN, a, (n. f.) the act of being hated, detested
+« PAKWÂTITUWOK, (v. m.) they hate one another
+« PAKWÂTITUWIN, a, (n. f.) mutual hatred
+x PAMIHEW, (a. a.) TTAW, HIWEW, TCHIKEW, he takes care of him, he serves him
+« PAMIHIWEWIN, a, (n. f.) service, care
+« PAMIHISUW, ak, (v. r.) he cares for himself, he has power over himself
+« PAMIHISUWIN, a, (n. f.) care for oneself
+
+532
+
+PÂN
+
+« PAMIKKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he gives him care, he cares for him
+« PAMISTAWEW, (v. a.) TAM, etc., idem, he stays by him to serve him
+« PANISTÂKEWIN, a, (n. f.) office, duty, service
+« PAMINEW, (v. a.) NAM, NIWEW, NIKEW, he takes care of it
+x PÂN, (rac.) to spread, to expand, to flourish, to splay out
+« PÂNÂKUTTEW, (v. im.) the ground begins to uncover itself in the springtime
+« PÂNEPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he uncovers it, he lights it up
+« PÂNAHWEW, (v. a.) HAM, HUWEW, HIKEW, he discovers it, he uncovers it
+« PÂNAHIKEW, ok, (v. n.) he uncovers the ground, he removes the snow, where he must set up his lodge
+« PÂNINEW, (v. a.) NAM, NIWEW, NIKEW, he splays it out
+« PÂNIHEW, (v. a.) TTAM, HIWEW, TCHIKEW, he makes it splayed out
+« PÂNESIW, ok, (a. a.) he is splayed out
+« PÂNEYAW, a, (a. in.) idem
+« PÂNESIWIN, a, (n. f.) something which is splayed out
+« PÂNEPAYIW, ok, a, (a. a. and in.) it is splayed out
+« PÂNEYÂGAN, a, (n. f.) splayed out vase
+x PÂNÂKATAMUW, a, (a. in.) battered, well marked trail
+« PÂNÂKATAMUTTAW, ok, (v. a. in.) he makes a battered trail, he batters the trail
+
+PÂP
+
+PÂPÂK, (ad.) a bit. See. etato, apisis
++ PAPAK, (rac.) thin
+« PAPAKISIW, ok, (a. a.) he is thin
+« PAPAKAW, a, (a. in.) idem
+« PAPAKEGIN, wa, (n. f.) cloth
+« PAPAKISIHEW, (v. a.) TTAM, HIWEW, TCHIKEW, he thins it
+« PAPAKIKUTEW, (v. a.) TAM, SIWEW, TCHIKEW, he thins it with a knife, or a plane
+« PAPAKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he thins it with an axe
+« PAPAKISWEW, (v. a.) SAM, SUWEW, SIKEW, he shapes it thinly
+« PAPAKITTAK, wa, (n. f.) thin wooden board
+« PAPKIWEYÂN, a, (n. f.) shirt
+« PAPAKIWEYÂNEGIN, a, (n. f.) Indian cloth, cotton
+« PAPAKÂBISKUSIW, ok, (a. a.) he is thin, when speaking of metal
+« PAPAKÂBISKWAN, wa, (a. in.) idem
+« PAPAKÂSKUSIW, ok, (a. a.) he is thin, when speaking of wood
+« PAPAKÂSKWAN, wa, (a. in.) idem
+« PAPAKEGAN, wa, (a. in.) he is thin, speaking of sheet, Indian cloth, etc.
+« PAPAKEKASIN, wa, (a. in.) idem
+« PAPAKATCHIW, ok, (a. a.) he is thinly frozen
+« PAPAKATIN, wa, (a. in.) idem
++ PAPAKWATCH, (adv.) to distract, to divert, to amuse, e.g., papakwatch pittwaw, he smokes to distract himself
+
+533
+PAP
+
+« PAPAKWATCHIHEW, etc., (v. a.) he distracts him, he diverts him
+« PAPAKWATEYIMEW, etc., (v. a.) he finds it amusing, distracting
+« PAPAKWATEYITTAM, wok, (v. n.) he entertains himself, he distracts himself
+« PAPAKWÂTISIW, ok, (a. a.) he has an amusing character
+« PAPAKWÂTISIWIN, a, (n. f.) distracting character
+« PAPAKWATEYITTÂKUSIW, ok, (a. a.) he is entertaining, amusing
+« PAPAKWATEYITTÂKWAN, wa, (a. in.) idem
+« PAPAKWATEYITTÂKUSIWIN, e, (n. f.) distraction, amusement
++ PÂPAKUPAYIW, ok, (a. a.) the skin peels from him, he has blisters
+« PÂPAKUSITESIN, wok, (a. a.) he has peeled skin on his feet
+« PÂPAKUNEW, etc., (v. a.) he peels it, he gives him blisters
+x PAPÂ, or, PAPÂMI, (rac.) from one end to the other, from side to side, e.g. papâ nakamow, he goes from one side to the other singing; papâmi kiskinohamâkew, he will teach from all sides; papâmi kiiskwew, he does crazy things from one end to the other
+« PAPÂMAHOHOW, ok, (a. a.) he is carried by the water, from one side to the other
+« PAPÂMAHOTEW, a, (a. in.) idem
+
+PAP
+
+« PAPÂMÂMOW, ok, (v. n.) he flees from one side to the other
+« PAPÂMATWEMOW, ok, (v. n.) he goes from one side to the other, crying
+« PAPÂMÂSIW, ok, (a. a.) he goes by sail
+« PAPÂMÂTAN, wa, (a. in.) it goes by wind
+« PAPÂMEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he worries about him, he is preoccupied with him
+« PAPÂMEYITTAMOWIN, a, (n. f.) worry, concern
+PAPÂMIKKAWEW, KAM, he follows him everywhere
+« PAPÂMIPAYIW, ok, a, (v. n.) he goes from one side to the other
+« PAPÂMIPATTAW, ok, (v. n.) he runs from one side to the other
+« PAPÂMIPATTÂWIN, a, (n. f.) a race
+« PAPÂMIYAW, ok, (v. n.) he flies from one side to the other
+« PAPÂMIPITCHIW, ok, (v. n.) he moves camp from one side to the other
+« PAPÂMIPITCHIWIN, a, (n. f.) peregrination (long and meandering journey(s))
+« PAPÂMISKANAWEW, ok, (v. n.) he makes trails in all directions
+« PAPÂMITTÂTCHIMOW, ok, (v. r.) he drags himself in all directions
+« PAPÂMUTTEW, ok, (v. n.) he journeys, he goes from one side to the other 
+« PAPÂMUTTEWIN, a, (n. f.) journey, walk
+« PAPÂMUTTAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes him journey, he leads him from one side to the other
+« PAPÂMUTTEHUW, ok, (v. r.) he journeys, he walks from one side to the other
+
+534
+
+PÂP
+
+« PAPÂMUTTATAM, wok, (v. a. in.) he journeys in such a place
+« PAPÂMAPIWOK, ok, (a. a.) he is seated from one side to another
+« PAPÂMASTEW, a, (a. in.) idem
+« PAPÂMÂPOKOW, ok, (a. a.) he goes on the drift/current
+« PAPÂMÂPOTEW, a, (a. in.) idem
+« PAPÂMÂHUTTEW, ok, (v. n.) he prowls from one side to the other
++ PAPÂSIW, ok, (a. a.) he is hurried, he is in a great hurry. See. nanikisîw
+« PAPÂSIWIN, a, (n. f.) haste, hurry
+« PAPÂSIHEW, (v. a.) TTAM, HIWEW, TCHIKEW, he hurries him, he makes him hurry
+« PAPÂSIMEW, etc., (v. a.) he hurries him with his words
+« PAPÂSEYIMEW, (v. a.) he thinks that he is in a great hurry
+« PAPÂSEYITTAM, wok, (v. n.) he is worried and hurried
+« PAPÂSEYITTAMOWIN, a, (n. f.) haste, hurrying
+x PÂPÂTTEWIKWEW, ok, (a. a.) he has a spotted face
+« PÂPÂTTEWISIW, ok, (a. a) he is spotted
+« PÂPÂTTEYAW, a, (a. in.) it is spotted
+« PÂPÂKÂPITTESIS, ak, (n. f.) woodcock, snipe
+« PÂPÂSTCHEW, ok, (n. f.) woodpecker, bird which pecks at wood with its beak
+x PÂPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he vomits it, he makes it come, he brings it
+
+PÂP
+
+« PÂPAHEW, etc., (v. a.) idem
+« PÂPAYIW, ok, (v. n.) he comes on horseback
+« PÂPIYAW, ok, (v. n.) he comes flying
+« PÂPATTAW, ok, (v. n.) he comes running
+PAPEYAK, (ad.) one by one, some ones
+x PAPÊTCHIW, ok, (a. a.) he is slow, tardy
+« PAPÊTAN, wa, (a. in.) idem
+« PAPÊTCHIWEYIMEW, etc., (v. a.) he finds him slow
+x PAPEWEW, ok, (a. a.) he is lucky, fortunate
+« PAPEWEWIN, a, (n. .f) luck, good fortune
+« PAPEWESKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he brings him luck, he brings him good fortune
+« PAPEWEHEW, etc., (v. a.) he makes him lucky
+« PAPEWEMEW, etc., (v. a.) idem
+x PAPESTIN, (v. im.) there is a whirlwind of snow
+« PAPESTIN, wa, (n. f.) snowbank, snow cluster
+« PAPESTINOWIN, (v. im.) there is a snowbank
+PAPESKUSIW, ok, (a. a.) he is rough, bumpy
+« PAPESKWAW, a, (a. in.) idem
+PAPETIKKUNEW, etc., (v. a.) he ties it in a boot
+« PAPETIKUNISKWEW, ok, (a. a.) he is unarmed
+x PÂPPAWOKEW, he beats his wings, he flaps his wings
+
+535
+
+PÂP
+
+« PÂPPAWIW, ok, (v. r.) he shakes himself, to make what is attached to him fall off
+« PÂPPAWIWIN, a, (n. f.) shock, shake, to dust off
+« PÂPPAWISITESIMOW, ok, (v. r.) he shakes his feet to make the mud or snow fall off
+« PÂPPAWISIMEW, (v. a.) TITAW, SIMIWEW, TCHIKEW, he shakes it, he hits it against something to make what is attached to it fall off
+« PÂPPAWINEW, (v. a.) NAM, NIWEW, NIKEW, he dusts it off
+« PÂPPAWIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he shakes it, etc.
+« PÂPPAWIPAYITTAW, ok, (v. a. in.) he cleans it by shaking it
+« PÂPPAWEHWEW, (v. a.) HAM, HUWEW, HIKEW, he cleans it by shaking it
+« PÂPPAWITAKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he cleans it by hitting it against something
+« PÂPPAWIWEBINEW, (v. a.) NAM, NIWEW, NIKEW, he shakes it to get out what is inside, e.g. a bag which one shakes, etc.
+x PÂPPIW, ok, (v. n.) he laughs
+« PÂPPIWIN, a, (n. f.) laughing
+« PÂPPIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he laughs about it
+« PÂPPISIMEW, etc., (v. a.) he pleases him, he laughs at him
+« PÂPPIWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he mocks him, or, pâppinweyimew, or, pâppinottâwew
+« PÂPPIWEYIMIWEWIN, a, (n. f.) mockery
+
+PÂP
+
+« PÂPPIWEYITTÂKUSIW, ok, (a. a.) he is laughable, ridiculous
+« PÂPPIWEYITTÂKWAN, wa, (a. in.) idem
+x PASAK, (rac.) sticky, gluey, that which adheres
+« PASAKUSIW, ok, (a. a.) he is gluey, he is thick
+« PASAKWAW, a, (a. in.) it is thick, e.g., a soup
+« PASAKWÂBUIY, a, (n. f.) a sticky, gluey liquid
+« PASAKUSKIW, ok, (n. f.) sticky gum
+« PASAKUSKIWIW, ok, (a. a.) he is sticky like gu
+« PASAKÂBIW, ok, (v. n.) he blinks his eyes
+« PASAKÂBIWIN, a, (n. f.) blinking of the eyes
+« PASAKWÂBIW, ok, (v. n.) he closes his eyes
+« PASAKWÂBIPAYIW, a, (v. n.) idem, he dozes off
+« PASAKWÂBIWIN, a, (n. f.) the action of closing the eyes
+« PASAKUSKITCHÂN, a, (n. f.) tobacco juice formed in the pipe
+« PASAKUSIN, wok, (a. a.) he is gluey
+« PASAKUTTIN, wa, (a. in.) idem
+« PASAKUSIMEW, (v. a.) TITAW, SIMIWEW, etc., he pastes it by spreading it on the ground
+« PASAKUSKIWATCHIGAN, a, (n. f.) sealing wax
+« PASAKUSKIWAHEW, etc., (v. a.) he sticks it, he glues it
+« PASAKWAMOW, ok, a, (a. a. and in.) he holds, he adheres, being stuck
+« PASAKWAMOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he adheres it, he sticks it together
+
+536
+
+PAS
+
+« PASAKWAHWEW, (v. a.) HAM, HUWEW, HIKEW, idem, pasakwamohew
+« PASAKWAHIGAN, a, (n. f.) adhesive, wax, glue
+« PASAKWEWEW, ok, (a. a.) he has sticky flesh/skin, e.g. a ruinous, fatigued animal
+« PASAKUSKIWEW, ok, (a. a.) he is bogged down
+« PASAKUSKIWOKAW, (v. im.) it is muddy, boggy
+« PASAKUTCHESKIWOKAW, (v. im.) idem, miry
+x PASÂBAHWEW, etc., (v. a.) he hits him in the face
+« PASASTEHWEW, (v. a.) HAM, HUWEW, HIKEW, he whips him
+« PASASTEHUWEWIN, a, (n. f.) chastisement, punishment
+« PASASTEHWÂWASUW, ok, (v. n.) he chastises, he whips his children
+« PASASTEHWÂWASUWIN, a, (n. f.) the action of punishing children
+« PASASTEHIGAN, a, (n. f.) whip
+« PASASTEHIGANIKÂKEW, ok, (v. n.) he makes a whip
+« PASASTEHIGANIKAWEW, (v. a.) he makes him a whip
+« PASASTEPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he delineates a line above with a string, a rope, whipping the part that he marks
+« PASASTEPAYITCHIGAN, a, (n. f.) rope for marking, in the form of a whip
+
+PAS
+
+« PASASTEPAYITCHIKEW, ok, (v. n.) he draws lines by whipping with a rope
+« PASASTEPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he designates lines on him by whipping him
+x PASIKKWEHWEW, etc., (v. a.) he hits him in the face, he subdues him
+« PASITCHITCHEHUSUW, ok, (v. r.) he hits himself in the hands
+« PASITCHITCHEHWEW, (v. a.) he hits him in the hands
+« PASIKKWEPITEW, (v. a.) he blindfolds him, covers his face
+« PASIKKWENEW, etc., (v. a.) idem
+« PASISKWEPITEW, etc., (v. a.) he covers his hed, he puts a crown on him
+« PASISTIKWÂNEPITEW, etc., (v. a.) idem
+« PASISKWENEW, etc., (v. a.) idem
+« PASISKWEPISUW,ok, (a. a.) he has a banded, crowned head
+« PASISKWEPISUN, a, (n. f.) headband, crown
+« PASITONEHWEW, etc., (v. a.) he gives him snub in the mouth
+x PASISIW, ok, (a. a.) he is hollow, concave, fluted, furrowed
+« PASAW, a, (a. in.) idem
+« PASIKISIW, ok, (a. a.) idem
+« PASIKAW, a, (a. in.) idem
+« PASISIWIN, a, (n. f.) furrow, groove, concavity
+« PASIKISIWIN, a, (n. f.) idem
+« PASATCHAW, (v. im.) coulee, small ravine, ravine
+« PASÂBISKAW, (v. im.) ravine, fissure, opening in a rock, stone
+
+537
+
+PAS
+
+« PASÂNEPAYIW, ok, a, (a. a. and in.) he has a fissure, a split
+« PASAKÂNEPAYIW, ok, a, (a. a. and in.) idem
+« PASAKIPAYIW, ok, a, (a. a. and in.) idem
+« PASIKUTCHIKEW, ok, (v. n.) he furrows out, he makes a groove
+« PASIKUTCHIKEWIN, a, (n. f.) groove
+« PASIKUTCHIGAN, a, (n. f.) instrument for grooving, bouvet (Translator's Note: a tool used to make grooves in pieces of wood)
+« PASIKUTEW, (v. a.) TAM, SIWEW, TCHIKEW, he makes a groove for him
+« PASIPESIN, wok, (a. a.) he turns, he goes in a concave shape
+« PASIPETTIN, wa, (a. in.) idem
+« PASIPESTIN, (v. im.) tornado, wherein air in a grooved form brushes against the ground or water
+« PASIPEYOWEW, (v. im.) like Pasipestin
+« PASIPEYAW, (v. im.) it goes like a furrow
+« PASAHWEW, (v. a.) HAM, HUWEW, HIKEW, he squares it off
+« PASAHIKEW, ok, (v. ind.) he squares off the wood
+« PASAHIKEWIYINIW, ok, (n. f.) squarer
+« PASAHIKEWITCHIKAHIGAN, a, (n. f.) axe for squaring
+x PASIKOW, ok, (v. r.) he gets up, from being seated
+« PASIKOWIN, a, (n. f.) the action of getting up
+« PASIKOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it lift up, he lifts it up
+« PASIKONEW, (v. a.) NAM, NIWEW, NIKEW, he lifts it
+« PASIKOTISAHWEW, (v. a.) HAM, HUWEW, HIKEW, he lifts it suddenly
+
+PAS
+
+« PASIKOSTAWEW, (v. a.) TAM, TÂKEW, TÂTCHIKEW, he gets up in his presence. Also, he resists him
+« PASIKOPATTAW, ok, (v. n.) he gets up very quickly
+PASINAW, (ad.) and, pasinaw tchi? expression of doubt. I don't know if, is it so? e.g. pasinaw kita pe-kiwew, he is doubtful that he has come back; pasinaw tchi ki miyin? are you not going to give it to me? pasinaw ekusi itwew eka ketchinahutji, without doubt, he would not speak in such a way if he was not certain; pasinaw ni pa pittukân? is it alright if I enter? See. Matwân, etc.
+x PASISÂWEW, ok, (v. n.) he makes (it) burn, he sets (it) ablaze, he sets fire to the prairie
+« PASISWEW, (v. a.) SAM, SUWEW, SIKEW, he makes it burn, he blazes it
+« PASISUW, ok, (a. a.) he burns, he is on fire
+« PASITEW, a, (a. in.) there is fire
+x PÂSITCH, (prep.) pâsitchi, above
+« PÂSITCHIPAYIW, ok, a, (a. a. and in.) it passes above
+« PÂSITCHIPEW, (v. im.) the water submerges (things), there is a flood
+« PÂSITINEW, (v. a.) NAM, NIWEW, NIKEW, he takes it by putting his hand above something
+« PÂSITAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he puts it above
+
+538
+
+PÂS
+
+« PÂSITCHIKWÂSKUTTIW, ok, (v. n.) he jumps above
+« PÂSITCHIWEBINEW, etc., (v. .a) he throws it above
+« PÂSITÂSKUW, ok, (v. n.) he passes above, e.g. a fence
+« PÂSITÂTTAWIW, ok, (v. n.) idem
+« PÂSITUTTEW, ok, (v. n.) he walks above
+« PÂSITAHWEW, (v. a.) HAM, HUWEW, HIKEW, he passes above him
+« PÂSITCHISKAWEW, etc., (v. a.) he passes over his body
+« PÂSITCHITAKUSKEW, ok, (v. n.) he passes above
+« PÂSITATJIWEW, (v. n.) or, pâskiatjiwew, ok, he passes above, e.g. a mountain, a coastline, etc.
+« PÂSTÂMATJIWEW, ok, (v. n.) or, pâskitamatjiwew, idem
+« PÂSITÂTJIWASUW, ok, he spills it while boiling it, it passes above, etc.
+« PÂSTÂTJIWATEW, a, (a. in.) or, pâsitâtjiwatew, idem
++ PÂSK, (rac.) to open, to make an opening, to puncture, to burst
+« PÂSKÂKUNAKIW, ok, (a. a.) he only just passed, his tracks are fresh
+« PÂSKÂKUNAKIWIN, a, (n. f.) fresh tracks
+« PÂSKÂKUNAKAW, (v. im.) snow which has only just fallen
+« PÂSKÂKUNAKIYAW, (v. im.) idem
+« PÂSKÂKUNEW, ok, (a. a.) his fresh tracks are there on the snow
+
+PÂS
+
+« PÂSKÂBIW, ok, (a. a.) he has gouged eyes, he is one-eyed
+« PÂSKÂWEPAHWEW, etc., (v. a.) he gouges out his eyes
+« PÂSKÂWEHUW, ok, (v. r.) he (the chick) breaks the eggshell to get out
+« PÂSKÂBOWENEW, (v. a.) NAM, NIWEW, NIKEW, he uncovers it, he removes it from its cover
+« PÂSKEKINIKÂSUW, ok, (a. a.) he is uncovered, open
+« PÂSKEKINIKÂTEW, a, (a. in.) idem, e.g. a book
+« PÂSKEKINIGAN, a, (n. f.) page of a book
+« PÂSKEKINEW, (v. a.) NAN, NIWEW, NIKEW, he opens it, he turns it, e.g. the pages of a book
+« PÂSKEKINAMÂWEW, etc., (v. a.) he opens him
+« PÂSKITTEKUTEW, a, (a. in.) it is open, e.g. a door
+« PÂSKITTENIKÂSUW, ok, (a. a.) he is open
+« PÂSKITTENIKÂTEW, a, (a. in.) idem
+« PÂSKITTENEW, (v. a.) NAM, NIWEW, NIKEW, he opens it, e.g. a door, box, window, etc.
+« PÂSKITTENAMÂWEW, etc., (v. a.) he opens it for him
+« PÂSKIPAYIW, ok ,a , (a. a. and in.) it splits, it is dawn
+« PÂSKINEW, (v. a.) NAM, NIWEW, NIKEW, he opens it, he uncovers it, e.g. to remove what covers it
+« PÂSKIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he removes the covering
+
+539
+
+PÂS
+
+« PÂSKITTEPAYIW, ok, a, (a. a. and in.) it opens, it uncovers itself
+« PÂSKITTEWEPAHWEW, (v. a.) HAM, HUWEW, HIKEW, he opens it with a shake, he presses into it
+« PÂSKITONEHWEW, etc., (v. a.) he opens his mouth (somebody else's)
+« PÂSKITONEYIW, ok, (v. n.) he opens his own mouth
+« PÂSKINAMÂWEW, etc., (v. a.) he unconvers him, he opens him
+« PÂSKITCHIWANEW, etc., (v. a.) he uncovers it
+« PÂSKIW, ok, (v. r.) he uncovers himself, e.g. someone who is lying down and takes off their blankets
+« PÂSKISIKEW, ok, (v. n.) he fires a shot from his rifle
+« PÂSKISIKEWIN, a, (n. f.) munitions, gunpowder, bullets, etc.
+« PÂSKISIGAN, a, (n. f.) rifle, firearm
+« PÂSKISIGANIS, a, (n. f.) pistol, mistahi pâskisigan, cannon
+« PÂSKISIKANÂTTIK, wa, (n. f.) rifle mount, wooden part of the rifle
+« PÂSKISIKANÂBISK, wa, (n. f.) metal, barrel of the rifle
+« PÂSKISIKANASTOTINIS, a, (n. f.) (rifle) cap
+« PÂSKISIKANIWANIHIKEW, ok, (v. n.) he holds out a rifle, he places it like a trap
+« PÂSKISOSUW, ok, (v. r.) he shoots himself
+« PÂSKISOSUWIN, a, (n. f.) suicide, with a firearm
+« PÂSKISWEW, (v. a.) SAM, SUWEW, SIKEW, he shoots him
+« PÂSKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he breaks it to open it, e.g. an egg
+
+PÂS
+
+« PÂSKAMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he breaks it with his teeth, e.g. a nut
+« PÂSKAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he places it open, uncovered
+« PÂSKINOKEW, ok, (v. n.) he disassembles the lodge, the tent, he packs up camp, he opens it, he detaches it
++ PASK, (rac.) to fork, to divide, to separate
+« PASKEW, ok, (v. n.) he forks, he takes another direction
+« PASKEWIN, a, (n. f.) other direction
+« PASKEMUW, a, (a. in.) trail which forks
+« PASKESTIKWEYAW, (v. im.) branch of a river
+« PASKETTIN, wa, (a. in.) idem
+« PASKEWIYEW, (v. a.) TAW, YIWEW, TCHIKEW, he separates from him to go on another side
+« PASKETISAHWEW, (v. a.) HAM, HUWEW, HIKEW, he makes it fork, he sends it to another side
+« PASKETTAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he separates it
+« PASKETISINEW, (v. a.) NAM, NIWEW, NIKEW, idem
+« PASKESIWIN, a, (n. f.) limb
+« PASKESIWINEYÂBIY, a, (n. f.) nerve, muscle
+« PASKETIKWANAKISIW, ok, (a. a.) his branches spread out
+« PASKETIKWANEYAW, a, (n. in.) idem
+« PASKEYAW, (v. im.) there is branching, a fork, a junction
+
+540
+
+PAS
+
+« PASKAMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he cuts it with his teeth
+« PASKEMEW, (v. a.) TTAM, MIWEW, TCHIKEW, by biting it, he takes a piece off of it
+« PASKIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he breaks it, e.g. a rope
+« PASKIPAYIW, ok, a, (a. a. and in.) it breaks, it breaks up
+« PASKISUW, ok, (a. a.) the sparks fall on him
+« PASKITEW, a, (a. in.) it sparks, the fire falls on, etc.
+« PASKISWEW, (v. a.) SAM, SUWEW, SIKEW, he cuts it, he separates it with a knife, or scissors
+« PASKITTOWEW, ok, (v. n.) he speaks of another thing, he passes to another subject
+« PASKITTOWEWIN, a, (n. f.) another (topic of) speech, another story, another prayer
+« PASKIYÂKEW, ok, (v. n.) he wins, he is a conquerer, he wins over, he dominates
+« PASKIYÂKEWIN, a, (n. f.) pre-eminence, victory, etc.
+« PASKIYAWEW, (v. a.) YAM, YÂKEW, YÂTCHIKEW, he wins it, he conquers it, he dominates it
++ PASKWAW, (v. im.) infertile, desert plains
+« PASKUSIW, ok, (a. a.) he is bare
+« PASKWAW, a, (a. in.) idem
+« PASKUW, ok, (v. n.) he moults. N.B. This word is only used for birds
+« PASKUWIN, a, (n. f.) moulting of birds
+
+PAS
+
+« PASKUHUWIPISIM, (n. f.) month where the birds moult, July
+« PASKUPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he plucks/defeathers it
+« PASKUSWEW, (v. a.) SAM, SUWEW, SIKEW, he mows it
+« PASKWAHAMÂWEW, etc., (v. a.) idem, he cuts his hair
+« PASKWAHAMAW, ok, (v. n.) he cuts his own hair
+« PASKWÂTIPESWEW, etc., (v. a.) he shears it, he renders it bald
+« PASKUSTIKWÂNEW, ok, (a. a.) he is bald
+« PASKUWITTIKEW, ok, (v. n.) he scrapes (off) the hair
+« PASKUSKISUW, ok, (a. a.)
+« PASKUSKITEW, a, (a. in.)
+« PASKWÂSKITEW, (v. im.) burnt forest, burnt woods
+« PASKWÂSKISUW, ok, (a. a.) he is completely burnt
+« PASKUNEW, ok, (a. a.) he is fat. This is used for animals
+« PASKWESKOYUW, ok, (a. a.) he is full from eating food. See. Pasweskoyuw
+« PASKWATJIY, a, (n. f.) bare mountain
+« PASWAHIKEW, ok, (v .n.) he scrapes, he scratches the hair from the skin
+« PASKWAHWEW, (v. a.) HAM, HUWEW, HIKEW, he scrapes the hair from it
+« PASKWAHIGAN, a, (n. f.) instrument of bone for scraping, scratching off hair, scraper
+« PASKWATAHIKEW, ok, (v. n.) See. Paskwahikew
+« PASKWATAHWEW, (v. a.) See. Paskawahwew
+
+541
+
+PAS
+
+« PASWATAHIGAN, a, (n. f.) See. Paskwahigan
+x PASKITAPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he straps it
+« PASKITAPISUW, ok, (a. a.) he is strapped
+« PASKITAPITEW, a, (a. in.) idem
+« PASKITAPITCHIGAN, a, (n. f.) strap
+« PASKITATAYEPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he straps his belly
+« PASKITATAYEPITCHIGAN, a, (n. f.) saddle strap
+« PASKATAYEPITCHIGAN, a, (n. f.) idem
+PÂSKATCH, (adv.) up to, even, e.g. mistahi ni kisimaw pâskatch e matchi ijit, I angered him quite a lot, to the point that he insulted me, pâskatch nama wi-mitjisuw, he doesn't even want to eat, ki ki sâkihikonow mistahi Jesus-Christ pâskatch e ki wi-nipustamâkoyak, Jesus Christ loved us very much, to the point that he wished to die for us
+x PASP, (rac.) through, to escape with difficulty
+« PASPAHAM, wok, (v. n.) he leaves, or, he enters through an opening, by a hole, e.g. a dog which wants to enter a lodge, by coming in through some hole
+« PASPAHAM, he looks on the inside, or, paspâbiw
+« PASPIW, ok, (v. n.) he escapes danger
+« PASPIWIN, a, (n. f.) the action of escaping danger
+
+PAS
+
+« PASPINEW, NAM, NIWEW, NIKEW, he saves him from danger, he takes him out through an exit
+« PASPITISINEW, (v. a.) he puts him through an opening, e.g., by an open window, he presents something
+« PASPINEW, ok, (v. n.) he avoids death with difficulty, he escapes death
+« PASPINATEW, etc., (v. a.) he kills him, he puts him in great danger
+« PASPINASUW, ok, (v. ind.) he puts someone in great danger
+x PASPASKÂBIW, ok, (a. a.) his eyes sparkle
+« PASPASKITEW, a, (a. in.) the fire sparkles, crackles
+x PASWEW, (v. a.) SAM, SUWEW, SIKEW, he makes him feel it, e.g., running after an animal, which he approaches in hiding, all of the sudden he is sensed by the animal, which flees
+PASUHEW, etc., (v. a.) idem
+« PASUW, ok, (v. n.) he smells, he sniffs
+« PASUWIN, a, (n. f.) odour, smell
++ PASWESIN, ok, (a. a.) he is full of fat, he is fat, oily
+« PASWEYAW, a, (a. in.) idem. e.g. meat which contains nothing but fat
+« PASKWESKOYUW, ok, (a. a.) he is full from eating fat, he is oily, (he is disgusted)
+« PASKWESKOYEW, etc., (v. a.) he is full of fat
+
+542
+
+PÂS
+
++ PÂSWEW, (v. a.) SAW, SUWEW, SIKEW, he dries it
+« PASUW, ok, (a. a.) he is dry, arid
+« PÂSTEW, a, (a. in.) idem
+« PÂSTEWAKATOSUW, ok, (a. a.) he is arid, e.g., a landscape hardened by dryness, or a piece of very hard, dried leather
+« PÂSTEWÂKATOTEW, a, (a. in.)
+« PÂSTEYÂKATOSUW, ok, (a. a.) idem
+« PÂSTEYÂKATOTEW, a, (a. in.) idem
+« PÂSINÂSUW, ok, (v. n.) he dries his clothes
+« PÂSINÂSTEW, (v. a.) TAM, SIWEW, TCHIKEW, he dries his clothes for him
+« PÂSTEWÂTTIK, wok, a, (n. f.) dry tree
+« PÂSTEWIMITTI, a, (n. f.) dry firewood
+« PÂSIMINEW, ok, (v .n.) he dries seeds, fruit
+« PÂSIMINÂN, a, (n. f.) dried seed
+« PÂSIPAKWEW, ok, (v .n.) he dries leaves
+« PÂSIPAKWÂN, a, (n. f.) dried leaf
+« PÂSEGINWEW, ok, (v. n.) he dries leather, skin
+« PÂSWEWOKWEW, ok, (v. n.) he dries meat
+« PÂSTEWITONEW, ok, (a. a.) he has a dry mouth
+« PÂSTEWÂBIW, ok, (a. a.) he has dry eyes
+« PÂSTEWISKIJIKWEW, ok, (a. a.) idem
+
+PÂS
+
+
+« PÂSTAKIW, ok, (v. n.) he licks his lips
+« PÂTAKIWIN, a, (n. f.) the action of licking one's lips
+x PÂSWEWEW, ok, (v. .n.) he echoes, he makes you remember
+« PASWEWESIN, wok, (a. a.) he echoes
+« PASWEWETTIN, wa, (a. in.) idem
+« PASWEWETTITOWEW, etc., (v. a.) he echoes to him, he returns the sound to him
+« PASWEWETOWAWEW, etc., (v .a.) idem
+« PASWEWEHEW, (v. a.) TTAM, HIWEW, TCHIKEW, he makes it sound, he makes it resonate
+« PASWEWESIMEW, etc., (v. a.) he makes it echo, by hitting it against, etc.
++ PÂST, (rac.) to cause a misfortune, to commit a great fault, to break, to break up. N.B. Only useage can truly make one understand the full power of this root
+« PÂSTÂHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he causes him misfortune, he makes him sin, he hurts him, he scandalises him
+« PÂSTÂMEW, etc., (v. a.) he curses him, he blasphemes him, he scandalises him, he slanders him, he vilifies him
+« PÂSTÂMIWEW, ok, (v. ind.) he blasphemes, he curses
+« PÂSTÂHUW, ok, (v. r.) he causes himself a misfortune, he sins
+« PÂSTÂHUWIN, a, (n. f.) misfortune, sin
+« PÂSTÂMOW, ok, (v. r.) he causes himself misfortune, by his words, he blasphemes
+
+543
+
+PAT
+
+« PÂSTÂMOWIN, a, (n. f.) fatal speech, blasphemy
+« PÂSTÂPAYIW, ok, a, (a. a. and in.) it is fatal, dangerous, dreadful
+« PÂSTÂPAYIHEW, etc., (v. a.) See. pâstâhew
+« PÂSTÂPAYISKAWEW, etc., (v. a.) idem
+« PÂSTÂKAMAW, ok, (v. n.) See. pâstâhuw
+« PÂSTÂSIW, ok, (a. a.) idem
+« PÂSTÂSIWIN, a, (n. f.) See. pâstâhuwin
+« PÂSTÂSKAMÂWEW, etc., (v. a.) he brings him misfortune by pursuing him
+« PÂSTINEW, (v. a.) NAM, NIWEW, NIKEW, he cracks it, he breaks it up, he breaks it, e.g. a pipe in his hand
+« PÂSTIPAYIW, ok, a,(a. a. and in.) he cracks, he breaks up, he splits
+« PÂSTISIN, wok, (a. a.) he breaks, he splits by falling
+« PÂSTITTIN, wa, (a. in.) idem
+« PÂSTATCHIW, ok, (a. a.) he breaks, he splits from the cold
+« PÂSTATTIN, wa, (a. in.) idem
+« PÂSTAHWEW, (v. a.) HAM, HUWEW, HIKEW, he breaks it by striking it
+« PÂSTAMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he breaks it with his teeth
++ PAT, (rac.) to miss being deceived, to miss one's blow
+« PATAHWEW, (v. a.) HAM, HUWEW, HIKEW, he misses it when wanting to hit or shoot it
+
+PAT
+
+« PATÂBAMEW, (v. a.) TTAM, KKEW, TCHIKEW, he loses sight of it, also: he is mistaken in seeing it
+« PATITISAHWEW, etc., (v. a.) he sends it to the side, he loses it
+« PATITISAMÂWEW, etc., (v. a.) he makes his miss his strike
+« PATESKENAM, wok, (v. n.) he loses the bottom, being in water
+« PATÂBATTAMOWIN, a, (n. f.) contempt
+« PATÂBATTAMÂWEW, etc., (v. a.) he does not notice him
+« PATCHIMEW, etc., (v. a.) he mistakes himself in talking to him
+« PATCHIPAYIW, ok, a, (a. a. and in.) he makes a mistake, it goes to the side
+« PATOTEPAYIW, ok, a, (a. a. and in.) it foes to the side, e.g. a car which goes to the side of a path
+« PATOWEW, ok, (v. n.) he makes a mistake when speaking
+« PATAHAMEW, ok, (v. n.) he misses the path
+« PATAKIMOW, ok, (v. n.) See. pâstâmow
+« PATAKIMEW, etc., (v. a.) he makes a mistake on his account
+« PATASOWÂTEW, etc., (v. a.) idem, when carrying judgement on him
+« PATINEW, (v. a.) NAM, NIWEW, NIKEW, he misses it when wishing to seize it with his hand
+
+544
+
+PAT
+
+« PATOTE, (ad.) next to, outside. See. opime, e.g., patote pimuttew, he walks next to, off of the path
+« PATOTESKANAW, (ad.) next to the path
+« PATOTETCHIWAN, (v. im.) current which passes outside of its (river)bed
+« PATAMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he misses it when wishing to seize it with his mouth
+« PATASINAHWEW, (v. a.) HAM, HUWEW, NIKEW, he is mistaken in marking it, he makes a mistake in acting towards him
+« PATAMISK, wok, (n. f.) beaver which goes on for two years
+« PATAWÂNISIS, ak, (n. f.) idem
+« PATAWÂTÂMOW, ok, (v. n.) he makes a mistake when singing
+« PATATÂMOW, ok, (v. n.) idem
+« PATOTETTAWEW, (v. a.) TTAM, TTÂKEW, TTÂTCHIKEW, he makes a mistake in speaking, he mistakes what he says, he mistunderstands
+« PATCHÂYIS, ak, (n. f.) aniaml which is going to have two winters
++ PATAKUSKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he tramples it with his feet, he walks on him
+« PATAKUNEW, (v. a.) NAM, NIWEW, NIKEW, he bows it down on the ground, he holds it against the ground
+« PATAKWAHWEW, (v. a.) HAM, HUWEW, HIKEW, he holds it against the ground by hitting it
+« PATAPISTAWEW, (v. a.) TAM, etc., he bows down before him
+« PATAPIW, ok, he bows down
+
+PAT
+
+« PATAPIWIN, a, (n. f.) bowing down
+« PATAPITISAHWEW, (v. a.) he makes him bow down
+« PATAPIHEW, etc., (v. a.) idem
+« PATAPISKWEYIW, ok, (v. n.) he bends down to the ground
+« PATCHAHASKAHASK, wok, (n. f.) bird which announces rain
+x PATHTEW, (v. a.) TAM, SIWEW, TCHIKEW, he burns it up, he grills it
+« PATHTAW, ok, (v. a. in.) he blazes it
+« PATHTCHIKÂSUW, ok, (a. a.) he is burnt up
+« PATHTCHIKÂTEW, a, (a. in.) idem
+PÂTIMA, (adv.) in another time. See. tcheskwa
++ PÂTUS, (adv.) another time (seldom used)
+« PÂTUSÂK, (adv.) in the desert
++ PÂWÂMIW, ok, (v .n.) he dreams, he wonders
+« PÂWÂMIWIN, a, (n. f.) dream, contemplation
+« PÂWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he dreams of him
+« PÂWÂMEW, etc., idem, (seldom used)
+« PÂWÂGAN, etc., (v. a.) dream, contemplation, spirit of dreams
+« PÂWAHUTCH, (adv.) as if throough a veil, through something
+« PÂWÂYIK, (ad.) idem, or, pâwâyek
+« PÂWINÊM (ad.) idem
+« PÂWANIW, ok, (a. a.) he is meagre, he is nothing but skin and bone, he succumbs to malnutrition, he wastes away
+
+545
+
+PAW
+
+« PÂWÂNIWIN, a, (n. f.) malnutrition, wasting away
+« PÂWASKWEW, (v. im.) he appears through the clouds, e.g., the Sun
+« PÂWAPAK, (adv.) through the lodge
+« PÂWINEKWASIW, ok, (a. a.) he is dozing off
+« PÂWINEKWÂMIW, ok, (a. a.)
+« PÂWOSIMEW, (v. a.) TITAW, SIMIWEW, TCHIKEW, he sees it, but only with difficulty, as if through a veil
+« PÂWOTITAW, ok, (v. n.) he has a very faint view, he can barely see it
+« PÂWÂTTAW, ok, (v. n.) with negation; e.g. namawâtch pâwâttaw, he doesn't even see, he has no knowledge of it, it is little more than a dream to him
+« PÂWINAWEW, (v. a.) NAM, NAKEW, NÂTCHIKEW, he sees it through something, he glimpses it
+« PÂWISTIK, wa, (n. f.) rapids, waterfall
+x PAW, (rac.) to drop something by shaking
+« PÂWAHWEW, (v. a.) HAM, HUWEW, HIKEW, he drops it by shaking it, he shells it
+« PAWINEW, (v. a.) NAM, NIWEW, NIKEW, he shakes it, he shells it, he peels it, e.g., an ear of grain whose seeds one makes fall, a branch whose leaves one strips, a piece of wood with the bark removed
+
+PAW
+
+PAWÂTAKINEW, etc., (v. a.) idem
+« PAWÂTAKIPAYIW, ok, a, (a. a. and in.) he shells himself, he peels
+« PAWISIMEW, (v. a.) TITAW, SIMIWEW, etc., he drops it by shaking it against
+« PAWITISAHWEW, (v. a.) HAM, HUWEW, HIKEW, he disperses them, he makes them all flee, e.g., a hunter who makes all of the beasts in path flee, he leaves nothing
+« PAWITISAHAMÂWEW, etc., (v. a.) he leaves him nothing to hunt
+« PAWITISAHIKÂTEW, a, (a. in.) e.g., misiwe pawitisahikâtew eoko askiy, this ground is all deserted by the hunting animals
+« PAWIPAYIW, ok, a, (a. a. and in.) he falls by experiencing a shake
+« PAWÂSIW, ok, (a. a.) he falls from the wind
+« PAWÂSTAN, wa, (a. in.) idem
+« PAWÂHAMOYAW, (v. im.) snow which falls from the trees
+« PAWÂTCHAKINASIS, (n. f.) December, month where the snow falls from the trees, and, still holds on to the trees
+« PAWIKASWEW, (v. a.) SAM, SUWEW, SIKEW, he burns all of it; e.g., pawikasam, okaskitem, he burns all of his powder
+« PAWIKASIGAN, a, (n. f.) plaster
+« PAWINESIW, ok, (a. a.) he has a plaster
+
+546
+
+PWÂ
+
+« PAWINESIGAN, a, (n. f.) plaster
+« PAWISKAWEW, (v. a.) KAM, KÂKEW, etc., he drops it, he shatters it by walking on top of it
+« PAWEYIMEW, etc., (v. a.) he knows only half of it
+« PAWEYITTAM, wok, (v. n.) See. Pâwâttaw
+« PAWEYITTAMOWIN, a, (n. f.) suspicion, half-knowledge
+PAYAK, virga partium (penis), genitalium (genitals)
+« PAYAKUW, ok, (v. n.) partit morbum, in hac parte (suffering from, in this part)
+« PAYATTÉ, (adv.) all ready, at hand. See. Neppem
+x PWÂ, (rac.) to succumb under a heavy burden, to be powerless
+« PWÂSTAWIW, ok, (a. a.) he is slow, nonchalant, incapable
+« PWÂSTAWIWIN, a, (n. f.) non-chalance, incapacity
+« PWÂSTAWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he finds it slow, nonchalant
+« PWÂSTAWIPAYIW, ok, a, (a. a. and in.) he slows down, he languishes
+« PWÂMUW, ok, (a. a.) See. Pwâstawiw
+« PWÂPITETTIN, wa, (a. in.) he misses, a rifle, he makes a false start
+« PWÂSTAWI MATWEWEW, (v. im.) idem, the shot does not leave until after the start
+« PWÂSTAWI TAKUSIN, wa, (v. n.) he arrives afterwards, late
+« PWÂWATEW, ok, (v. n.) he is too weighed down, he carries a heavy load
+
+PWÂ
+
+« PWÂWATEWIN, a, (n. f.) heavy load
+« PWÂWATAHEW, etc., (v. a.) he burdens him with a heavy load, he overburdens him
+« PWÂTAWIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he cannot make it to the end, he is incapable of doing it; e.g. Kijemanito nama kekway pwâtawittaw, there is nothing impossible to God
+« PWÂWATCHIHEW, etc., (v. a.) idem
+« PWÂTAWIPAYIW, ok, a, (a. a. and in.) it misses, it fails
+x PWÂT, ak, (n. r.) Sioux, savages of this name
+« PWÂTIWIW, ok, (a. a.) he is Sioux
+« PWÂTIMOW, ok, (v. n.) he speaks Sioux
+« PWÂTIMOWIN, a, (n. f.) the Sioux language
+« PWÂSIMOW, ok, (v. n.) he speaks Assiniboine
+« PWÂSIMOWIN, a, (n. f.) the Assiniboine language
+x PAYATTENAWEW, (v. a.) NAM, NÂKEW, NÂTCHIKEW, he sees it, he perceives it clearly
+« PAYATTENÂKUSIW, ok, (a. a.) he appears clearly
+« PAYATTENÂKWAN, wa, (a. in.) idem
+« PAYATTEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he knows it in and out, he has a clear idea of it
+« PAYATTÂBAMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he looks at it clearly, without anything blocking his view
+
+547
+
+PAY
+
+« PAYATETTAWEW, (v. a.) TTAM, TTÂKEW, TTÂTCHIKEW, he hears it clearly
+x PAYEWE, (adv.) or, Payewek, mark of doubt, uncertainty; e.g., payewe ayamihaw, he prays without having faith
+« PAYETTAW, (ad.) idem
+« PAYETTÂWISIW, ok, (a. a.) he does not believe that it must be so, he is incredulous, he is not convinced
+« PAYETTÂWISIWIN, a, (n. f.) doubt, incredulity
+« PAYETTÂWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he does not have faith, nor trust in him
+« PAYETTÂWITITAW, ok, (v. a. in.) he does it without believing that it will succeed
+« PAYETTÂWASPINEW, ok, (a. a.) he is not convinced that he is sick
+« PAYETTÂWIHUW, ok, (v. r.) he acts, he lives incredulously
+« PAYETTÂWIHUWIN, a, (n. f.) lack of conviction
+« PAYETTÂWITTAWEW, etc., (v. a.) he does not believe what he says
+« PAYETTÂWINAWEW, (v. a.) NAM, NÂKEW, NÂTCHIKEW, he does not believe in his appearance
+« PAYETTÂWÂBISIN, wok, (v. n.) he does not believe what he sees
+x PAYIP, (rac.) to pierce with an auger, to perforate again and again
+« PAYIPAHIGAN, a, (n. f.) piercer
+« PAYIPAHWEW, (v. a.) HAM, HUWEW, HIKEW, he pierces his, he pierces through it
+
+PAY
+
+« PAYIPAWISIW, ok, (v. n.) he leaves the woods, the forest, e.g., an animal which leaves the forest to go to the prairies
+« PAYIPISWEW, (v. a.) SAM, SUWEW, SIKEW, he pieces it by making a split with scissors
+« PAYIPISIW, ok, (a. a.) he is pierced, pierced through
+« PAYIPAW, a, (a. in.) idem
+x PE, or, PETCHI, particular prefixed before the verb, to give it the meaning of 'to come'. Sometimes, it changes it entirely, and makes it mean the opposite; e.g., kiwew, he is leaving; pe-kiwew, he is coming; ituttew, he is going; petchi-ituttew, he is coming
+« PEHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he waits for him
+« PEHUW, ok, (v. n.) he waits
+« PEHUNÂN, a, (n. f.) place where one waits
+« PEHUWIN, a, (n. f.) waiting, expectation
+x PEKATEW, ok, (v. n.) he burps
+« PEKATEWIN, a, (n. f.) a burp
+« PEKUPEW, ok, (v. n.) he emerges from the water, he reappears on the surface of the water
+« PEKUPEWIN, a, (n. f.) the action of emerging on the water
+« PEKUPEPAYIW, ok, a, (a. a. and in.) he emerges
+« PEKUPEPAYIWIN, a, (n. f.) the action of emerging
+« PEKUHEW, etc., (v. a.) he wakes him up, he wakes him out of sleep
+
+548
+
+PEK
+
+« PEKUMEW, etc., (v. a.) idem, by speaking to him
+« PEKUNEW, etc., (v. a.) idem, by touching him
+« PEKUSIN, wok, (a. a.) he wakes up by falling
+« PEKUTTIN, wa, (a. in.) it emerges, it returns to the surface
+« PEKWAKIW, ok, he drips gouts of blood, e.g. a wounded animal, which leaves a trail of blood, pekwakiskam
+« PEKUSIMEW, (v. a.) TITAW, SIMIWEW, etc., he wakes him up by giving him a shake
+« PEKWAHWEW, etc., (v. a.) idem
+« PEKWATASKWAHHWEW, (v. a.) HAM, HUWEW, HIKEW, he makes a hole, he pierces a hole, e.g., in the ice to let water come out
+« PEKWATAMEW, etc., (v. a.) e.g. a beaver below the ice who pierces it to come above
+« PEKWATAMOWIN, a, (n. f.) beaver holes, to leave the ice
+« PEKWATCHIPAYIW, (a. a.) there are holes formed in the ice in the springtime
+« PEKWATASKAWEW, (v. im.) idem
+« PEKWATCHAW, (v. im.) there are holes in the ground, e.g., in springtime when things thaw
+« PEKWATAHWEW, etc., (v. a.) See. Pekwataskwahwew
+« PEKWATAHIGAN, a, (n. f.) instrument for digging holes in the ice. See. Asisuy
+
+PET
+
+« PE-IJITISAHWEW, (v. a.) HAM, HUWEW, HIKEW, he sends him here
+« PETCHINÂKUSIW, ok, (a. a.) he appears, by coming
+« PETCHINÂKWAN, wa, (a. in.) it appears by coming
+« PETCHINÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he comes near to him, he approaches him
+« PE-NÂTEW, etc., (v. a.) idem
+« PETCHIWIYEW, (v. a.) TAW, YIWEW, TCHIKEW, he brings him
+« PETCHIPAHEW, etc., (v. a.) idem
+« PETCHITCHIPAYIW, ok, a, (a. a. and in.) it comes, e.g. something which one sucks with one's mouth
+« PETCHITCHIWAN, (v. im.) the water that rises up, e.g. water which comes from a spring
+« PEHISPÂKINEW, (v. a.) NAM, NIWEW, NIKEW, he comes by rising up
+« PEITISAHWEW, (v. a.) HAM, HUWEW, HIKEW, he sends him to this side
+« PEKIWETAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he brings it back
+« PE-NITTATCHIWEW, ok, (v. n.) he descends
+« PE-NITTASKEW, ok, (v. n.) he descends on the ground
+« PE-NOKUSIW, ok, (a. a.) he appears by coming
+« PE-NOKWAN, wa, (a. in.) idem
+« PE-OTCHIPAYIW, ok, a, (a. a. and in.) he comes from there
+« PE-OTUTTEW, ok, (v. n.) he comes from there
+« PETCHÂSTAMUTTEW, ok, (v. n.) he comes by walking
+« PETCHÂSTAMISKAW, ok, (v. n.) he comes by swimming, or, rowing
+
+549
+
+PET
+
+« PE-PETIKKUNAM, wok, (v. n.) he makes noise while walking
+« PETÂBOYUW, ok, (v. n.) he comes on the water
+« PETCHÂSTAMAHAM, wok, (v. n.) idem
+« PETÂSIW, ok, (a. a.) he comes by saik
+« PETÂSTAN, wa, (a. in.) it is carried by the wind
+« PEYÂSIW, ok, (v. n.) he descends from the air
+« PEYÂSASKEW, ok, (v. v.) he descends on the ground
+« PEYÂSIWEPAHWEW, etc., (v. a.) he brings it down by hitting it
+« PEYÂSIPAYIW, ok, a, (a. a. and in.) he comes down, it comes to the bottom
+« PEYÂSIPAYIHEW, etc., (v. a.) he brings it down
+« PEYÂSIPITEW, etc., (v. a.) idem, by pulling it
+« PESIWEW, (v. a.) TAW, he brings it, he carries it along
+« PETOWEW, (v. a.) TWÂKEW, he brings him along
+« PETAMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he sucks it, he inhales it, e.g. a child who suckles the bosom of his mother to draw milk
+« PETÂBAN, (v. im.) the dawn begins to appear
+« PETCHIWÂBAN, (v. im.) idem
+« PETÂSTEW, (v. im.) idem
+« PETATOPAYIW, ok, (v. n.) he returns from the war
+« PETCHITEHESKAWEW, (v. a.) he enters into his heart
+
+PET
+
+« PETCHIYÂWESKAWEW, (v. a.) he enters into his body
+« PETCHITATCHÂKOWESKAWEW, (v. a.) he enters into his soul
+« PETTAWEW, (v. a.) TTAM, TTÂKEW, TTÂTCHIKEW, he hears him
+« PETTAM, wok, (v. n.) he obeys
+« PETTAMOWINM, (n. f.) obedience
+« PETWEWEHAM, wok, (v. n.) one hears him coming on the water
+« PETWEWENAM, wok, (v. n.) one hears him walking
+« PETWEWITAM, wok, (v. n.) one hears him coming by his speaking
+« PETWEWESIN, wok, (a. a.) he comes, making noise
+« PETWEWETTIN, wa, (a. in.) idem
+« PETCHISTIMOW, (v. im.) the storm, the tempest approaches, draws forth
+« PETÂMOW, ok, (v. n.) he comes fleeing
+« PETEYIYIMEW, etc., (v. a.) he thinks that it is coming
+« PETCHIMEW, etc., (v. a.) he makes him come, by speaking to him, or calling him
++ PESO, (adv.) close, (seldom used). See. Kisiwâk
+« PESOSIW, ok, (a. a.) he is close
+« PESWASIN, wa, (a. in.) it is close
+« PESOWAN, wa, (a. in.) idem
+« PESWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks it is close
+« PESOTCHIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he puts it close
+« PESOHAMEW, ok, (v. v.) he takes short steps
+
+550
+
+PEK
+
+« PESONÂKUSIW, ok, (a. a.) he appears close
+« PESONÂKWAN, wa, (a. in.) idem
+« PESOWISKWEYIW, ok, (v. n.) he approaches the head
+« PESOWISKWESTAWEW, etc., (v. a.) he puts his head close to him
+« PESOTTAWEW, (v. a.) TTAM, TTÂKEW, TTÂTCHIKEW, he believes he is close by hearing his voice
+« PESWÂBAMEW, (v. a.) TTAM, KKEW, TCHIKEW, he sees it, he sees it close by
+« PESWEYITTÂKUSIW, ok, (a. a.) he is thought to be close
+« PESWEYITTÂKWAN, wa, (a. in.) idem
+x PEKKÂTCH, (adv.) or, PEKKÂTCHI, calmly, slowly, (this word is seldom used). See. Peyattik, nîsikkâtch
+« PEKIKÂTISIW, ok, (a. a.) he is slow
+« PEKIKÂTAN, wa, (a. in.) idem
+« PEKIKÂTISIWIN, a, (n. f.) slowness
+« PEKIKÂTEYIMEW, etc., (v. a.) he finds it slow
+« PEKIKÂTEYITTAM, wok, (v. n.) he is bored, he finds the time long. See. Pîtteyittam
+« PEKIKÂTEYITTAMOWIN, a, slowness to decide
++ PEKKISIW, ok, (a. a.) he is pure, clean
+« PEKKAN, wa, (a. in.) idem
+« PEKKISIWIN, a, (n. f.) purity
+« PEKKÂTISIW, ok, (a. a.) he has a pure character
+« PEKKÂTAN, wa, (a. in.) it is pure
+
+PEK
+
+« PEKKITEHEW, ok, (a. a.) he has a pure heart
+« PEKKITEHEWIN, a, (n. f.) purity of heart
+« PEKKIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he purifies him
+« PEKKIHISUW, ok, (v. r.) he purifies himself
+« PEKKIHISUWIN, a, (n. f.) purification
+x PES, (rac.) to draw lines, bars, streaks
+« PESAHWEW, (v. a.) HAM, HUWEW, HIKEW, he streaks it, he stripes it, he draws lines on him
+« PESAKUNEHWEW, etc., (v. a.) he makes lines on the snow
+« PESASKAMIKAHWEW, etc., (v. a.) he draws lines on the ground
+« PESATAWOKKAHWEW, etc., (v. a.) he draws lines on the sand
+« PESEGIN, wa, (n. f.) cloth streaked with lines
+« PESEGAN, (v. im.) it is striped
+« PESEKKUTEW, (v. a.) TAM, SIWEW, TCHIKEW, he makes grooves on him with a knife, or another cutting edge
+« PESASINAHWEW, (v. a.) HAM, HUWEW, HIKEW, he draws lines, he forms lines above
+« PESAHIGAN, a (n. f.) plan, line, stripe
+« PESAHIKÂSUW, ok, (a. a.) he is streaked, striped
+« PESAHIKÂTEW, a, (a. in.) idem
+« PESÂBOWEYÂN, a, (n. f.)  striped blanket
+« PEPESÂBOWEYÂN, a, (n. f.) (more often used) striped blanket
+
+551
+
+PEY
+
+« PESITCHIN, ok, (a. a.) he wounds himself, he scrapes his skin, he tears his skin, his flesh, in a streak
+« PESITTIN, wa, (a. in.) it is torn in lines, in edges
+« PESEKAHWEW, (v. a.) HAM, HUWEW, HIKEW, See. Pesahwew
+« PEPESWEW, etc., (v. a.) he incises it
+« PEPESOSUW, ok, (v. r.) he makes incisions on himself
+« PEPESUW, ok, (a. a.) he is incised, slit
+PEPEKISIS, ak, (n. r.) small bird, marillon
++ PESISKAW, ok, (v. n.) he goes slowly, he walks heavily
+« PESISKÂPAYIW, ok, (a. a. and in.) it goes slowly
+« PEYÂSKAW, ok, (v. n.) he is slow, heavy, lazy
+« PÉTUTTEW, ok, (v. n.) idem
+x PEYAK, one, an, a certain, e.g. peyak kit awâssimis, one of his children
+« PEYAKUW, ok, (a. a.) he is one, alone
+« PEYAKUWIN, a, (n. f.) unity, solitude
+« PEYAKUKWÂMIW, wok, (v. n.) he sleeps alone
+« PEYAKOKKAWEW, etc., (v. a.) he is alone around him, to work him
+« PEYAKOKAM, wok, (v. n.) he is alone in his canoe
+« PEYAKOKEW, ok, (v. n.) he is alone in his house, he lives alone
+« PEYAKOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, it is always him that he uses, he always uses the same one
+
+PEY
+
+« PEYAKWEYIMEW, etc., (v. a.) he only thinks of him
+« PEYAKWEYITTAM, wok, (v. n.) he only thinks of one thing
+« PEYAKWEYITTAMWOK, (v. n.) they are unanimous. See. tâbitaweyittamwok
+« PEYAKWEYITTAMOWIN, a, (n. f.) single thought, unanimity
+« PEYAKUTCHITCHEW, ok, (a. a.) he has only one hand
+« PEYAKWÂBIW, ok, (a. a.) he has only one eye
+« PEYAKWAPIW, ok, (a. a.) he is sitting alone in this place, or, he is alone
+« PEYAKOKUNEW, (n. f.) one mouth
+« PEYAKOKUNES, (n. f.) idem (more often used)
+« PEYAKOKKAMIKISIW, (a. a.) his lodge, his dwelling is alone, his lodge is the only one there
+« PEYAKOKASKWEW, ok, (a. a.) he has only one nail on his foot, e.g. the horse
+« PEYAKOMIN, (n. f.) a single seed
+« PEYAKOPEHIGAN, ak, (n. f.) card
+« PEYAKOPEHIKEW, ok, (v. n.) he plays cards
+« PEYAKONISK, (n. f.) a brasse (Translator's Note: An antiquated French unit of measure, roughly 1.6 metres)
+« PEYAKONISKESIW, ok, (a. a.) he is a brasse long
+« PEYAKONISKEYAW, a, (a. in.) it is a brasse long
+
+552
+
+PEY
+
+« PEYAKWAN, (v. im.) it is the same thing, it is all one
+« PEYAKWÂBOYEW, ok, (v. n.) he is alone to row
+« PEYAKOSÂB, eleven
+« PEYAKOSÂBIWOK, (a. a.) they are eleven
+« PEYAKOSKÂN, (n. f.) a tribe, a nation
+« PEYAKOSKÂNESIWOK, (a. a.) they are a single nation
+« PEYAKUTTEW, ok, (v. n.) he walks alone
+« PEYAKWEYIMISUW, ok, (v. r.) he is egotistical, he thinks only of himself
+« PEYAKWEYIMOW, ok, (v. r.) idem
+« PEYAKWEYIMOWIN, a, (n. f.) egoism
+« PEYAKOWITEW, ok, (a. a.) he has only one horn
+« PEYAKWATTAY, (n. f.) one more (fur)
+« PEYAKWATTAYESIW, ok, (a. a.) it is worth one more (fur)
+« PEYAKWATTAYEYAW, a, (a. in.) idem
+« PEYAKWÂBISK, (n. f.) a measure, pint, or bottle
+« PEYAKWÂTTIK, (n. f.) a measure, a stick, a bar of soap, a roll of tobacco
+« PEYAKWASKATEW, etc., (v. a.) he abandons him alone
+« PEYAKWEGAN, (v. im.) a piece of Indian cloth, merchandise
+« PEYAKWAW, (adv.) once
+« PEYAKOSÂBWAW, (ad.) eleven times
+
+PEY
+
+« PEYAKOSÂBOMITANO, one hundred and ten
+« PEYAKWANOK, (ad.) in the same place, in one place
+« PEYAKWÂYI, (n. f.) a single sort, type
+« PEYAKOYEWÂMÂN, See. Peyakoskân
+« PEYAKOYEMÂN, (n. f.) idem
+« PEYAKOYEWÂMAK, (n. f.) a band, a family
+x PEYATTIK, or, PEYATTAK, (ad.) with care, be careful, precaution, e.g., peyattik! be careful! and peyattik pikiskwe: speach calmly, with caution
+« PEYATTIKOWISIW, ok, (a. a.) he acts slowly, without hurrying
+« PEYATTIKOWAN, wa, (a. in.) idem
+« PEYATTIKOWÂTISIW, ok, (a. a.) he has a peaceful, calm character
+« PEYATTIKWEYIMEW, etc., (v. a.) he thinks him to be peaceful
+« PEYATTIKWEYITTAM, wok, (v .n.) he is calm, quiet
+« PEYATTIKWEYITTAMOWIN, a, (n. f.) calm, tranquility
+PWEKITOW, ok, (v. n.) he farts
+« PWEKITOWIN, a, (n. f.) fart
++ PIK, (rac.) murky, muddy, thick, confused
+PIKISIW, ok, (a. a.) he is murky, dirty
+« PIKAN, wa, (a. in.) idem
+« PIKÂGAMIW, (v. im.) dirty, murky, muddy water
+« PIKÂGAMISKAM, wok, (v. a. in.) he makes the water murky by walking in it
+
+553
+
+PIS
+
+« PIKISKA, wok, (v. a. in.) idem
+« PIYEGANOWISIPIY, (n. f.) river of dirty water, Missouri
+« PIKANOWIYINIW, ok, (n. f.) savages called Piegans
+« PIYEKANOWIYINIW, ok, (n. f.) idem
+« PIKINEW, (v. a.) NAM, NIWEW, NIKEW, he makes it murky by touching it with his hand
+« PIKISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he makes it murky, e.g., by walking in the water
+« PIKÂGAMITTAW, ok, (v. a. in.) he makes the water murkey, muddy
+« PIKÂGAMINAM, wok, (v. v. in.) idem
+« PIKISEYAW, (v. imp.) there is fog, thick smoke, caused by the cold
+« PIKISEPAYIW, (v. im.) idem
+« PIKISEYÂBATTEW, (v. im.) idem
+« PIKISEWIN, a, (n. f.) steam
+« PIKITTEW, (v. im.) smoke which comes up from afar
+« PIKISESUW, ok (a. a) steam which comes from the body when it heats up
+« PIKISETÂMOW, ok ,(v. n.) he breathes, as steam, e.g. when one walks in the cold, one's breath is like a steam
+« PIKITTEWATÂMOW, ok, (v. n.) idem
+« PIKISETÂMOWIN, a, (n. f.) breathing in heavy smoke
+« PIKITTEWATÂMOWIN, a, (n. f.) idem
+
+PIK
+
++ PIKIN, (rac.) thin, to reduce to powder, to pulverise
+« PIKININEW, (v. a.) NAM, NIWEW, NIKEW, he reduces it to a powder, to little pieces
+« PIKINIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, idem
+« PIKINIWEPAHWEW, (v. a.) HAM, HUWEW, HIKEW, he breaks it all into little pieces
+« PININIHEW, (v. a.) TTAM, HIWEW, TCHIKEW,  he divides it into little pieces
+« PIKINATAHWEW, etc., (v. a.) he puts it in pieces
+« PIKINISIW, ok, (a. a.) he is a powder
+« PIKINAW, a, (a. in.) idem
+« PIKINIPAYIW, ok, a, (a. a. and in.) it turns to powder
+« PIKINIGANEW, ok, (v. n.) he shakes in all of his bones
+« PIKINIKKASWEW, (v. a.) SAM, SUWEW, SIKEW, he reduces it to ashes
+« PIKINIKKATTEW, a, (a. in.) idem
+« PIKINIPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he spreads it out in little pieces
++ PIKK, (rac.) thin, fine, powdered
+« PIKHKOW, a, (n. f.) ash
+« PIKHKOWIN, (v. im.) it is ashen, or, there is ash
+« PIKHKOWIW, ok, (a. a.) it is ashy, covered in ashes, e.g. ki pikhkowin, ekusi kâwi ki ka kiwetoten pikhkok, you are ash, and you will return to ash
+
+554
+
+PIK
+
+« PIKHKWÂBUIY, a, (n. f.) ash water, lye
+« PIKKWÂBOKKEW, ok, (v. n.) he makes lye
+« PIKKUS, ak, (n. f.) small insect (firebrand)
+« PIKKASWEW, (v. a.) SAM, SUWEW, SIKEW, he reduces it to ashes
+« PIKKASUW, ok, (a. a.) he is reduced to ashes
+« PIKKATTEW, a, (a. in.) idem
+x PIKIW, ok, (n. f.) gum, resin. N.B. SKIWEW is the suffix which indicates gum, e.g., misimiskiwew, he chews gum
+« PIKIWIW, (v. im.) there is gum
+« PIKIWIW, ok, (a. a.) he is gummy
+« PIKIWAN, wa, (a. in.) idem
+« PIKIKKÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he smears it with gum
+« PIKIWEGIN, wa, (n. f.) oil cloth
++ PIKK, (rac.) to bend in two, to curve back
+« PIKKISIW, ok, (a. a.) he is bend, curved
+« PIKKAW, a, (a. in.) idem
+« PIKKIPAYIW, ok, (a. a. and in.) idem
+« PIKKIKEYIW, ok, (v. n.) he bends his knee
+« PIKKIKKESTAWEW, (v. a.) TAM, TAKEW, etc., he bents his knee before him
+« PIKKIPITUNEW, ok, (a. a.) he has a bent, hooked arm
+
+PIK
+
+« PIKKIPITUNEHWEW, etc., (v. a.) he bends his arm (somebody else's)
+« PIKKITCHITCHEYIW, ok, (a. a.) he has a bent, curved hand
+« PIKKIKKUMÂN, a, (n. f.) closing knife (Translator's Note: Presumably, a knife which folds in on itself, like a pocket-knife)
+« PIKKINEW, (v. a.) NAM, NIWEW, NIKEW, he bends it, he curves it back, e.g. he closes his knife
+« PIKKIPITEW, etc., (v. a.) he bends it by pulling it
+« PIKKEKINEW, (v. a.) NAM, NIWEW, NIKEW, he bends it in two, e.g. a piece of cloth
+« PIKKISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he bends it by placing his food above it
+« PIKKIKIW, ok, (a. a.) he pushes, he grows folded, curved over
+« PIKKIKIN, wa, (a. in.) idem
+« PIKKIKKISWEW, (v. a.) SAM, SUWEW, SIKEW, he bends it, and curves it over in the fire
+« PIKKIKASUW, ok, (a. a.) he is bent, curved in the fire
+« PIKKIKKATTEW, a, (a. in.) idem
+x PIKISK, (rac.) weak, soft, of little hardness, spoiled, rotten
+« PIKISKISIW, ok, (a. a.) he is weak, without consistency
+« PIKISKAW, a, (a. in.) idem, hardly solid
+« PIKISKISIWIN, a, (n. f.) weakness, e.g. a piece of sheet which is not strong
+« PIKISKIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it weak, powerless, without consistency
+« PIKISKIPITEW, etc., (v. a.) idem
+« PIKISKAHWEW, etc., (v. a.) idem
+
+555
+
+PIK
+
+« PIKISKATAHWEW, etc., (v. a.) idem
+« PIKISKISIHEW, etc., (v. a.) idem, This also means something which is tender, easy to eat
+« PIKISKIPAYIW, ok, a, (a. a. and in.) it becomes weak, etc.
+« PIKISKASTWAW, ok, (v. n.) he conducts himself without courage, without strength, without energy
+« PIKISKEWEW, ok, (a. a.) he has limp, bad flesh, e.g. a catarrhal animal running
+« PIKISKWATITIW, ok, (a. a.) he is rotten, spoiled
+« PIKISKATIN, wa, (a. in.) idem
+« PIKISKATITIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it rot
+« PIKISKATCHIKEW, etc., (v. a.) idem
+x PIKISKÂT, (rac.) to overwhelm with worries, to dispirit, to tear down, to discourage
+« PIKISKÂTCHIMEW, etc., (v. a.) he saddens him, he tears him down with his words
+« PIKISKÂSOMEW, etc., (v. a.) idem
+« PIKISKÂTCHIHEW, (v. a.) he saddens him, makes him melancholic
+« PIKISKÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he delays him from seeing it
+« PIKISKATEYIMEW, etc., (v. a.) he thinks him to be sad, melacholic
+« PIKISKÂTEYITTAM, wok, (a. n.) he is melancholic, he is weary
+« PIKISKÂTEYITTAMOWIN, a, (n. f.) ennui, melancholy
+« PIKISKÂTAMATCHIHUW, ok, (a. a.) he is melancholic, or, he is bothered by his illness, due to his suffering
+
+PIK
+
+« PIKISKÂTAPPINEW, ok, (a. a.) his sickness makes him melancholic
+« PIKISKÂTISIW, ok, (a. a.) he has a weary, melancholic character
+« PIKISKÂTAN, wa, (a. in.) it is wearisome, melancholic
+« PIKISKÂTISIWIN, a, (n. f.) melancholy
+« PIKISKÂSINÂKUSIW, ok, (a. a.) he seems sad, dejected
+« PIKISKÂSINÂKWAN, wa, (a. in.) idem
+« PIKISKÂSITTAWEW, (v. a.) TTAM, TTÂKEW, etc., he becomes melancholic by hearing it
+« PIKISKÂSITTÂKUSIW, ok, (a. a.) he speaks in a manner which causes melancholy, he has a sad, weary tone of voice
+« PIKSIKÂSITTÂKWA, wa, (a. in.) the sound is sad, melancholic
+« PIKISKÂTEYITTÂKUSIW, ok, (a. a.) there is somethin which makes him sad, melancholic
+« PIKISKÂTIKUSIW, ok, (a. a.) idem
+« PIKISKÂTEYITTÂKUSIWIN, a, (n. f.) sadness, dejection
+« PIKISKÂTIKUSIWIN, a (n. f.) idem
+« PIKISKÂTEYITTÂKWAN, wa, (a. in.) it is lamentable, melancholic, wearisome
+« PIKISKÂTIKWAN, wa, (a. in.) idem
+
+556
+
+PIK
+
+x PIKISKWEW, ok, (v. n.) he speaks, he talks
+« PIKISKWEWIN, a, (n. f.) speech, speaking
+« PIKISKWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he speaks to him, he converses with him
+« PIKISKWÂTAM, wok, (v. a. in.) he speaks of it
+« PIKISKWESKIW, ok, (a. a.) he is a talker, he speaks a lot
+PIKO, (adv.) only, apart from, nothing but, e.g., niya piko, only me, Kijemanito piko mâ mâttâwisiw, God alone is great, piko kimiwaki, except that it's raining, piko nipitji, except that he died, nipiy piko, nothing but water, piko pittwaw, he does nothing but smoke, piko ituke kitchi mâtuyan, you have to cry, piko kakiyaw tchi nipiyak, we must all die
+« PIKO KISPIN, (adv.) unless, e.g. piko kispin Kijemaniito, unless you pray, you will not see God, or, it is only by praying that you will see God
+PIKONATA, (adv.) without purpose, without reason, freely. See. Konata, e.g. pikonata ki miyitin, I give it to you freely, pikonata itwew, he speaks without purpose, without cause
+x PIKU, and, PIKW, (rac.) to break, to break up, to smash
+« PIKUHEW, (v. a.) HAM, HUWEW, HIKEW, he breaks it, he breaks it up
+« PIKUNEW, (v. a.) NAM, NIWEW, NIKEW, he breaks it with his hand
+
+PIK
+
+« PIKUPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he breaks it, as by tearing it
+« PIKUNIKEW, ok, (v. ind.) he breaks
+« PIKUNIKEWIN, a, (n. f.) fracture, rupture
+« PIKUNISUW, ok, (v. r.) he harms himself, e.g. someone who makes a mistake, or breaks his promise
+« PIKUNISUWIN, a, (n. f.) he breaks it, he tears it up with his words
+« PIKUKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he cuts it in pieces, he chops it
+« PIKUPITCHIKEW, ok, (v. n.) he plows
+« PIKUPITAJISKIWEW, ok, (v. n.) he breaks up, he tears up the ground, he plows, he breaks the earth
+« PIKUPITCHIGAN, a, (n. f.) plow
+« PIKUPITAJISKIWÂGAN, a, (n. f.) idem
+« PIKWASKAMIKIPITCHIKEW, ok, (v. n.) he plows, he tears up the ground
+« PIKWASKAMIKIPITCHIGAN, a, (n. f.) plow
+« PIKUPITCHIKEWIN, a, (n. f.) plowing
+« PIKUPITAJISKIWEWIN, a, (n. f.) idem
+« PIKUPAYIW, ok, a, (a. a. and in.) it is broken, broken up. One also says this word for: he is covered in wounds, scabs, boils, inflammation, he has a breakout (of something)
+« PIKUPAYIWIN, a, (n. f.) breakout, appearance of boils
+
+557
+
+PIK
+
+« PIKUSIMEW, (v. a.) TITAW, SIMIWEW, TCHIKEW, he breaks it by knocking it against
+« PIKUSIN, wok, (a. a.) he breaks by falling
+« PIKUTTIN, wa, (a. in.) idem
+« PIKUSKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he breaks it by walking on it
+« PIKUSTIKWÂNESIN, wok, (d. a.) he breaks his head by falling
+« PIKUSWEW, (v. a.) SAM, SUWEW, SIKEW, he cuts it in pieces
+« PIKWAMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he breaks it with his teeth
+« PIKWASTEHWEW, etc., (v. a.) he breaks it by whipping it, he tears up by striking
+« PIKWASKISINEW, ok, (a. a.) his shoes are pierced
+« PIKWATAHWEW, (v. a.) HAM, HUWEW, HIKEW, he breaks it, he breaks up by hitting it
+« PIKWAHWEW, etc., (v. a.) idem
+« PIKWÂSIW, ok, (a. a.) he is broken by the wind
+« PIKWÂSTAN, wa, (a. in.) idem
+« PIKWEYIMEW, etc., (v. a.) he is full of anxiety on account of him, he thinks him to be lost
+« PIKWEYITTAM, wok, (v. n.) he is disturbed, he has a tormented spirit, his imagination is broken
+« PIKWEYITTAMOWIN, a, (n. f.) anxiety, unease
+x PIKKOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he acquires it, he wins it, he saves it, he pulls it from danger, he delivers it
+
+PIK
+
+« PEKKUHIWET, or, OPIKKUHIWEW, (n. f.), a saviour, a liberator
+« PIKKUHIWEWIN, a, (n. f.) salvation, deliverance
+« PIKKUHUW, ok, (v. r.) he saves himself, he delivers himself
+« PIKKUHUWIN, a, (n. f.) salvation, deliverance
+x PIKWATCHI, (prefix) deserted, that which is solitary
+« PIKWATCHI AYISIYINIW, ok, (n. f.) wild man, who always stays alone
+« PIKWATASTIM, wok, (n. f.) wild horse, which is not tamed
+« PIKWATCHIPIJISKIW, ok, (n. f.) wild animal
+« PIKWATOSÂN, ak, (n. f.) bastard. See. Kiminitchâgan
+« PIKWATOSEW, ok, (v. n.) she puts a bastard into the world
+« PIKWATASKIY, a, (n. f.) deserted, solitary land
+« PIKWATASKAMIK, (n. f.) desert
+« PIKWATASKAMIKAW, (v. im.) there is a desert
+« PIKWATASKAMIKOWIWWAN, (a. in.) it is desert
++ PIM, (rac.) that which passes, that which has its course, towards, by, that which crosses, that which twists. N.B. At first glance, it appears that many of the words which follow do not belong to this root, but it is best to collate them under the same root, seeing as they all derive from there
+
+558
+
+PIM
+
+« PIMÂHUPOK, wa, (n. f.) vetch, (jargeau) wild pea
+« PIMÂHWEW, (v. a.) HAM ,HUWEW, HIKEW, he screws it, he twists it, he twists it round, he plaits it, or, pimatahwew
+« PIMÂBISKUSIW, ok, (a. a.) he is twisted, when speaking of metal
+« PIMÂBISKAHIGAN, a, (n. f.) screw, nut
+« PIMÂBISKAHWEW, (v. a.) HAM, etc., he screws it, he screws it on
+« PIMÂBISKWAW, a, (a. in.) twisted, bent metal
+« PIMÂSKUSIW, ok, (a. a.) he is twisted, across, when speaking of a tree, a piece of wood
+« PIMÂSKWAN, wa, (a. in.) idem
+« PIMIKISIW, ok, (a. a.) idem
+« PIMIKAN, wa, (a. in.) idem
+« PIMÂTTIK, wok, (n. f.) twisted, hooked tree
+« PIMIKUTCHIGANÂTTIK, wok, (n. f.) twisted column, wooden screw
+« PIMITAKAHWEW, (v. a.) HAM, etc., he screws it
+« PIMITAKINEW, (v. a.) NAM, etc., idem
+« PIMITAKAHIGAN, a, (n. f.) auger
+« PIMITAKAHIGANIS, a, (n. f.) gimlet
+« PIMITAKINIGAN, a, (n. f.) idem
+« PIMIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he does it wrong
+« PIMIKWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he sews it wrong
+
+PIM
+
+« PIMIKWEYIW, ok, (v. n.) he has his neck crooked
+« PIMIKWEYÂWEYIW, ok, (v. n.) idem
+« PIMIKWENEW, etc., (v. a.) he twists his neck
+« PIMINEW, (v. a.) NAM, NIWEW, NIKEW, he twists it
+« PIMINIKÂSUW, ok, (a. a.) he is twisted, twirled
+« PIMINIKÂTEW, a, (a. in.) idem
+« PIMINIKEPAYIW, ok, a, (a. a. and in.) it twists around
+« PIMINIGAN, a, (n. f.), rolled tobacco
+« PIMAHOKUW, ok, (v. n.) he twists it, e.g. a skin that one has tanned
+« PIMINAKKWÂN, a, (n. f.) cable, rope
+« PIMINAKKWÂNIW, a, (n. f.) string
+« PIMISIW, ok, (a. a.) he is twisted, askew
+« PIMAW, a, (a. in.) idem
+« PIMAKÂM, (adv.) pâpimâkam, from one end of a river or lake to the other
+« PIMAKÂMEHAM, wok, (v. n.) he goes from one end of the water to the other
+« PIMAKÂMEPISUN, a, (n. f.) shoulder strap, suspender
+« PIMAKÂMEPISUW, ok, (a. a.) he wears straps
+« PIMÂMEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he is antipathetic to him, he is intrigued with him
+« PIMÂMEYITTAM, wok, (v. n.) he is intrigued
+« PIMÂMEYITTAMOWIN, a, (n. f.) antipathy
+
+559
+
+PIM
+
+« PIMÂMEYIMOW, ok, (a. a.) he is reserved, he does not dare integrate himself into that which does not concern him
+« PIMÂMEYIMOWIN, a, (n. f.) reservedness, discomfort
+« PIMÂMITTAWEW, (v. a.) TTAM, TTÂKEW, TTÂTCHIKEW, he listens to it with displeasure, he takes his words badly
+« PIMÂMINAWEW, (v. a.) NAM, NÂKEW, etc., he looks at it in a negative light
+« PIMÂTCHIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he gives him life, he saves him, he delivers him
+« PIMÂTCHIHIWEWIN, a, (n. f.) salvation, redemption
+« PIMÂTCHIHIWEW, ok, (v. ind.) he is a saviour, he is a liberator
+« PIMÂRCHIHUW, ok, (v. r.) he makes himself live, he saves himself
+« PIMÂTCHIHUWIN, a, (n. f.) salvation, deliverance by oneself
+« PIMÂTISIW, ok, (a. a.) he lives
+« PIMÂTAN, wa, (n. f.) it lives
+« PIMÂTISISKAWEW, etc., (v. a.) he keeps him alive
+« PIMÂTISISTAWEW, etc., (v. a.) he lives for him
+« PIMÂTISIWÂTTIK, (n. f.) the tree of life
+« PIMÂTISIWIMISTIK, (n. f.) idem
+« PIMÂTAKAW, ok, (v. n.) he walks in the water
+« PIMISKAM, wok, (v. n.) idem
+« PIMÂTAKÂWIN, a, (n. f.) the action of walking in water
+« PIMEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, see. Pimâmeyimew
+« PIMÂBOYEW, (v. a.) TAW, he makes him go on the water, he sends him with the current
+
+PIM
+
+« PIMÂBOKOW, ok, (a. a.) he floats on the water, he goes with the current
+« PIMÂBOTEW, a, (a. in.) idem
+« PIMÂSKWEYAW, (v. im.) forest which advances into the plains
+« PIMÂHAN, (v. im.) it goes with the wind
+« PIMÂBATTEW, (v. im.) cloud of smoke which passes
+« PIMÂBISKISIN, wok, (a. a.) he is there on the ground (metal)
+« PIMÂBISKITTIN, wa, (a. in.) idem
+« PIMÂSIW, ok, (a. a.) he sails past, he goes by sail
+« PIMÂSIWIN, a, (n. f.) the action of sailing
+« PIMÂSTAN, wa, (a. in.) it is carried off by the wind
+« PIMÂSKUSIN, wok, (a. a.) he is spread out across the ground (when speaking of wood)
+« PIMÂSKUTTIN, wa, (a. in.) idem
+« PIMÂSAKÂMEPITCHIKEW, ok, (v. ind.) he pulls from edge to edge
+« PIMÂSAKÂMEPITAM, wok, (a. a. in.) he pulls it from edge to edge
+x PIMIY, a, (n. r.) grease, oil, tallow
+« PIMIWIW, ok, (a. a.) he is greasy, fatty, oily
+« PIMIWISIW, ok, (a. a.) idem
+« PIMITEW, a, (a. in.) idem
+« PIMIWITEW, a, (a. in.) idem
+« PIMIKKEW, ok, (v. n.) he makes grease; (though the meaning understood in this country is: he mixes grease with crushed meat, that is to say, he makes pemmican
+
+560
+
+PIM
+
+« PIMIKKEWIN, a, (n. f.) the action of making pemmican, grease, etc.
+« PIMIKKÂN, a, (n. f.) bag filled with a mix of grease and crushed meat, this is pemmican, a word disfigured in pronunciation by the Whites for pimikkân above
+« PIMIKKÂNÂBUIY, a, (n. f.) pemmican soup, (rababou)
+« PIMIKKÂNÂBOKKEW, ok, (v. n.) he makes pemmican soup
+« PIMIKKÂNIWAT, a, (n. f.) bag of pemmican
+« PIMIWÂTTIK, wok, (n. f.) olive tree
+« PIMIMINISSA, (n. f.) olives
+« PIMIWOKAN, (v. im.) it tastes of grease
+« PIMIWAN, wa, (a. in.) it is greasy
+« PIMIWASTEW, a, (v. im.) it smells of grease
+« PIMÂTTAWIW, ok, (v. n.) he walks on a piece of wood
+« PIMIKWÂSKUTTIW, ok, (v. n.) he is frolicking
+« PIMINAWASUW, ok, (v. n.) he makes food, he cooks food
+« OPIMINAWASUW, ok, (n. f.) cook
+« PIMINAWASUWIKAMIK, wa, (n. f.) kitchen
+« PIMINAWATEW, etc., (v. a.) he makes gim food, he cooks him something to eat
+« PIMIPAHEW, etc., (v. a.) he carries it running
+
+PIM
+
+« PIMIPATTWAW, ok, (v. a. in.) he transports it by running
+« PIMIPATTAW, ok, (v. n.) he runs
+« PIMIPATTÂWIN, a, (n. f.) running
+« PIMIPAYIW, ok, a, (a. a. and in.) he passes by running, or, it passes
+« PIMIPAYIWIN, a, (n. f.) horse running
+« PIMIPAYIHEW, etc., (v. a.) he makes him run
+« PIMIPITCHIW, ok, (v. n.) he journeys with his family, he moves camp from one side to the other
+« PIMIPITCHIWIN, a, (n. f.) peregrination (journeying a long way)
+« PIMISÂBOSKAWEW, (v. a.) KAM, etc., he passes across, etc.
+« PIMISIMEW, (v. a.) TITAW, SIMIWEW, TCHIKEW, he lays it on the earth
+« PIMISIN, wok, (a. a.) he is lying down, spread out on, etc.
+« PIMITTIN, wa, (a. in.) e.g. a river, it runs its course there, a rope which is strained in such a direction
+« PIMAMUW, a, (a. in.) trail which goes in such a direction
+« PIMISKAW, ok, (v. n.) he swims, e.g. a fish in the water, or a man in a canoe
+« PIMISKÂWIN, a, (n. f.) the action of swimming, rowing
+« PIMISKAWEW, (v. a.) KAM, etc., he crosses his path
+« PIMISKANAWEHEW, etc., (v. a.) idem
+« PIMISKANAWEW, ok, (v. n.) he crosses, he cuts the trail
+
+561
+
+PIM
+
+« PIMISKUTTEW, ok, (v. n.) he walks on the ice
+« PIMITISAHWEW, (v. a.) HAM, HUWEW, HIKEW, he pursues him, he runs after him
+« PIMITISAHIKEW, ok, (v. ind.) he runs after the others (who) have left, he pursues them
+« PIMITISAHIKEWIN, a, (n. f.) pursuit
+« PIMITÂTCHIMOW, ok, (v. n.) he crawls, he drags himself
+« PIMITÂTCHIMOWIN, a, (n. f.) crawling
+« PIMITAKKUNEW, (v. a.) NAM, etc., he passes holding it in his arms
+« PIMIWIYEW, (v. a.) YIWEW, TAW, TCHIKEW, he carries it with him, he transports it
+« PIMOYUW, ok, (v. n.) he carries something with him, e.g. some object in his bosom, in his clothes
+« PIMOYUWIN, a, (n. f.) the action of carrying something in one's clothes
+« PIMITCH, (ad.) across, askew
+« PIMITCHIKÂBAWIW, ok, (a. a.) he stands sideways
+« PIMITÂSKOMOW, ok, a, (a. a. and in.) it is thrown sideways
+« PIMITÂSKOMOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he places it askew
+« PIMITÂSKWAHYEW, (v. a.) STAW, etc., he places it across, e.g., a piece of wood
+
+PIM
+
+« PIMITAMOW, a, (a. in.) it is placed across
+« PIMITAMOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he places it across
+« PIMITASKAMIK, (adv.) from one side of the ground to the other
+« PIMITASKAMIKINAM, wok, (v. n.) he goes from one end of the world to the other
+« PIMITASKAMIKWESKAM, wok, (v. n.) idem
+« PIMITAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he places it across, to the side
+« PIMITAPIW, ok, (a. a.) he is seated across
+« PIMITASTEW, a, (a. in.) it is placed to the side
+« PIMITATIMAN, a, (a. in.) rope which attaches the end of the foot to the snowshoe
+« PIMITCHISTINOWEHAM, wok, (v. n.) there is wind on the side of the water
+« PIMITCHISTINOWESKAM, wok, (v. n.) there is wind on the side of the ground
+« PIMIYAW, ok, (v. n.) he passes by flying
+« PIMUTAKKWEW, ok, (v. n.) he shoots his bow
+OPIMUTAKKWEW, ok, (n. f.) archer
+« PIMUTAKKWÂGAN, a, (n. f.) instrument for shooting a bow, bow
+« PIMUTTÂTAM, wok, (v. a. in.) he travels such a distance, through such a country
+« PIMUTTAHEW, etc., (v. a.) he makes him walk
+
+562
+
+PIN
+
+« PIMUTTATAW, ok, (v. a. in.) he carries, he transports it
+« PIMUTTEW, ok, (v. n.) he walks
+« PIMUTTEWIN, a, (n. f.) walking, place for walking
+« PIMUTTESKANAW, a, (n. f.) beaten path, frequently used path
+« PIMUTTESKANÂWIW, WAN, (v. im.) there is a beaten path
+« PIMUTTAHIWEW, ok, (v. ind.) he guides, he leads
+« PIMWASINEW, ok, (v. n.) he throws
+« PIMWÂBISKAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he throws stones at him
+« PIMWÂBISKAHWEW, (v. a.) HAM, etc., idem
+« PIMWASINÂTEW, etc., (v. a.) idem
+« PIMWASINAHEW, etc., (v. a.) idem
+« PIMWASINAHWEW, etc., (v. a.) idem
+« PIMWÂTTIKWAHEW, etc., (v. a.) he throws a piece of wood at him
+« PIMWÂTTIKWANÂTEW, etc., (v. a.) idem
+« PIMWEW, (v. a.) MUTAM, MUWEW, MUTCHIKEW, he shoots it with a bow
+« PIMWEWESTIN, (v. imp.) violent wind
+« PIMWEWETTAWEW, (v. a.) TTAM, TTÂKEW TTÂTCHIKEW, he hears him pass
+x PIN, (rac.) to fall into pieces, to be slim, thin
+« PINAHIKKWÂN, a, (n. f.) thin comb
+
+PIN
+
+« PINAHIKKWÂGAN, a, (n. f.) idem
+« PINAHWEW, (v. a.) HAM, HUWEW, HIKEW, he combs it
+« PINEKUMIN, a, (n. f.) hawfinch
+« PINÂWEW, ok, (v. n.) she has eggs, she lays
+« PINIYÂWEW, ok, (v. n.) idem
+« PINÂWEWIN, ok, (v. n.) laying (eggs)
+« PINÂSKOW, (v. im.) season where the leaves fall. The suffix âskow indicates leaves, e.g. mestâskow, the leaves have all fallen
+« PINIPUYEW, (v. a.) TAW, YIWEW, TCHIKEW, he chews it, he pulverises it
+« PINIPUTCHIGAN, a, (n. f.) mill, or, that which is milled, milling residue
+« PINIPUTCHIKEW, ok, (v. ind.) he chews
+« PINIPUTCHIKEWIYINIW, ok, (n. f.) miller
+« PINIPUSUW, ok, (a. a.) he is milled
+« PINIPUTEW, a, (a. in.) idem
+« PINIPUTCHIKÂSUW, ok, (a. a.) idem
+« PINIPAYIW, ok, a, (a. a. and in.) it shatters, it falls into bits
+x PINASIWEW, ok, (v. n.) he goes down to the side
+« PINASIWEWIN, a, (n. f.) descent, path which goes down to the side of the hill
+« PINASIWETCHIWAN, (v. im.) current of water which hurls down to the side
+
+563
+
+PIP
+
+« PINASIWEPAYIW, ok, a, (a. a. and in.) he thrusts down to the side
+« PINASIWEPATTAW, ok, (v. n.) he runs down to the side
+« PINASIWETTAHEW, etc., (v. a.) he transports it down to the side
+PIPIK, wok, (n. r.) flea, insect
+PIPIKWAN, a, (n. r.) small bone or piece of wood with which one whistles, pipes, flutes
+« PIPIKWÂNÂTTIK, wok, (n. f.) wood for whistling
+x PIPIKUSIW, ok, (a. a.) he is bumpy, rough
+« PIPIKWAW, a, (a. in.) idem
+« PIPIKWATETTEW, ok, (n. f.) toad
+« PIPIKWATCHAW, (v. im.) bumpy terrain
+« PIPIKWATINAW, (v. im.) bumpy, rough hill
+« PIPITCHIW, ok, (n. r.) blackbird, bird
+x PIPON, (v. im.) it is winter
+« PIPON, wa, (n. f.) winter. N.B. The plural is seldom used, e.g. nijo pipon, two winters, nisto pipuwew, he is three winters old, tantatto piponweyan? how many winters old are you? tattwaw pepoki, every winter, piponôk, last winter, ke pipôk, next winter
+« PIPONÂYAW, ok, (n. f.) winter animal, or bird
+« PIPONISIW, ok, (a. a.) he winters
+« PIPONISIWIN, a, (n. f.) wintering, winter quarters
+« PIPONÂSKUS, ak, (n. f.) aniaml which has already seen one winter
+« PIPONÂSKUSIWIW, ok, (a. a.) he has seem one winter, (an animal) aged one winter
+
+PIP
+
+x PIPUTCH, (adv.) against, in front of, e.g. piputch nakiskawew, he goes to meet him
+« PIPUTCHIWEW, (v. a.)
+« PIPUTCHEYIWEW, (v. a.)
+x PIS, (rac.) in small bits, in pieces
+« PISIPESTAW, (.v im.) the rain falls finely
+« PISIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he tears it in pieces
+« PISIPUYEW, (v. a.) TAM, YIWEW, TCHIKEW, he pulverises it
+« PISIPAYIW, ok, a, (a. a. and in.) he falls to pieces
+« PISISIW, ok, (a. a.) he is in pieces, in fragments
+« PISAW, a, (a. in.) idem
+« PISISIN, wok, (a. a.) he breaks up into little pieces
+« PISITTIN, wa, (a. in.) idem
+« PISISIMEW, (v. a.) TITAW, SIMIWEW, TCHIKEW, he breaks it into pieces by hitting it against (something)
+« PISAWOYAW, (v. im.) it is slim, fine like sand
+« PISISÂWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he cuts it into little pieces
+« PISAHWEW, (v. a.) HAM, HUWEW, HIKEW, he breaks it into little pieces
+x PISÂKUSIW, ok, (a. a.) he is abundant, he contains a lot, he is of great dimensions, he yields lots
+« PISÂKWAN, wa, (a. in.) idem
+« PISÂKWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he makes it abundant, he multiplies it
+
+564
+
+PIS
+
+« PISÂKOPAYIHEW, etc., (v. a.) idem
+« PISÂKOPAYIW, ok, a, (a. a. and in.) e.g., a bag which contains lots, a field which produces lots
+« PISÂKOPAYIWIN, a, (n. f.) abundance
+« PISÂKUSIWIN, a, (n. f.) idem
+« PISÂGANÂBIY, a, (n. f.) rope
+« PISIW, ok, (n. r.) lynx, pichou, wild cat
+x PISIKWÂTISIW, ok, (a. a.) he is shameless, immoral
+« PISIKWÂTAN, wa, (a. in.) idem
+« PISIKWÂTISIWIN, a, (n. f.) shamelessness, immorality
+« PISIKWÂTISKWEW, ok, (n. f.) bad-mannered woman
+« PISIKWÂSCHIYINIW, ok, (n. f.) shameless person
+« PISIKWÂTCHITOTAM, wok, (v. n.) he commits fornication
+« PISIKWÂTCHITOTAMOWIN, a, (n. f.) fornication
+« PISIKWÂTEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks him to be shameless
+« PISIKWÂTCHI ITEYMEW, etc., (v. a.) he has bad thoughts about her
+« PISIKWÂTCHI-ITEYITCHIGAN, a, (n. f.) impure thoughts
+« PISIKWÂTCHIMITONEYITCHIGAN, a, (n. f.) idem
+« PISIKWÂTONÂMOW, ok, (v. n.) he speaks shamelessly
+
+PIS
+
+« PISIKWÂTONÂMOWIN, a, (n. f.) shameless speech
+« PISIKWÂTCHI-ITTIW, ok, (v. n.) he behaves himself in a shameless fashion
+« PISIKWÂTCHI-ITTIWIN, a, (n. n.) shameless action
+« PISIKWÂTÂBAMEW, etc., (v. a.) he looks at him shamelessly
+x PISIM, wok, (n. r.) sun, moon. When one wants to differentiate, one says: kijikâwipisim, the Sun, tibiskâwipisim, the Moon
+« PISIMOTÂK, (adv.) from the southern side
+« PISIM, wok, (n. f.) month, moon, because the savages count the months by the moon. N.B. Here are the names of the twelve months
+1. KIJE-PISIM, (the great month) January
+2. MIKISIWIPISIM, (month of the eagle) February
+3. NISKIPISIM, (month of the bustard) March
+4. AYEKIPISIM, (month of the frog) April
+5. OPINIYÂWEPISIM, (month where the birds make their eggs) May
+6. OPÂSKÂWEHUWIPISIM, (month where the younglings leave their shells) June
+7. OPASKOWIPISIM, (month where the birds moult) July
+8. OPPAHUWIPISIM, (month where the birds, their feathers having come out, take flight) August
+9. ONOTCHIHITUWIPISIM, (month where the animals are in heat) September
+
+565
+
+PIS
+
+10. KASKATINOWIPISIM, (month where it freezes) October
+11. IYEKOWIPISIM, (month where there is frost) November
+12. PAWÂTCHAKINASIS, (month where the snow suspended in the trees falls) December
+« PISIMITÂSPINEW, ok, (a. a.) he is a lunatic
+« PISIMITÂSPINEWIN, a, (n. f.) sickness of lunatics
+« PISIMOKKÂN, ak, (n. f.) timepiece, clock (artificial sun)
+« PISIMOKKÂNITIPAHIGAN, a, (n. f.) hour. See. Tipahipisimwân
+« PISIMOWIW, WAN, (v. im.) it is a month, it has been a month
+« PISIMWEW, ok, (a. a.) e.g. peyakopisimwew, he is a month old, tantatto pisimwet? how many months old is he?
+« PISIMWAPPINEW, ok, (a. a.) menstrual, she is sick every month
+« PISIMWAPPINEWIN, a, (n. f.) menstruation, sickness of every month
+« PISIMWEYÂBIY, ak, (n. f.) rainbow (rope of the sun)
+x PISIMEW, ok, (v. n.) he lays down a line, a small rope the length of the wooden part of a snowshoe
+« PISIMAN, a, (n. f.) rope which is fixed, attached to the length of the wooden part of a snowshoe
+« PISIMAMEYÂBIY, a, (n. f.) idem
+« PISIMÂTEW, (v. a.) he fixes his snowshoes with a line attached to the length of the poles
+x PISINE, or, PISINEY, (adv.) See. Ekweyâk
+
+PIS
+
+x PISINIW, ok, (a. a.) he has something in his eye, e.g. dirt, a grain of sand, dust
+« PISINIHEW, etc., (v. a.) he throws something in his eyes
+« PISINIWIN, a, (n. f.) the action of having something in one's eyes
++ PISISIK, (adv.) alone, simply, nothing but, e.g. pisisik wiyâs, nothing but meat, pisisik pe-kiwew, he comes back empty, empty-handed, with nothing. pisisik nakamow, he only sings
+« PISISIKUSIW, ok, (a. a.) he is alone, he is empty
+« PISISIKWAW, a, (a. in.) idem
+« PISISIKAYAW, ok, (a. a.) she is not pregnant, she is alone
+« PISISIKUTTAK, (n. f.) nothing but wood
+« PISISIKAPIW, ok, (a. a.) he is alone there
+« PISISIKASTEW, a, (a. in.) idem
+« PISISIKWÂBISK, (n. f.) nothing but metal
+x PISISK, (rac.) to notice, to pay attention
+« PISISKITTAWEW, (v. a.) TTAM, TTÂKEW, TTÂTCHIKEW, he pays attention to what he says
+« PISISKÂBAMEW, (v. a.) TTAM, KKEW, TCHIKEW, he watches it attentively, he observes it
+« PISISKEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he pays attention to him, he notices him, he takes care of him
+« PISISKEYITTAMOWIN, (n. f.) attention, care
+
+566
+
+PIS
+
+« PISISKEYIMIWEWIN, a, (n. f.) observation, remark
+« PISISKEYITTÂKUSIW, ok, (a. a.) he is remarkable
+« PISISKEYITTÂKWAN, a, (a. in.) it is remarkable
+« PISISKEYITTÂKUSIWIN, a, (n. f.) glory, honour
+« PISISKITTÂKUSIW, ok, (a. a.) he is worthy of being noticed
+« PISISKITTÂKWAN, wa, (a. in.) it is worthy of being noticed
+x PISISKIW, ok, (n. f.) animal, beast
+« PISISKIWIW, ok, (a. a.) he is an animal, without reasoning
+« PISISKIWIWIN, a, (n. f.) animality
+« PISISKIWIHUW, ok, (v. r.) he takes the form of an animal, in his clothes
+« PISISKIWITTWAW, ok, (v. n.) he behaves like an animal
+« PISITOSIWEW, WAN, (v. im.) sorcerer of the wind, whirlwind
+x PISWAHWEW, (v. a.) HAM, HUWEW, HIKEW, he stumbles, he makes a mistake by touching it, he hits it with his foot, etc.
+« PISOHEW, etc., (v. a.) he makes a mistake to him
+« PISIN, wok, (v. n.) he makes a mistake
+« PISUSKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he touches it with his foot in passing, he stumbles against
+x PISKIS, (adv.) differently, in anotherway, otherwise. See. Pitus
+« PISKITCHIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he compartmentalises it, he divides it into, etc.
+
+PIS
+
+« PISKITCHÂSIN, wok, (a. a.) he is divided, he is separated
+« PISKITCHEYAW, a, (a. in.) it is divided into compartments
+« PISKITCHIKIPAHAM, wok, (v. a. in.) he divides it into compartments
+« PISKITTINAMÂWEW, he sets it aside
+« PISKITTÂYAW, a, (v. im.) it is divided into rooms, etc.
+« PISKISKIPAYIW, ok, a, (a. a. and in.) it is different, distinct
+« PISKITCHIHUW, ok, (v. n.) he distinguishes himself in his clothes
+« PISKITTAWEW, (v. a.) TTAM, TTÂKEW, TTÂTCHIKEW, he hears it differently
+« PISKITTOWEW, ok, (v. n.) he speaks another language
+« PISKITTOWEWIN, a, (n. f.) foreign language
+« PISKISITEYIMOW, ok, (v. n.) he has another idea
+« PISKISITEYIMOWIN, a, (n. f.) different idea
+PISKWA, plur. piskwok, (n.r.) night bird, eater of mosquitos
+PISKUKANÂN, a, (n. r.) joint, articulation
+PISKUKKUWAW, (v. imp.) bushes
+x PISKUSIW, ok, (a. a.) he has a bump, an elevation of (his) flesh
+
+567
+
+PIS
+
+« PISKUSIWIN, a, (n. f.) bump, elevation of the flesh
+« PISKWAW, a, (a. in.) there is a bump
+« PISKUSIKWAW, (v. im.) bumpy ice
+« PISKWÂKUNAKAW, (v. im.) bumpy snow
+« PISKUPAYIW, ok, a, (a. a. and in.) he has a, or several, bumps, he has an elevation of his flesh
+« PISKWÂWIKANEW, ok, (a. a.) he has a bump on his back
+« PISKWÂWIKANEWIPISISKIW, ok, (n. f.) camel
+« PISKWAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he puts it in a pile, in heaps, like a small hill
+« PISKWATINAW, (v. im.) a small hill
+« PISKWATCHAW, (v. im.) bumpy, hilly terrain
+« PISKWATANASKAHIGAN, a, (n. f.) debranched tree, with branches left only at the head, May
+« PISKWATINASKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he debranches it
+PISKWATCH, (adv.) See. Piskis, e.g. niya piskwatch, as for me alone
++ PISTEW, a, (n. r.) foam
+« PISTEWATÂMOW, ok, (v. n.) he foams at the mouth
+« PISTEWATÂMOWIN, a, (n. f.) foam at the mouth
+« PISTEWÂTCHIWASWEW, (v. a.) SAM, SUWEW, SIKEW, he boils it, until foam forms
+
+PIS
+
+« PISTEWÂTCHIWÂSUW, ok, (a. a.) it boils, foaming
+« PISTEWÂTCHIWATEW, a, (a. in.) idem
++ PISWESIW, ok, (a. a.) he is woolly, soft, spongy
+« PISWEYAW, a, (a. in.) idem
+« PISPISKUTEWEYIK, wok, (n. f.) spider
+« PISWEYÂKUNAW, (v. im.) it is spongy like the crumb of bread
+« PISWEYÂKUSIN, (v. in.) idem, like wool
+« PISWEYAGAN, (v. im.) woolen cloth
+« PISWEPIWAY, a, (n. f.) down
+« PISWETCHAW, (v. im.) soft terrain
+« PISWEPIWEYÂN, a, (n. f.) flannel, woolen cloth
+« PISWEPITCHIGAN, a, (n. f.) oakum, caulk
+« PISWEPAKKWESIGAN, ak, soft, spongy bread
+« PISWEPAYIW, ok, (a. a. and in.) swollen, bloated, etc.
+« PISWEWEYÂN, a, (n. f.) flannel, (duffel)
++ PIST, (rac.) by mistake, to make a mistake, not to do (something) on purpose
+« PISTCHI, (adv.) pronounced pitchi, by mistake, e.g. ni pistchi sikinen, I spill it by mistake, pistchi totam, he does not do it on purpose
+« PISTAMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he chews it by mistake, without intending to chew it
+« PISTINEW, (v. a.) NAM, NIWEW, NIKEW, he makes a mistake by taking it
+
+568
+
+PIT
+
+« PISTAHWEW, (v. a.) HAM, HUWEW, HIKEW, he hits it by mistake, without wanting to, e.g. someone who kills another by mistake
+« PISTISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he walks on him by mistake
+« PISTISWEW, (v. a.) SAM, SUWEW, SIKEW, he cuts it by mistake
+« PISTISOSUW, ok, (v. r.) he cuts himself by mistake
+PITA, (adv.) firstly, to begin, e.g., pita ni wi pittwân, before that, I want to smoke, tcheskwa pita! wait a bit! stop a bit! piya ayamiha mayâwes kâwisimoyani, pray first before going to bed
+« PITAMA, (adv.) idem
+« PITANE! (ex.) if it please the heavens! God willing! utinam! (if only!) e.g., pitane tâpwe God willing, let it be so! pitane wâbamak, why can't I see it! pitani ekusi ikkik! so be it! patane! idem
+x PITCHIPUW, ok, (a. a.) he is poisoned. N.B. This word and its derivations must belong to the root pistchi, or, pitchi, above
+« PITCHIPUWIN, a, (n. f.) poison
+« PITCHIPUYEW, etc., (v. a.) he poisons it
+« PITCHIPUYIWEWIYINIW, ok, (n. f.) poisoner
+« PITCHIPUYISUW, ok, (v. r.) he poisons himself
+
+PIK
+
+« PITCHIPUWINIWIW, (v. im.) it is poison
+x PITT, (rac.) to penetrate into the inside, to go within
+« PITTÂPEK, wa, (n. f.) swamp which runs with a current
+« PITTÂPEKOSIPIY, a, (n. f.) river with almost no current
+« PITTÂPÂWAYEW, (v. a.) TAW, YIWEW, TCHIKEW, he infuses him in a liquid, he gives him a wash
+« PITTÂHWEW, (v. a.) HAM, HUWEW, HIKEW, he introduces it within
+« PITTÂSUW, ok, (v. n.) he loads his firearm
+« PITTÂSUWIN, a, (n. f.) the action of loading a firearm
+« PITTATWÂN, a, (n. f.) quiver
+« PITTATCHÂBÂN, a, (n. f.) bag for placing a bow
+« PITTÂKIYAW, (n. f.) the inside of the body
+« PITTUKAMIK, (adv.) in the house, in the inside of a residence
+« PITTUKAHÂN, a, (n. f.) park, enclosure into which the savages make buffaloes enter
+« PITTUKAHÂNAPIW, ok, (a. a.) he resides in the enclosure
+« PITTUKAHÂNIKKEW, ok, (v. n.) he makes a enclosure
+« PITTINEW, (v. a.) NAM, NIWEW, NIKEW, he inserts it within with his hand
+« PITTUKEW, ok, (v. n.) he enters
+« PITTUKEWIN, a, (n. f.) entry
+« PITTUKEPATTAW, ok, (v. n.) he enters while running
+« PITTUKEMOW, ok, a, (a. a. and in.) it enters, it adjusts itself
+
+569
+
+PIT
+
+« PITTUKEPAYIW, ok, a, (a. a. and in.) idem
+« PITTUKAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he inserts it
+« PITTUKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he enters his home, he enters his dwelling
+« PITTÂSINÂN, a, (n. f.) lead bag, game bag
+« PITTÂWIYEW, etc., (v. a.) he takes it within, like a fish in a net
+« PITTSKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he carries it on him, e.g. like undergarments
+« PITTUWETÂS, a, (n. f.) underpants
+« PITTUWETÂSÂN, a, (n. f.) idem
+« PITTUWESÂKAY, a, (n. f.) underskirt
+« PITTUWETÂSEW, ok, (v. n.) he wears underpants
+« PITTUWESÂKEW, ok, (v. n.) she wears an underskirt
+« PITTWAW, ok, (v. n.) he smokes
+« PITTWÂWIN, a, (n. f.) the action of smoking
+« PITTWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he smokes it
+« PITTWÂHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes him smoke it
+« PITTÂHAMÂWEW, etc., (v. a.) he sends him tobacco, he sends him something to smoke, as a sign of peace, as a message for important business
+« PITTWÂNISIB, ak, (n. f.) duck of the second type
+x PITCH, (same root)
+« PITCHEYAS, (adv.) or, pitteyas, within, in the centre; e.g. pitteyas nibâwiw, he is standing in the middle
+
+PIT
+
+
+« PITCHÂYIK, (adv. and noun) e.g., nipitchâyimik, on the inside of me, within, on the inside
+« PITCHITCHIGAN, a, (n. f.) funnel
+« PITCHITCHIPÂTCHIGAN, a, (n. f.) idem
+« PITCHIKKUMÂN, a, (n. f.) sheath of a knife, case
+« PITCHIPIKKWÂN, a, (n. f.) powder horn, powder keg for hunting
+« PITCHIPIKKWEW, ok, (v. n.) See. Pittâsuw
+« PITCHIPIKKWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he loads it, e.g., a firearm
+« PITCHISKANAW, (n. f.) in the path
+« PITCHIKUNEW, (n. f.) the inside of the mouth
+« PITCHITON, (n. f.) idem
+« PITCHIPIMEW, ok, (v. n.) he pours the grease in, e.g., he puts the grease in a bladder
+« PITCHIPUYÂGAN, a, (n. f.) a type of basket made with branches, for fishing
+« PITCHIPAYIW, ok, a, (a. a. and in.) he falls in
+« PITCHITONESKAWEW, etc., (v. a.) he inserts it into his mouth
+« PITCHITEHESKAWEW, etc., (v. a.) he enters into his heart
+« PITCHIYÂWESKAWEW, etc., (v. a.) he enters into his body
+« PITCHIYAW, (n. f.) on the inside of the body. See. Pittâkiyaw
+« PITCHIWEBINEW, (v. a.) NAM, NIWEW, NIKEW, he throws it in
+
+570
+
+« PITCHISIN, wok, (a. a.) he is lying down, spread out within
+« PITCHITTIN, wa, (a. in.) idem
+« PITCHISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he enters into him, into his home, he wears a piece of clothing on him
+« PITCHISKANAW, (v. imp.) in the trail, trail which goes around
+« PITCHISKANAWEW, ok, (v. n.) he makes a trail all around
+« PITCHISKANAWEHEW, etc., (v. a.) he makes a trail all around him
+« PITCHITINEW, (v. a.) NAM, NIWEW, NIKEW, he shoots it at him, he shoots it in
+« PITCHIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, idem
+« PITCHITCHIPAYIW, ok, a, (a. a. and in.) it comes; e.g. ati pitchichipayiw, it begins to appear, to trickle
+« PITCHITCHIWAN, (v. im.) it comes (water)
+« PITTEGAN, (v. im.) wide cloth, Indian cloth
+x PITAHWEW, etc., (v. a.) he disassembles, he breaks his lodge (beaver's lodge)
+« PITAHIKEW, ok, (v. n.) he breaks beaver's lodges
+PITCHEYAK, (adv.) See. Ekweyâk
+PITTAW, (adv.) expression of disappointment; e.g. pittaw namâwiya ki wi-atuskân, what do you want? you don't want to work? pittaw namâwiya tâpwe kit ayamihân, to say the truth, you don't pray; pittaw osâm kissin, in truth, it is too cold out
+
+PIT
+
+x PITCHAW, (v. imp.) it is far, there is far
+« PITTAKÂMEYAW, (v. imp.) long part of a river, or a lake
+« PITTEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he can't wait to see him, he thinks of him from afar
+« PITTEYITTAM, wok, (v. n.) he can't wait for him, he finds the time long, he is bored
+« PITEYITTAMOWIN, a, (n. f.) boredom, worry
+« PITCHIW, ok, (v. n.) he moves camp far, or better, he goes camping far (in the same day). N.B. Pronounced pîtchiw
+« PITCHIWIN, a, (n. f.) long distance made during one day, while moving camp
+« PITCHIW, ok, (v. n.) he moves camp, he breaks camp
+« PITCHIWIN, a, (n. f.) the action of moving camp, and, distance between two encampments; e.g. nijo pitchiwina, two decampments; nisto pitchiwineyaw ekute tchi otittamik, he must break camp three times to get there, or, three days of walking. One says: pâpitchiw, he arrives by moving camp; pepitchiw, he lifts camp while coming; kiwepitchiw, he leaves by moving camp
+« PITCHITTAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes him break camp, he transports him by moving camp
+« PITCHITWAW, ok, (v. ind.) he transports (it) when moving camp, e.g., someonw who cannot take all of their baggage at once, and leaves part of it to return to fetch it
+
+571
+
+PIP
+
+« PITCHIWÂWIN, a, (n. f.) the action of carting (things) when moving camp. N.B. The word to move camp is used in this country to speak of journeys with family, with a band, and the nomadic way of life
+« PITCHITINÂSTAN, (v. imp.) long view in a river
+« PITTASKUSTEWEYAW, (v. imp.) long view in the prairie
+x PITIKUSIW, ok, (a. a.) he is stocky, short and fat, almost round like a ball
+« PITIKWAW, a, (a. in.) idem, made into a ball
+« PITIKUNEW, (v. a.) NAM, NIWEW, NIKEW, he forms it, he arranges it together, in the shape of a ball
+« PITIKUNIGAN, a, (n. f.) circular boat, or raft, with a lodge or tent, made to traverse the rivers
+« PITIKUHEW, etc., (v. a.) he makes it in the shape of a ball
+« PITIKOTCHITCHEYIW, ok, (v. n.) he has a closed fist
+x PITIKKUTTAW, ok, (v. n.) he makes noise while walking
+« PITIKKWEW, ok, (v. n.) he makes a noise while walking, e.g. one hears his steps
+« PITIKKWEWIN, a, (n. f.) noise of steps, noise of walking
+x PITTU, (rac.) to peel, to remove the skin
+« PITTUKASIGAN, a, (n. f.) that which removes the skin, by burning, blister
+
+PIT
+
+« PITTUKASWEW, (v. a.) SAM, SUWEW, SIKEW, he peels it, by burning it, he puts a blister on him
+« PITTUKASUW, ok, (a. a.) he has a blister
+« PITTUNEW, (v. a.) NAM, NIWEW, NIYEW, he peels it, he husks it
+« PITTUNIKEWIN, a, (n. f.) peeling
+« PITTUPEKIKKATTEW, a, (a. in.) it is formed in a bladder by a blister, or fire
+« PITTUPEKIPAYIW, ok, a, (a. a. and in.) it forms in a bladder
+« PITTUPEKIPAYIWIN, a, (n. f.) swelling, bladder filled with water
+« PITTUPEKINEW, (v. a.) NAM, NIWEW, NIKEW, he peels it to get the water out
+« PITTUPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he peels it by tearing it, or by ripping it off
+« PITTUSIGAN, a, (n. f.) plaster, blister
+« PITTUSWEW, (v. a.) SAM, SUWEW, SIKEW, he peels it by cutting it. See. Pittukaswew
+« PITTUSAKEW, ok, (a. a.) the skin peels off
+« PITUSAKEPAYIW, ok, (a. a.) idem
+x PITUS, (adv.) otherwise, differently, e.g., pitus pimâtisiw, he lives differently, pitus ayamihaw, he is of another religion
+« PITUSÂYIK, (adv.) in another place
+« PITUS ITE, (adv.) idem
+
+572
+
+PÂT
+
+« PITUSISIW, ok, (a. a.) he is different
+« PITUSAYAW, ok, a, (a. a. and in.) idem
+« PITUSNAWEW, (v. a.) NAM, NÂKEW, NATCHIKEW, he finds him dissimilar
+« PITUSINÂKWAN, wa, (a. in.) idem
+« PITUSISIWIN, a, (n. f.) difference
+« PITUSINÂKUSIWIN, a, (n. f.) dissimilarity
+« PITUTEYIMEY, (v. a.) TTAM, MIWEW, TCHIKEW, he finds it different, he mistakes it for something else, he things him another, a stranger
+« PITUSEYIMEW, etc., (v. a.) idem
+« PITUSIWIW, ok, (a. a.) See. pitusisiw
+« PITUSIWAN, wa, (a. in.) idem
+« PITUS ISI, (adv.) in another manner
+« PITUTOWEW, ok, (v. n.) he speaks another language
+« PITUTOWEWIN, a, (n. f.) foreign language. N.B. One also says (this with) reduplication on the same root
+« PÂPITUS ITEYITTAM, wok, (v. n.) he differs in opinion
+« PÂPITUSEYITTUWOK, (v. m.) he does not agree with their opinions
+« PÂPITUTEYITTAMOWIN, a, (n. f.) dissent in opinions
+« PÂPITUSEYITTAMOWIN, a, (n. f.) idem
+
+PIW
+
+x PIWÂBISK, wa, (n. r.) metal, iron, steel. N.B. The suffix âbisk is used to indicate metal and stone, e.g., osâwâbisk, yellow metal, copper, manitopiwâbisk, steel, kaskitewâbisk, or, kaskitewasiniy, black stone
+« PIWÂBISKAPPIT, a, (n. f.) lighter
+« PIWÂBISKOWEMIKKWÂN, ak, (n. f.) metal spoon, iron spoon, etc.
+« PIWÂBISKOPISÂGANÂBIY, a, chain, metal rope
+« PIWÂBISKUS, a, (n. f.) sou (Translator's Note: A sou is a coin and unit of currency, worth five centimes, or one twentieth of a franc)
+« PIWÂBISKOTCHITCHÂN, a, (n. f.) pincers, tongs
+« PIWÂBISKOWIW, ok, (a. a.) he is iron, he is metallic
+« PIWÂBISKOWAN, a, (a. in.) idem
+« PIWÂBISKOKUTAWÂNÂBISK, wa, (n. f.) stove
+« PIWÂBISKOYÂGAN, a, (n. f.) dish of white metal
+« PIWÂBISKASKIK, wok, (n. f.) metal boiler
+« PIWÂBISKWEYÂBIY, a, (n. f.) single brass wire
+x PIW, (rac.) nothing, that which has no value, contemptible, the rest, that which one rejects, in little pieces
+« PIWASKISWEW, (v. a.) SAM, SUWEW, SIKEW, he reduces it to ashes
+« PIWASKISUW, ok, (a. a.) he is burned to ashes
+« PIWASKITEW, a, (a. in.) idem
+
+573
+
+PIW
+
+« PIWAN, (v. im.) he is dispersed, scattered, there is a whirlwind of (powdery) snow
+« PIWASTEW, a, (a. in.) idem
+« PIWÂSIW, ok, (a. a.) he is dispersed, scattered by the wind
+« PIWÂSTAN, wa, (a. in.) idem
+« PIWATCHIGAN, a, (n. f.) fragment, rest of the food, crumb
+« PIWAMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he makes crumbs while eating, he leaves something behind, he does not eat everything
+« PIWATTAKINEW, (v. a.) NAM, NIWEW, NIKEW, he disperses it, he scatters it
+« PIWIPINEW, etc., (v. a.) he powders it on, etc., he powders it using, etc.
+« PIWASIGAN, ak, (n. f.) socks, stockings, clothes
+« PIWASIGANIKKAWEW, etc., (v. a.) he makes him clothes, stockings, socks
+« PIWIKISTIKANIS, a, (n. f.) seed, seeds for sowing
+« PIWIKKUTEW, (v. a.) TAM, SIWEW, TCHIKEW, he cuts it in little pieces with a knife
+« PIWIKKUTÂGAN, a, (n. f.) a ripe (Translator's Note: A ripe is a fine-toothed, S-shaped tool, akin to a chisel, which is used by sculptors and stonemasons)
+« PIWIKKUTCHIGAN, a, (n. f.) idem
+« PIWITTAKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he chops it in little pieces
+« PIWITTAKAHIGAN, a, (n. f.) shavings made with an axe
+
+PIW
+
+« PIWIKAHWEW, etc., (v. a.) idem
+« PIWIKAHIGAN, a, (n. f.) idem
+« PIWIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he spreads it, he disperses it
+« PIWIPAYIW, ok, a, (a. a. and in.) he crumbles, he emits
+« PIWISIGAN, a, (n. f.) cuttings, remnants of what was cut, or cut off
+« PIWISWEW, (v. a.) SAM, SUWEW, SIKEW, he cuts it in little pieces
+« PIWISKAHWEW, (v. a.) HAM, HUWEW, he slices it, he chops it, he sizes it by chopping
+« PIWISKAHIGAN, a, (n. f.) log
+« PIWEY, a ,(n. f.) hair, wool, opiwaw, he has hair
+« PIWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he despises him
+« PIWEYITTÂKUSIW, ok, (a. a.) he is despicable
+« PIWEYITTÂKWAN, wa, (a. in.) idem
+« PIWEYITTÂMOWIN, a, (n. f.) contempt
+« PIWIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he debases him, he renders him despicable with his words
+« PIWOMEW, (v. a.) TTAM, MIWEW, TCHIKEW, idem
+« PIWINAWEW, (v. a.) NAM, NÂKEW, NÂTCHIKEW, he looks with contempt
+« PIWINÂKUSIW, ok, (a. a.) he seems despicable
+
+574
+
+PIY
+
+« PIWINÂKWAN, wa, (a. in.) idem
+« PIWINÂKOHUW, ok, (v. r.) he puts himself in a despicable form
+« PIWINÂKOHUWIN, a, (n. f.) (voluntary) shabby appearance
+« PIWIHUW, ok, (a. a.) he has shabby, poor clothes
+« PIWEYIMISUW, ok, (v. r.) he has lowly ideas of himself, he is humble
+« PIWEYIMOW, ok, (v. r.) idem
+« PIWEYIMISUWIN, a, (n. f.) humility
+« PIWEYIMOWIN, a, (n. f.) idem
+« PIWISPUN, (a. im.) it snows a little
+« PIWÂYIS, ak, (n. f.) small bird, small animal, insect
+« PIWÂYIS, a, (n. f.) a trifle, a nothing (something insignificant), filth
++ PIWITAM, wok, (v. n.) he jumps a rapid
+x PIYAWEW, (v. a.) YAM, YÂKEW, YÂTCHIKEW, he scales it, e.g. a fish
+x PIYASI, (rac.) happiness, satisfaction
+« PIYASIW, ok, (a. a.) he is happy, content
+« PIYASIWIN, a, (n. f.) contentment
+« PIYASEYIMEW, etc., (v. a.) he sees it again with pleasure
+« PIYASEYITTAM, wok, (v. n.) he is happy, content
+« PIYASEYIMOW, ok, (v. n.) idem
+« PIYASEYITTAMOWIN, a, (n. f.) happiness
+« PIYASEYIMOWIN, a, (n. f.) idem
+x PIYÂWE, (adv.) aside, further, forward, e.g., piyâwe takusin, he arrives ahead, piyâwe wikiw, he stays farther
+
+PIY
+
++ PIYÂSKAW, ok, (v. n.) he goes gently, he advances slowly
+« PIYÂSKÂWIN, a, (n. f.) slow, dragging walk
+« PIYÂSKÂPAYIW, ok, a, (a. a. and in.) it goes slowly
+x PIYEKUSIW, ok, (a. a.) he is bland, dry, tasteless, e.g., a poor piece of meat
+« PIYEKWAW, a, (a. in.) idem
+« PIYEKUSIWIN, a, (n. f.) blandness, tastelessness
+« PIYEKUSKUYEY, etc., (v. a.) he only fills himself with bland, dry food
+« PIYEKUSKUYUW, ok, (v. n.) he only eats dry, tasteless things
+x PIHYEW, ok, (n. r.) wood partridge
+« PIYESIS, ak, (n. f.) small bird
+« PIYESIW, ok, (n. f.) imaginary bird; this is how the savages refer to thunder, e.g., piyesiwok kitowok, it thunders, the thunder rumbles, piyesiwok pâskisikewok, the thunder falls, the lightning bursts
+« PIYEW, ok, (n. f.) idem (seldom used)
+x PIYIS, (adv.) finally, at the end, e.g., piyis takusin, finally he arrived, piyis na kaskittân, finally, I am coming to the end
+« PIYIS ISKO ISKWEYÂTCH (adv.) until the finish, until the end, e.g., isko iskweyâtch pikiswew, he speaks until the last moment, piyis kakiyaw ki ka nipinâwaw, there will come a time when all of you must die, piyis osâmeyittam, he comes to the point of despair
+
+575
+
+PON
+
+x PO, (rac.) to stop acting, to end
+« POMEMEW, etc., (v. a.) he dissuades him from continuing, he makes his stop what he has undertaken
+« POMEW, ok, (v. n.) he stops acting, he is discouraged
+« POMEWIN, a, (n. f.) cessation
+« POMEYIMEW, TTAM, MIWEW, TCHIKEW, he stops thinking of him, he abandons the thought of it
+« PONIHEW, etc., (v. a.) he finishes it, also: he leaves it alone
+« PONIMEW, etc., (v. a.) he stops talking to him, he leaves him alone
+« PONITTAW, ok, (v. a. in.) he finishes it
+« PONÂKKUSIW, ok, (a. a.) he stops being sick
+« PONÂBAMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he loses sight of him, he stops seeing him
+« PONEYIMEW, (v. a.) he stops thinking of it, he abandons the though of it, also: he pardons him, he does not hold a grudge against him
+« PONEYITTAMÂWEW, etc., (v. a.) he pardons him of it
+« PONEYITTAMÂKEWIN, a, (n. f.) pardon, remission
+« PONEYITTAMÂTUWOK, (v. m.) they remit them of their offences
+« PONEYITTAMÂTUWIN, a, (n. f.) mutual pardon
+« PONI-AYAMIHEWIKIJIKAW, (v. im.) the Sunday finishes
+
+PON
+
+« PONI-AYAMIHAW, ok, (v. n.) he finishes praying
+« PONI-AYAW, ok, (v. n.) he ceases to be, to exist
+« PONIYÂWESIW, ok, (a. a.) he ceases to be angry
+« PONINOKUSIW, ok, (a. a.) he disappears
+« PONINOKWAN, wa, (a. in.) idem
+« PONINONIW, ok, (v. n.) he ceases to suckle
+« PONINOYEW, etc., (v. a.) she weans him
+« PONI-PIMÂTISIW, ok, (a. a.) he ceases to live
+« PONIPAYIW, ok, a, (a. a. and in.) it ceases, it finishes acting
+« PONIWITJEWEW, etc., (v. a.) he separates from him
+« PONIYOTIN, (v. im.) the wind eases
+« POYUW, ok, (v. n.) he ceases to act, he desists
+« POYUWIN, a, (n. f.) cessation, desisting
+x PONEW, (v. a.) NAM, NIWEW, NIKEW, he feeds the fire with him, he uses him as word, e.g., matchi-manito ponew owebinikowisiwa, the Devil feeds the fire with the damned (or, casts them there)
+« PONAM, wok, (v. n.) he feeds the fire, he puts wood in the fire
+« PONIKÂTEW, a, (a. in.) the fire is prepared, made
+POUS, ak, cat
+POSÂKKWÂMIW, ok, (a. a.) he sleeps deeply
+x POSIW, ok, (r. n.) he embarks in a canoe, barge, ship, and he rides, in a car on the ground
+
+576
+
+POS
+
+« POSIWIN, a, (n. f.) embarkment
+« POSIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he embarks it, he makes it embark, he makes it ride in a car
+« POSIPAYIW, ok, a, (a. a. and in.) it enters within, it embarks, e.g., posipayiw nipiy, the water comes in, enters
+« POSITTÂSUW, ok, (v. n.) he loads, e.g. a ship
+« POSITTÂSUWIN, a, (n. f.) load of a canoe, or, the action of loading
+« POSIWEBINEW, (v. a.) NAM, NIWEW, NIKEW, he embarks it by throwing it in
+« POSIWEPAHWEW, (v. a.) HAM, HUWEW, HIKEW, he embarks it by giving it a shake
+« POSISKISIW, ok, (a. a.) he is concave
+« POSISKAW, a, (a. in.) idem
+« POSISKIHEW, etc., (v. a.) he makes it concave
+« POSKU, (prefix) in the same time, in the same space, e.g. posku kijik, the same day, posku pipon, in the course of the same winter, posku tibisk, in the interval of the night, posku wâskâhigan, in the bounds of the same house, posku sâkahigan, in the space of the lake, posku kijik takusin, he arrives the same day (that he left)
+x POSK, (rac.) to puncture, to burst, to explode
+
+POS
+
+« POSKUPAYIW, ok, a, (a. a. and in.) it splits open, it bursts
+« POSKUNEW, (v. a.) NAM, NIWEW, NIWEW, he bursts it with his hand
+« POSKWAHWEW, (v. a.) HAM, HUWEW, HIKEW, he bursts it, he makes an opening by hitting it
+« POSKUSWEW, (v. a.) SAM, SUWEW, SIKEW, he bursts it with an edge, also: by fire, e.g. someone who bursts his rifle, he makes it explode
+« POSKUSIMEW, (v. a.) TITAW, SIMIWEW, TCHIKEW, he bursts it, he makes a hole in it, by knocking it against (something)
+« POSKUSIW, ok, (a. a.) he is burst, he has a hole
+« POSKWAW, a, (a. in.) idem
+« POSKUSIN, wok, (a. a.) he makes a hole by falling
+« POSKUTTIN, wa, (a. in.) idem
+« POSKUSKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he bursts it, he makes a hole in him by walking on him
+« POSKUPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he makes an opening in it by tearing it
+« POSKUTEW, (v. im.) he explodes
+« POSKUWASKISINEW, ok, (a. a.) his shoes have holes
+« POSKWATIPEW, ok, (a. a.) he has a split open head
+« POSKWATIPEHWEW, etc., (v. a.) he makes a hole in his head
+x POTÂTAKINAM, wok, (v. n.) he puts his foot in a hole
+x POTÂTCHIKEW, ok, (a. n.) he breathes, e.g. in an instrument
+
+577
+
+PUS
+
+« POTÂTCHIKESIS, ak, (n. f.) mole
+« POTOTCHIGAN, a, (n. f.) wind instrument, flute, trumpet, megaphone
+« POTÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he breaks into it, he breathes on him
+x POTA, (adv.) (pron. indef.) This word gives the idea of something which arrives, and which one was not expecting, e.g. potâni tâpwe, yet is is true
+« POTCHI, (adv.) within, at the bottom, e.g., potchiwâtikânik, in the cave, potchipayiw, he falls in
+« POTI, behold, etc., e.g. poti ka wâbamak, behold I see it (without expecting it) poti ni nakiskawaw! behold I meet him! poti tâpwe! it is quite true!
+« POTAWAH! here it is!
+« POTANIKI! here they are!
+« POTOMA! (inanimate) idem
+x PUST, (rac.) to clothe, to fit (with)
+« PUSISKAWEW, (v. a.) he puts it (on) e.g. a piece of clothing
+« PUSTÂBÂNIKKAHEW, etc., (v. a.) he harnesses it to the back, or, to the cart
+« PUSTAMOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he fits it, he fixes it to something, he harnesses it
+« PUSTÂSKWAMOHEW, etc., (v. a.) idem
+« PUSTÂSÂKEW, ok, (v. n.) he puts on his cap, his outer clothes
+« PUSTASÂKAHEW, etc., (v. a.) he puts his clothes on him
+
+PUS
+
+« PUSTASÂMEW, ok, (n. n.) he puts on his snowshoes
+« PUSTAYONISEW, ok, (v .n.) he puts on his clothes
+« PUSTAYONISAHEW, etc., (v. a.) he puts his clothes on him
+« PUSTASKISINEW, ok, (v. n.) he puts on his shoes
+« PUSTASTISEW, ok, (v. n.) he puts on his mittens
+« PUSTASTOTINEW, ok, (v. n.) he puts on his hat, his cap
+« PUSTASKISINÂHEW, (v. a.) he puts his shoes on him
+« PUSTASTISÂHEW, (v. a.) he puts his mittens on him
+« PUSTASTOTINÂHEW, (v. a.) he puts his hat on him
+« PUSTITÂSEW, ok, (v. n.) he puts on his pants
+« PUSTITÂSAHEW, (v. a.) he puts his pants on him
+« PUSTASPASTÂKANEW, ok, (v. n.) she puts on an apron
++ PUTINEW, (v. a.) NAM, NIWEW, NIKEW, he puts his hand in
+x PUTOWISIW, ok, (a. a.) he is swollen, puffy
+« PUTOWAW, a, (a. in.) idem
++ PUYAKINEW, (v. a.) NAM, NIWEW, NIKEW, he peels it, he skins it, he scales it
+« PUYAKISWEW, (v. a.) SAM, SUWEW, SIKEW, he skins it, e.g. with a knife
+« PUYAKAMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he removes the bar with his teeth, e.g. a beaver
+« PUYAKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he barks it (the tree) with an axe
+
+SÂK
+
+« PUYAKIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he removes the skin, he pulls off the bark
++ PUYAWEW, ok, (n. r.) two-winter old beaver
+« PUYAWESIS, ak, (n. f.) idem
+SAKAMO, (adv.) at all moments, without cease, often
+SAKO, (adv.) idem
+x SÂK, (rac.) to come out, to grow, to push, to begin to appear
+« SÂKÂBATTEW, (v. im.) smoke which rises up
+« SÂKÂBATTEPAYIW, (v. im.) fume which suddenly rises up
+« SÂKAHIGAN, a, (n. f.) lake
+« SÂKAHIGANIWIW, (v. im.) there is a lake, or, it is a lake
+« SÂKAHIGANIS, a, (n. f.) small lake
+« SÂKAHIGANISIS, a, (n. f.) pond
+« SÂKASKISIW, ok, (a. a.) he appears, he seems to come out of, etc.
+« SÂKASKAW, a, (a. in.) idem
+« SÂKASKAW, (v. im.) the grass, the hay begins to push out
+« SÂKÂSKWAHWEW, (v. a.) HAM, HUWEW, HIKEW, he raises it in the air
+« SÂKÂSKWAN, (v. im.) branch which stick out
+« SÂKÂSKIW, ok, (a. a.) gum, resin which comes out of trees
+« SÂKÂSTEW, (v. im.) the Sun rises, appears
+« SÂKÂSTENOK, (adv.) from the eastern side
+
+SÂK
+
+« SÂKATCHIWEW, ok, (v. n.) he climbs on the summit, he appears on the summit
+« SÂKATCHIWETOTAWEW, (v. a.) TAM, TÂKEW, TCHIKEW, he climbs towards him on the summit
+« SÂKASKIN, wa, (v. im.) it pushes out, it comes out of the ground
+« SÂKASKIN, (ad.) filled, full; e.g. sâkaskin ni miyik, he gives it to me full
+« SÂKASKINEW, ok, a, (a. a. and in.) he is full, filled
+« SÂKASKINAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he fills it
+« SÂKASKINEMÂKUSIW, ok, (a. a.) he is full of a smell
+« SÂKASKINEMÂKWAN, wa, (a. in.) idem
+« SÂKASKINEPEW, ok, a, (a. a. and in.) he is full of water
+« SÂKASKINEPÂHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he fills it with water
+« SÂKASKINESKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he fills him by putting strain on him; e.g., ki sâkaskineskâkun ki matchi ayiwiwin, you are full of your wickedness; Marie ki sakaskineskâkuw Kijemanito osâkihiwewiniyu, Mary was filled by the grace of God
+« SÂKASKINATTOWEW, etc., (v. a.) he fills it for him
+« SÂKASKINATTAMÂWEW, etc., (v. a.) he fills it for him
+« SÂKASKISUW, ok, (a. a.) someone which is planted and of which one only sees the end, e.g., a tree planted in water
+
+579
+
+SÂK
+
+« SÂKASKITEW, a, (a. in.) idem
+« SÂKASKINEPAYIW, ok, a, (a. a. and in.) it fills itself
+« SÂKASKINEYÂBATTEW, (v. im.) it is full of smoke
+« SÂKEW, ok, (n. f.) crawfish
+« SÂKIKIW, ok, (a. a.) he comes out of the ground, he pushes out, he believes
+« SÂKIKIN, wa, (a. in.) idem
+« SÂKIKIWIN, a, (n. f.) belief
+« SÂKIPAKAW, (v. im.) the leaves begin to come out, it buds
+« SÂKITOW, ok, (v. n.) he harangues in public, while walking, or on horseback. This word also means, when a savage goes outside, and remains there, either walking or on horseback, proclaiming news and notices in a high voice, etc., he harangues
+SÂKITOWIN, a, (n. f.) harangue
+« SÂKITOSTAWEW, (v. a.) TAM, TÂKEW, TÂTCHIKEW, while speaking outside, while haranguing, he apostrophises (speaks brusquely and impolitely)
+« SÂKITOWIYINIW, ok, (n. f.) herald
+« SÂKOWEW, ok, (v. n.) he screams to invigorate himself, to encourage himself, to cry lively, he applauds, he cries out in joy, or, sâsâskwew, ok
+« SÂKOWEWIN, a, (n. f.) applause, cry of joy
+« SÂKOWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW. This word has two meanings. 1. he applauds him, he indicates that he is in his favour by crying out. 2. he mocks him, he challenges him by crying out against him. This last meaning is the most common
+
+SÂK
+
+« SÂKIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he makes it push up, he makes it grow
+« SÂKISIN, wok, (a. a.) he appears, he projects, he shows his head
+« SÂKITIN, wa, (a. in.) idem
+« SÂKIKUTEW, ok, (v. n.) he shows his nose
+« SÂKISKWEW, ok, (v. n.) he shows his head
+« SÂKINISKEW, ok, (v. n.) he shows his hand
+« SÂKITEYANIWEW, ok, (v. n.) ok, (v. n.) he puts out his tongue
+« SÂKITEYANIWIYIW, ok, (v. n.) idem
+« SÂKITEYANIW, ok, (v. n.) idem
+« SÂKITTAWAW, (v. im.) mouth of a river, being where it falls or leaves off into a lake
+« SÂKITAWEHAM, wok, (v. n.) he arrives at the mouth of the river or the lake in a canoe
+« SÂKIWEHAM, wok, (v. n.) idem
+« SÂKITAWESKAM, wok, (v. n.) idem, by walking
+« SÂKOTTEW, (v. im.) the sun appears on the horizon
+x SÂKÂWISIW, ok, (a. a.) he is straight, narrow, straightened
+« SÂKÂWAW, (a. in.) idem
+« SÂKÂWISIWIN, a, (n. f.) straightness, narrowing
+« SÂKÂWIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it straight
+« SÂKÂWISWEW, (v. a.) SAM, etc., he sizes it straight
+
+580
+
+SÂK
+
+« SÂKÂWISINAHWEW, etc., (v. a.) he marks it, he describes it as straight
+« SÂKÂWÂBISKUSIW, ok, (a. a.) he is straight (when speaking of metal(
+« SÂKÂWÂBISKAW, a, (a. in.) idem
+« SÂKÂWÂSKUSIW, ok, (a. a.) idem
+« SÂKÂWÂKUSIW, ok, (a. a.) idem (when speaking of wood)
+« SÂKÂWÂSKWAN, wa, (a. in.) idem
+« SÂKÂWEGASIW, ok, (a. a.) idem, (when speaking of cloth, Indian cloth, sheet)
+« SÂKÂWEGAN, wa, (a. in.) idem
+« SÂKÂWIKKWEW, ok, (a. a.) he has a straight face
++ SAKAW, (v. im.) dense woods, there is forest
+« SAKÂKKWAN, (v. im.) there is brush, tangle
+« SAKIPAKAW, (v. im.) thick foliage
+« SAKIKKUBAW, (v. im.) thick brush
+« SAKIMITUSISKAW, (v. im.) there is an aspen forest
+« SAKIMINAHIKUSKAW, (v. im.) there is a spruce forest
+« SAKÂSKWEYAW, (v. im.) there is a thick forest
+« SAKIKWAN, a, (n. f.) tangle, outgrowth of trees, root of the branch
+« SAKÂTIKKWAN, a, (n. f.) idem
+« SAKIKWANIWIW, (v. im.) there is tangle
+« SAKÂTIKWANIWIW, (v. im.) idem
++ SÂKI, (rac.) to like, to not like to leaving something, to be greedy
+
+SÂK
+
+« SÂKIHÂGAN, ak ,(n. f.) lover, favourite
+« SÂHIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he loves him, he is attached to him, he does not want to detach from him
+« SÂKIHIWEW, ok, (v. ind.) he loves
+« SÂKIHIWEWIN, a, (n. f.) love for, affection for, etc.
+« SÂKIHIWEWINIWIW, ok, a, (a. a. and in.) he is in love, it is love
+« SÂKIHIWEWISIW, ok, (a. a.) he is in love
+« SÂKIHITUWOK, (v. m.) they love one another
+« SÂKIHITUWIN, a, (n. f.) mutual love
+« SÂKIHIKUSIW, ok, (a. a.) he is lovable
+« SÂKIHIKWAN, wa, (a. in.) idem
+« SÂKIHIKUSIWIN, a, (n. f.) lovability
+« SÂKIHIKOWIN, a, (n. f) the action of being loved
+« SÂKIHIKOWISIW, he is loved by God
+« SÂKIHISUW, ok, (v. r.) he loves himself
+« SÂKIHISUWIN, a, (n. f.) self-esteem, love of self
+« SÂKISIW, ok, (a. a.) he is greedy, he loves his wealth. N.B. This word and the following are always said with reduplication, thus, sâsâkisiw
+« SÂKISIWIN, a, (n. f.) (sâsâkisiwin) greed, love of one's wealth
+SÂKITTIW, ok, (a. a.) (sâsâkittiw) he has bare feet. See. the further root
+
+
+
+
+
+x SAKK, (rac.) to attach oneself to, to hook onto, to hang on, to load down with, etc.
+« SAKKAPPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he attaches it, e.g. to a pole
+« SAKKAPPISUW, ok, (ok, (a. a.) he is attached to, etc.
+« SAKKAPPITEW, a, (a. in.) idem
+« SAKKÂBÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he attaches it there, he sews it to
+« SAKKIPÂTEW, etc., (v. a.) idem, he buttons it
+« SAKKIPÂSUW, ok, (v. n.) he buttons himself, he hooks his clothing
+« SAKKIPÂSUN, a, (n. gf.) button, hook. See. Aniskamân
+« SAKKÂSKWAHWEW, (v. a.) HAM, HUWEW, HIKEW, he hooks it, he buttons it, he attaces it, he laces it
+« SAKKÂSKUHEW, etc., (v. a.) he hooks it, etc.
+« SAKKÂSKWAHUN, a, (n. f.) button, hook
+« SAKKAMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he holds it tight between his teeth
+« SAKKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he nails it
+« SAKKAHIGÂN, a, (n. f.) nail, peg
+« SAKKAHIGANIS, a, (n. f.) small nail, spike
+« SAKKAMOW, ok, a, (a. a. and in.) it is nailed there, attached
+« SAKKAMOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he attaches it there by nailing it
+
+SAK
+
+« SAKKAMOSKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he attaches it by pressing from above
+« SAKKAPWÂN, a, (n. f.) hook for suspending a boiler, rack
+« SAKKAPWÂNEYÂBIY, a, (n. f.) rope which is used to suspend a boiler
+« SAKKAPWEW, ok, (v. n.) he roasts it in front of the fire
+« SAKKAPWÂTEW, etc., he roasts it in front of the fire
+« SAKKINEW, (v. a.) NAM, NIWEW, NIKEW, he grabs it with his hand, he grasps it
+« SAKKEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he still thinks of it, he is attached to it, he regrets it
+« SAKKEYITTAMOWIN, a, (n. f.) regret, attachment, e.g. nama kekway sakkeyittam, he isn't attached to anything
+« SAKKITSIMEW, (v. a.) TITAW, SIMIWEW, TCHIKEW, he loads it down, he entangles it
+« SAKKITCHIN, wok, (a. a.) he is weighed down, hooked, by his clothing
+« SAKKITTIN, wa, (a. in.) idem
+« SAKKIKKWENEW, etc., (v. a.) he weighs it down
+« SAKKIKKWEPITEW, etc., (v. a.) idem
+« SAKKINISKENEW, etc., (v. a.) he takes him by the hand, sakkitchitchenew, he holds his hand
+« SAKKINISKETAHITUWOK, (v. m.) they are arm in arm
+
+582
+
+SÂK
+
+« SAKKINISKENITUWOK, (v.) they hold one another's hands. N.B. Bad words:
+« SAKKISTIWOK: coeunt, copulati sunt (they have sex, they are copulating)
+« SAKKISTIWIN, a, (n. f.) coitus, copula, these expressions are only said of dogs and wolves
+x SAKIMEW, ok, (n. r.) mosquito
+« SAKIMEWEYÂN, a, (n. f.) gauze, fabric to protect oneself from mosquitos
+« SAKIMESKAW, (v. im.) there are lots of mosquitos
+x SAKO, and, SÂKW, (rac.) to win over, etc., to vanquish, to surpass, to be beaten down, etc.
+« SÂKOTCH, (adv.) indication of powerlessness, lack of resistance, e.g. âkotch ni wi-mâtun, despite myself, I must cry, sâkotch wi-kisiwâsiw, it is stronger than him, he must be getting angry, sâkotch namawiya ni ki toten, what to do? I cannot make it to the end, ata e miyo itak, sâkotch nama ni wi-nantottâk, my good words notwithstanding, he did not want to listen to me
+« SÂKOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he vanquishes it, he summits it, he surpasses it
+« SÂKOTCHIHEW, etc., (v. a.) idem
+« SÂKOMEW, etc., (v. a.) he convinces him (seldom used)
+« SÂKOTCHIMEW, etc., (v. a.) idem
+« SÂKOHIWEW, ok, (v. ind.) he obtains victory
+« SÂKOTCHIHIWEW, ok, (v. ind.) idem
+
+SÂK
+
+« SÂKOTCHIMIWEW, ok, (v. ind.) he persuades
+« SÂKOTTOWEW, etc., (v. a.) he wins it for him
+« SÂKOTTAMÂWEW, etc., (v. a.) he earns victory for him
+« SÂKOTTWAW, ok, (v. n.) he earns victory
+« SÂKOTEYIMEW, etc., (v. a.) he thinks him to be cowardly
+« SÂKOTEHEW, ok, (a. a.) he is cowardly, his heart is as if vanquished
+« SÂKOTEHEWIN, a, (n. f.) cowardliness
+« SÂKOTISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he surpasses him, he prevails against him (by fighting)
+« SÂKOTCHIPAYIW, ok, a, (a. a. and in.) it prevails
+« SAKWEYIMOW, ok, (v. n.) he hesitates, he wavers, he experiences reluctance
+« SÂKWEYIMOWIN, a, (n. f.) reluctance, hesitation
+« SÂKWEYIMOTOTAWEW, (v. a.) TAM, TÂKEW, TÂTCHIKEW, he experiences aversion towards him
+« SÂKWEYIMOHEW, etc., (v. a.) he discourages him, he puts him off
++ SÂKKWEW, ok, (v. n.) he makes noise by walking, e.g., by putting his foot on a piece of wood that he snaps
+« SÂKKWEYAW, (v. im.) when the snow makes noise under one's feet
+« SAKKWEPAYIW, ok, a, like sâkkwew
+« SÂKKOPAYITTAW, ok, (v. a. in.) he makes noise by breaking it
+
+583
+
+SÂM
+
+« SÂKKWEHWEW, (v. a.) HAM, HUWEW, HIKEW, idem
++ SÂKWESIW, ok, (n. r.) vision, (foutreau). See. Atchakâs
+x SÂKWATAMOW, ok, (n. r.) large hawk, predatory bird
+x SAKASKINEW, (v. a.) NAM, NIWEW, NIKEW, he hermetically seals it
+« SAKASKISIW, ok, (a. a.) he closes, or, he is hermetically sealed
+« SAKASKAW, a, (a. in.) idem
+« SAKASKIPAYIW, ok, a, (a. a. and in.) idem
+x SÂM, (rac.) to touch, to feel
+SÂMINEW, (v. a.) NAM, NIWEW, NIKEW, he touches it with his hand, he feels it. One says: matchi sâminew, he touches someone badly
+« SÂMISIMEW, (v. a.) TITAW, SINAWEW, TCHIKEW, he makes it touch upon, etc., (by placing it)
+« SÂMISIN, wok, (a. a.) he touches something lying down, or, spread out
+« SÂMITTIN, wa, (a. in.) idem
+« SÂMIPEW, (v. im.) it touches the water
+« SÂMIPEW, ok, a, (a. a. and in.) he touches the water
+« SÂMISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he touches it by putting his foot on it
+« SÂMAHWEW, (v. a.) HAM, HUWEW, HIKEW, he touches it with something, e.g., a piece of wood
+« SÂMINITUWOK, (v. im.) they touch one another. This always means in the bad sense
+
+SÂM
+
+« SÂMINITUWIN, a, (n. f.) bad touching
+x SÂMAKINEW, (v. a.) NAM, NIWEW, NIKEW, he holds it crushed on the ground, he flattens it
+« SÂMAKISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he flattens it under his feet
+« SAMAKIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he flattens it by pulling it
+« SAMAKISIW, ok, (a. a.) he is flattened, crushed
+« SAMAKAW, a, (a. in.) idem
+« SAMAKIPAYIW, ok, a, (a. a. and in.) he flattens himself, he crushes himself, he lowers himself to the ground
+« SAMAKIPAYIHUW, ok, (v. r.) he crouches against the ground, e.g., to not be seen
+x SANASKISIW, ok, (a. a.) he is well joined, united together
+« SANASKAW, a, (a. in.) idem. also; a well trodden piece of clothing
+« SANASKIPAYIW, ok, a, (a. a. and in.) it is well put together, joined, e.g. two pieces of board (that are) stuck together well
+« SANASKAMOW, ok, a, (a. a. and in.) idem
+« SANASKAMOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he joins them together well
+« SÂNASKEGIN, a, (n. f.) tightly haired cloth
+« SANASKEGAN, wa, (a. in.) idem
+« SANASKAYOWEW, ok, (a. a.) he is quite furry, he is tightly haired
+« SANASKINEW, (v. a.) NAM, NIWEW, NIKEW, he joins it together well
+
+584
+
+SÂB
+
+« SANASKIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, idem
+« SANASKWAHWEW, (v. a.) NAM, HUWEW, HIKEW, idem
+« SANASKIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he puts it together, he flattens it, e.g., a sled passing over grass, puts it together, flattens it
+x SÂBO, and, SÂBW, (rac.) through, from one end to the other, from end to end
+« SÂBOMEW, etc., (v. a.) he is penetrated from end to end, by his words
+« SÂBONEW, (v. a.) NAM, NIWEW, NIKEW, he passes it across
+« SÂBONIGANIS, a, (n. f.) small needle
+« SÂBONOKUSIW, ok, (a. a.) he appears through
+« SÂBONOKWAN, wa, (a. in.) idem
+« SÂBONIGAN, a, needle (ostikwânisâbonigan), pin
+« SÂBOPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it pass through, he sends it from one side to the other
+« SÂBOPAYIW, ok, a, (a. a. and in.) it passes from one side to the other
+« SABOPAYISTAWEW, (v. a.) TAM, TÂKEW, TÂTCHIKEW, he pierces through it, e.g., passing an arrow through the body
+« SÂBOSTAHWEW, (v. a.) HAM, HUWEW, HIKEW, he sews it from end to end
+« SÂBOTCHIWAN, (v. im.) the water passes from end to end
+« SÂBOMIYÂSKAWEW, etc., (v. a.) he passes him without stopping
+« SÂBOMIN, ak, (n. f.) currant
+
+SÂB
+
+« SÂBOMINÂTTIK, wok, (n. f.) currant bush
+« SÂBOPEW, ok, a, (a. a. and in.) he is wet through and through
+« SÂBOPAHEW, (v. a.) TAW, HIWEW, TCHIKEW, he wets it through and through
+« SÂBOSKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he passes through. One says: ni sâboskâkun, it purges me, it makes me have a bowel movement
+« SÂBOSIGAN, a, (n. f.) purgative
+« SÂBOSWEW, (v. a.) SAM, SUWEW, SIKEW, he purges it
+« SÂBOSUW, ok, (v. a.) he is purged, he has diarrhea
+« SÂBOSUWIN, a, (n. f.) dysentry, diarrhea
+« SÂBOTTAWESKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he walks through someone, it
+« SÂBOTAWAW, (v. im.) there is an opening at the two extremities
+« SÂBOTTAWÂN, a, large and long lodge, with a door at each end, used for superstitions, conjurations, etc., by the savages
+« SÂBOTTAWEYAW, a, (a. in.) there is a passage, an opening
+« SÂBOTTAWESIW, ok, (a. a.) idem
+« SÂBOTTAWESIWIN, a, (n. f.) opening, passage
+« SÂBOWÂSTAN, wa, (a. in.) idem
+« SÂBWÂSIW, ok, (a. a.) idem, he is shining, luminous, from end to end
+« SÂBWÂSTAN, wa, (a. in.) idem
+
+585
+
+SÂB
+
+« SÂBOYOWEW, ok, (a. a.) he feels the air penetrating him, the wind penetrates him
+« SÂBOYAWESIW, ok, (a. a.) idem
+« SÂBOYOWEW, (v. im.) the wind passes through
+« SÂBOWÂSUW, ok, (a. a.) he is transparent
+« SÂBOWÂSTEW, a, (a. in.) idem
+« SÂBWÂSUW, ok, (a. a.) idem
+« SÂBWÂSTEW, a, (a. in.) idem
+« SÂBWÂSUWIN, a, (n. f.) transparence
+« SÂBOWÂSUWIN, a, (n. f.) idem
+« SÂBWÂSTEWIN, a, (n. f.) idem (of an inanimate object)
+« SÂBOKKWÂMIW, ok, (a. a.) he sleeps deeply. See. Posâkkwâmiw
+« SÂBOWEPINEW, (v. a.) NAM, NIWEW, NIKEW, he throws it through
+« SÂBOYAW, ok, (v. n.) he flies through, e.g., a bird which flies away through a hole
+« SÂBOYAKKIW, ok, (v .n.) he inserts himself by passing through
+« SÂBOYAKKIHEW, etc., (v. a.) he inserts it through
+« SÂBWAMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he pieces it from end to end by hitting on it
+« SÂBWAMOW, ok, a, (a. a. and in.) he passes through, e.g. an arrow which passes from end to end, of which one sees the end (sticking out) of the other side
+« SÂBWÂBAMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he sees it through something
+
+SÂB
+
+« SÂBONAWEW, (v. a.) NAM, NÂKEW, NÂTCHIKEW, he looks at it through (something)
+« SÂBWÂSKUPAYITTAW, ok, (v. a. in.) he passes through on horseback, e.g., through a forest
+x SÂPIW, ok, (a. a.) he has strength, e.g., someone who is convalescent, nama sâpiw, he is weak, he is powerless
+« SÂPIWIN, a, (n. f.) strength, convalescence
+« SÂPIGANEW, ok, (a. a.) has has strength in his limbs. One always says: sâsâpiganew, ok
+« SÂPEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he believes him to be firm, resistant, he thinks him to be capable, e.g. namawiya ni sâpeyitten, I do not have a great idea of him, I don't think much of him
+« SÂPITCHIWAN, (v. im.) river with a quite strong current
++ SÂSÂKINIKÂTEW, ok, (a. a.) he has bare legs
+« SÂSÂKIPITUNEW, ok, (a. a.) idem
+« SÂSÂKINISTIKWÂN, a, (n. f.) bare head
+« SÂSÂKINISTIKWÂNEW, ok, (a. a.) he has a bare head
+« SÂSÂKINISTIKWÂNENEW, etc., (v. a.) he makes his head bare, he uncovers his head
+« SÂSÂKISITEW, ok, (a. a.) he has bare feet
+« SÂSÂKITTIW, ok, (a. a.) idem
+x SÂSÂKUSIW, ok, (a. a.) he is thin, spindly, slim
+
+586
+
+SÂS
+
+« SÂSÂKIYAWEW, ok, (a. a.) idem
+« SÂSÂKAW, a, (a. in.) idem
+« SÂSÂKÂBISKUSIW, ok, (a. a.) idem (of metal)
+« SÂSÂKÂBISKWAW, a, (a. in.) idem
+« SÂSÂKÂSKUSIW, ok, (a. a.) idem (of wood)
+« SÂSÂKÂSKWAN, wa, (a. in.) idem (of wood)
+SÂSAY, (adv.) already, e.g. sâsay kuskupayiw, he is not already awake, sâsay tchi? isn't it already?
+x SÂSESKIKKWÂN, a, (n. r.) frying stove, also: trimmed and grilled meat
+« SÂSESKIKKWEW, ok, (v. n.) he fries
+« SÂSESKIKKWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he fries it
+« SÂSIPIMEW, ok, (v. n.) he reduces it to grease, by boiling it
+« SÂSIPIMÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he reduces it to grease, by boiling it
+« SÂSIMEW, (v. a.) TITAW, SIMIWEW, TCHIKEW, he makes it scatter, pour out, empty, e.g., by throwing a punctured bladder to the ground, the contents of which spill out
+« SÂSISIN, wok, (a. a.) he spills out by puncturing
+« SÂSITTIN, wa, (a. in.) idem
+x SÂSAKITCHIPAYIW, ok, (v. n.) he falls backwards
+« SÂSAKITISIN, wok, (a. a.) he is lying down on his back
+
+SÂS
+
+« SÂSAKITITTIN, wa, (a. in.) it is lying on its back
+« SÂSAKITISIMEW, (v. a.) TTITAW, SIMIWEW, TCHIKEW, he lays it on its back, he puts it backwards
+« SÂSAKITCHIWEBINEW, (v. a.) NAM, NIWEW, NIKEW, he throws it backwards
+« SÂSAKITCHIWEPAHWEW, (v. a.) HAM, HUWEW, HIKEW, he throws it backwards by hitting it
+SASIMEW, etc., (v. a.) he surprises him, he stuns him by speaking to him. See. Sisikutchimew, also Sastomew
+x SÂSIBITTAWEW, (v. a.) TTAM, TTÂKEW, TTÂTCHIKEW, he disobeys him. See. Sibittawew
+« SÂSIBITTAMOWIN, a, (n. f.) disobedience
+x SASKAN, (v. im.) the snow thaws, there is thawing
+« SASKAKUNAKAW, (v. im.) idem
+« SASKATCHAW, (v. im.) there is thawing
++ SASKAMOW, ok, (v. n.)
+« SASKAMOWIN, a, (n. f.) the action of putting (something) in one's mouth, ayamihewisaskamowin, the Holy Communion
+« SASKAMOYEW, etc., (v. a.) he puts him in his mouth, ayamihewisaskamoyew, he receives it as Communion
+« SASKATCHI, or, SASKAT, (rac.) to be tired, bored
+« SASKATEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he is tired, bored of him
+
+587
+
+SÂS
+
+« SASKATCHIPEHEW, etc., (v. a.) he is bored of waiting for it
+« SASKATCHIMITJIW, ok, (v. a. in.) he is tired of eating it, e.g. someone who always eats the same thing. N.B. And so on, placing saskatchi before (the word)
+x SASKAHUW, ok, (v. r.) he props it on a stick to walk
+« SASKAHUN, a, (n. f.) walking cane, stick
+« SASKAHUTTEW, ok, (v. n.) he walks with a stick
+x SASKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he puts him in the fire, he sets it on fire
+« SASKASUW, ok, (a. a.) he is alight, in flames
+« SASKITEW, a, (a. in.) idem, it catches fire
+« SASKISWEW, (v. a.) SAM, SUWEW, SIKEW, he lights it on fire by applying it to something
+« SASKITCHIGAN, a, (n. f.) match. See. Kutawâgan
+« SASKIPAYIW, ok, (a. a. and in.) he catches fire
+x SASKATWEMOW, ok, (v. n.) he cries while sobbing
+« SASKATWEMOWIN, a, (n. f.) crying accompanied by sobbing
+« SÂSÂSKWEW, ok, (v. n.) See. Sâkowew
+« SÂSÂSKWEWIN, a, (n. f.) See. Sâkowewin
+« SÂSKIYÂWESIW, ok, (a. a.) he is in a fury, enraged with anger
+
+SÂS
+
+« SÂSKIYÂWESIWIN, a, (n. f.) fury, anger
+« SÂSKIYÂWEHUW, etc., (v. a.) he infuriates him
+x SÂSTESIW, ok, (a. a.) he begins to spoil, he has a bad taste, it is bitter, bland
+« SÂSTEYAW, a, (a. in.) idem
+« SÂSTESIN, wok, (a. a.) he is spoiled
+« SÂSTETTIN, wa, (a. in.) idem
+SÂSTOWEW, etc., (v. a.) he stuns him with his speech. See. Sisikutchimew
+SASAWESKITTEW
++ SASWEPAYIW, ok, (a. a. and in.) he disperses
+« SASWEWEBINEW, (v. a.) NAM, NIWEW, NIKEW, he disperses it, he scatters it, e.g. throwing a handful of seeds
+« SASWETISAHWEW, (v. a.) HAM, HUWEW, HIKEW, he disperses them, e.g. to send horses to and fro
+« SASWEPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he throws it from one side to the other, he spreads it
+x SÂWÂNAKEYIMOW, ok, (v. n.) he is jealous. N.B. This word and its derivations are sometimes pronounced with i before them, so: isâwanakeyimow, ok
+« SAWÂNAKEYIMOWIN, a, (n. f.) jealousy. See. otteyittam, and, otteyittamowin
+« SÂWÂNAKEYIMEW, etc., (v. a.) he is jealous of him
+« SÂWÂNAKEYIMOTATAWEW, (v. a.) TAM, TÂKEW, TÂTCHIKEW, idem
++ SÂWAN, (n. r.) the south
+
+588
+
+SAW
+
+« SÂWANOK, (adv.) from the southern side
+« SÂWANOTÂK, (adv.) idem
+« SÂWANIYOTIN, (v. im.) wind from the south
+« SÂWANAHAN, (v. im.) idem
+« SÂWANIYOWEW, (v. r.) air, breeze from the south
++ SÂWATTOW, ok, (v. n.) he stretches his legs
+« SÂWATTOSIN, wok, (a. a.) he stretches his legs, lying down
+« SÂWATTOHEW, etc., (v. a.) he stretches his legs (somebody else's)
+« SÂWATTOPITEW, etc., (v. a.) idem, by pulling them
++ SAWEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he does good things to him, he benefits him
+« SAWEYITCHIKEW, ok, (v. ind.) he is merciful, he does good things
+« SAWEYITCHIKEWIN, a, (n. f.) mercy, blessing
+« SAWEYITTAMOWIN, a, (n. f.) idem
+« SAWEYIMIKOWISIW, ok, (a. a.) he is blessed by God
+« SAWEYITTÂKUSIW, ok, (a. a.) he is blessed
+« SAWEYITTÂKWAN, wa, (a. in.) idem
+« SAWEYITTÂKUSIWIN, a, (n. f.) blessing
+« SAWEYIMIKOWISIWIN, a, (n. f.) blessing from heaven
+« SAWEYITCHIKÂSUW, ok, (a. a.) he has been blassed, e.g. a rosary
+« SAWEYITCHIKÂTEW, a, (a. in.) idem
+
+SAY
+
+SAYE, (adv.) to be on the alert, to spy, e.g., mâna piko saye nando ni ka itikawin, I am in apprehension, as if one was going to say something to me
+SEHWEW, (v. a.) HAM, HUWEW, HIKEW, he unblocks it, e.g., a pipe which is blocked
+SEKKE, (adv.) voluntarily (proprio motu (on his own impulse)), on his own accord, e.g., sekke ituttew, he goes there on his own accord, sekke totam, he does it voluntarily
+x SEKIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he frightens him, he makes him afraid
+« SEKISIW, ok, (a. a.) he is afraid, he is frightened
+« SEKISIWIN, a, (n. f.) fear, fright
+« SEKIKWASIW, ok, (a. a.) he has frights in his sleep
+« SEKIKWÂMIW, ok, (a. a.) idem
+« SEKINÂKUSIW, ok, (a. a.) he seems to be afraid
+« SEKINEW, (v. a.) NAM, NIWEW, NIKEW, he makes him afraid by touching him
+« SEKÂBAMOW, ok, (v. n.) he is scared by looking
+« SEKÂBAMEW, (v. a.) TTAM, KKEW, TCHIKEW, he is scared by looking at it
+« SEKIMEW, etc., (v. a.) he scares him by speaking to him
+« SEKISIYEYIMEW, etc.. (v. a.) he thinks that he is frightened
+« SEKISIYEYITTAM, wok, (v. n.) he is frightened
++ SEKIPATWAW, ok, (v. n.) he has braided, plaited hair
+
+589
+
+SEK
+
+« SEKIPATWÂN, a, (n. f.) braid of hair, ponytail which hangs behind the head
+« SEKIPATOWEW, etc., (v. a.) he braids his hair (somebody else's)
++ SEK, (rac.) to stuff, to insert, to put between
+« SEKUTCH, (adv.) between, among, under
+« SEKWÂYIK, (adv.) in a space, between two objects
+« SEKUW, ok, he inserts himself, or, sekuyakkiw, he inserts himself by sliding in, sekwayik, in a space between two objects
+« SEKUNEW, (v. a.) NAM, NWIEW, NIKEW, he inserts it between with his hand
+« SEKUPAYIW, ok, a, (a. a. and in.) it is inserted between
+« SEKUPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he stuffs it, he inserts it between something
+« SEKUSIMEW, (v. a.) TITAW, SIMIWEW, TCHIKEW, idem
+« SEKUSIN, wok, (a. a.) he inserts himself, he stuffs himself between, etc.
+« SEKUTTIN, wa, (a. in.) idem
+« SEKUYAKKINEW, (v. a.) NAM, NIWEW, NIKEW, he stuffs it between, he inserts it there, etc.
+« SEKUYAKKIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, idem
+« SEKUYAKKIW, ok, (v. n.) he stuffs himself between, e.g, someone who inserts himself into a hole to hide
+« SEKWASUW, ok, (v. n.) he carries (it) on his belt, e.g., o mokkumân sekwasuw, he carries his knife between his belt and his clothes
+
+SEE
+
+« SEEWAMOW, ok, a, (a. a. and in.) it holds, being attached between
+« SEKWAMOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it go in, by stuffing it between
+« SEKWÂMOW, ok, (v. n.) he insets himself into something to flee
+SEKWAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he places it between
+« SEKWÂPITEHUW, ok, (a. a.) he has something inserted between his teeth, e.g. the rest of a piece of meat
+« SEKWEPAKAW, (v. im.) See. Sikipakaw
++ SEMÂK, (adv.) immediately, right away, as soon as, e.g., semâk ni wi-sipwettân, I want to leave immediately, semâk wittamâwin, tell me right away, semâk e wâbamât mâtuw, as soon as he saw him, he cried
+« SEMÂKITTWÂW, ok, (v. n.) he acts right away
+« SEMÂKITTWÂWIN, a, (n. f.) immediate action
+« SEMÂKUTTEW, ok, (v. n.) he walks right away, he goes straight on , without stopping
++ SENEW, (v. a.) NAM, NIWEW, NIKEW, he twists it, e.g., wet laundry
+« SENIPÂTINEW, (v. a.) NAM, NIWEW, NIKEW, he presses it between his hands to get the water out
+« SENIPÂPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he pulls it to get the water out
+« SENIPATISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he presses it under his feet to get the water out
+
+590
+
+SES
+
++ SENIBÂN, ak, (n. r.) silk, ribbon
+« SENIBÂNASSABÂB, akm (n. f.) silk thread
+« SENIBÂNITÂBISKÂGAN, a, (n. f.) silk handkerchief
+SESESKEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he is afraid of it, he is disgusted by it
+SESIKIHEW, (v. a.) TTAW, HIWEW, TCHIKEW
+SESINISKEW, ok, (v. n.) he is unarmed, he has no weapons with him
+SESIK, (adv.) close, at hand, e.g. sekik ayaw, he is at hand, sesik miskawaw, he is easy to find. See. Ketchiwâk
++ SESKISIW, ok, (v. n.) he leaves the path, or the prairie, to go into the forest
+« SESKITISAHWEW, (v. a.) HAM, HUWEW, HIKEW, he sends him, he makes him flee, into the forest, into an enclosure, etc.
+« SESKINEW, (v. a.) NAM, NIWEW, NIKEW, he puts it to the side, he removes it from a place to put it to the side
+« SESKIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he pulls it to the side, e.g. to pull a canoe out of the water to put far from the shore
+« SESKAHAM, wok, (v. n.) he enters into, etc., a canoe, e.g., in a port, a bay, a mouth (of a river)
+x SESSEGAN, (v. im.) it hails
+« SESSEGANITTAW, ok, (v. a. in.) he makes hail
+
+SES
+
+SESESIW, ok, (n. r.) snipe, teal
+x SESKEPISUN, ak, (n. r.) garter
+« SESKEPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he attaches garters to him
+x SESTAKWA, plur. sestakwok, (n. r.) wool of different colours
+SESTOYUW, ok, (v. n.) he puts something between his clothes to be warmly dressed
++ SEYÂKE, or, SEYÂKES, (adv.) at least, at the very least, e.g., seyâkes kakwe kiyâmapi, at least try to be calm
+« SEYÂKES ITUKE, (adv.) without doubt, at least
+x SEYÂPITEW, ok, (v. n.) he bare his teeth
+« SEYÂPITEWIN, a, (n. f.) the action of baring one's teeth
+« SEYÂPITESTAWEW, etc., (v. a.) he bares his teeth at him
+SHEW! (ex.) term of contempt, pooh!
+x SIKÂK, wok, (n. r.) stinking beast
+« SIKÂKWEYÂN, ak, (n. f.) skin of the stinking beast, of the polecat
+« SIKÂKOMIN, a, (n. f.) black seed
+x SIK, (rac.) to flow, to run, to spread out, to empty, to get through, to spill out, to to pour out
+« SIKAHAN, (v. im.) it flows from the wint, e.g., water which is pushed by the wind, into a canoe, or, outside of a boiler
+« SIKAHWEW, (v. a.) HAM, HUWEW, HICEW, he pours it, e.g. throwing the water in a barrel with a jug
+
+591
+
+SIK
+
+« SIKÂHÂTTAWEW, (v. a.) TTAM, TTÂKEW, TTÂTCHIKEW, he pours water on him, ayamihewi-sikâhâttawew, he baptises him
+« SIKÂHÂTTÂKEWIN, a, (n. f.) (ayamihewi-sikâhâttâkewin), baptism administered by someone
+SIKÂHÂTCHIKÂSUW, ok, (a. a.) (ayamihewi-sikâhâtchikâsuw) he is baptised
+« SIKÂHÂTCHIKÂSUWIN, a, (n. f.) (ayamihewi-sikâhâtchikâsuwin) baptism of someone
+« SIKÂHÂTTÂKEW, ok, (v. ind.) (ayamihew-sikâhâttâkew) he baptises
+SIKÂWIW, ok, (a. a.) e.g., kakiyaw sikâwiwok, they have all left, they have all emptied the place
+« SIKÂWIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes him empty the place
+« SIKÂSIW, ok, (a. a.) he is poured, overturned by the wind, e.g. a vase
+« SIKÂSTAN, ok, (a. a.) idem
+« SIKINEW, (v. a.) NAM, NIWEW, NIKEW, he pours it, he spills it
+« SIKIPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he spills it, etc., like sikinew
+« SIKIPAYIW, ok, a, (a. a. and in.) it spills, he spills, etc.
+« SIKISIMEW, (v. a.) TITAW, SIMIWEW, TCHIKEW, he spills it by throwing it, or, by dropping it
+« SIKIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he spills it by pulling it
+
+SIK
+
+« SIKÂTCHIWASUW, ok, (a. a.) e.g. a boiler which, by boiling, overflows
+« SIKÂTCHIWATEW, a, (a. in.) idem
+« SIKIPESTAW, (v. a.) there is a deluge of rain
+« SIKIWEBINEW, (v. a.) NAM, NIWEW, NIKEW, he pours it by throwing it
+« SIKIKKWEW, ok, (v. n.) he pours blood, he leaks blood
+« SIKINAMÂWEW, etc., (v. a.) he pours him, e.g. to drink
+« SIKISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he spills it with his foot, e.g., by walking on it
+« SIKUNEW, (v. a.) NAM, NIWEW, NIKEW, he empties it, by spilling it
+« SIKUPAYIW, ok, a, (a. a. and in.) he empties himself, also: he is thin, meagre
+« SIKUNIGAN, ak, (n. f.) residue of grease, (gretons) or better,  sikusâgan
+« SIKUPÂTINEW, (v. a.) NAM, NIWEW, NIKEW, he lets it flow, he pours it through, e.g. pouring milk
+« SIKUPÂTINIGAN, a, (n. f.) hallway
+« SIKUWEPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he sifts it, he sieves it
+« SIKUWEPAYITCHIGAN, a, (n. f.) sieve, bluteau (Translator's Note: A bluteau is a type of sieve used to separate chaff from flour)
+« SIKUWEYÂTCHIKUKOWIHEW, (v. a.) TTAW, he filters it, he pours it
+SIKUKUTEW, ok, (v. n.) he has the hiccups
+
+592
+
+SIK
+
+x SIKÂKWAN, a, (n. f.) hock
+x SIKÂWIHUW,ok, (v. r.) he is in mourning
+« SIKÂWIW, ok, (a. a.) idem
+« SIKÂWIHUWIN, a, (n. f.) mourning
+x SIKATCHIW, ok, (a. a.) he is meagre, thin
+« SIKATCHIWIN, a, (n. f.) meagreness, thinness
+« SIKATIMEW, etc., (v. a.) he makes him meagre, thin
+« SIKATEYIMEW, etc., (v. a.) he finds him meagre, thin
+x SIKIW, ok, (v. n.) he urinates
+« SIKITEW, TAM, SIWEW, TCHIEW, he pisses on him
+« SIKIWIN, a, action of urinating
+« SIKIWINÂBUIY, a, (n. f.) urine
+« SIKIWIKAMIK, wa, urinal
+x SIKKATTEW, ok, (v .n.) he makes a fire with a lighter, he beats the fire
+x SIKKÂPÂTEW, (v. a.) TAM, SIWEW, TCHIKEW
+« SIKKÂPAYIW, ok, a, (a. a. and in.)
+x SIKKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he combs
+« SIKKAHUW, ok, (v. r.) he combs himself
+« SIKKAHUN, a, (n. f.) comb
+« SIKÂTISIW, ok, (a. a.) he has a difficult character
+x SIKUSKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he crushes it with his feet, or, sikukkawew
+« SIKUHWEW, (v. a.) HAM, HUWEW, HIKEW, he crushes it
+« SIKUWEPAHWEW, (v. a.) HAM, HUWEW, HIKEW, he crushes it by hitting it, by overturning it with a blow
+
+SIK
+
+« SIKUNEW, (v. a.) NAM, NIWEW, NIKEW, he crushes it with his hand
+« SIKUKOTCHIGAN, a, (n. f.) chopped, prepared tobacco
+« SIKUKOSUW, ok, (a. a.) he is chop, e.g. tobacco
+« SIKUKOTEW, a, (a. in.) idem
+« SIKUKOTEW, (v. a.) TAM, SIWEW, TCHIKEW, he chops it into little pieces
++ SIKKUW, ok, (v. n.) he spits
+« SIKKUWIN, a, (n. f.) saliva, spit
+« SIKKWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he spits on him
+x SIKKIMEW, etc., (v. a.) he orders him, he encourages him, he persuades him, he pushes him to do something
+« SIKKIHEW, etc., (v. a.) idem
+« SIKKIMOW, ok, (v. n.) he encourages, he persuades
+« SIKKIMOWIN, a, (n. f.) order, encouragement
+« SIKIKKEMOW, ok, (v. n.) like, sikkimow
+« SIKIKKEMOWIN, a, (n. f.) order, persuasion
+« SIKKIMIWEW, ok, (v. ind.) he tries to persuade, he encourages
+« SIKKIMIWEWIN, a, (n. f.) encouragement, exhortation
+« SIKISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he tempts him, he induces him to, etc., he pushes him to, etc., he gives him an example
+« SIKKISKÂKEW, ok, (v. ind.) (matchi-sikkikâkew) he pushes to evil
+« SIKKISKÂKEWIN, a, (n. f.) (matchi) evil temptation, wicked incitement to evil
+
+593
+
+SIM
+
+x SIKKIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he extends it, by pulling it
+« SIPEKIPITEW, etc., (v. a.) idem
+« SIPEKIPAYIW, ok, a, (a. a. and in.) it stretches, it elongates
+x SIKKIP, ak ,(n. r.) moorhen
+x SIKKIP, a, (n. r.) boil, swelling, carbuncle, osikkipimiw, he has a boil
+x SIKKUS, ak, (n. r.) ermine, weasel
+SIKIPAKAW, (v. imp.) it is bushy (with leaves)
+SIKKWÂTTIK, wok, (n. f.) cedar
+SIKWAN, (v. im.) spring, when the snow begins to melt, one says: miyoskamiw, when the leaves appear
+x SIKWATAHWEW, (a. a.) HAM, HUWEW, HIKEW, he crushes it, he grinds it
+« SIKWATAHIKÂSUW, ok, (a. a.) he is crushed
+« SIKWATAHIKÂTEW, a, (a. in.) idem
+« SIKWATAKAHWEW, (v. a.) HAM, HUWEW, HIKEW
+x SIMÂGÂN, ak, (n. r.) a sword, a spear
+« SIMÂGANIKKUMÂN, a, (n. f.) idem
+x SIMATCHIW, ok, (v. n.) he is tamed, he stands on his feet, his legs, e.g., a horse which is tamed
+« SIMATCHIKÂBAWIW, ok, (v. n.) idem
+« SIMATINEW, (v. a.) NAM NIWEW, NIKEW, he trains it, he puts it straight
+
+SIM
+
+« SIMATAPIW, ok, (a. a.) he is sitting right
+« SIMATCH (prep) straight, e.g., simatch pimuttew, he walks straight, simatistikwâneyiw, he has his head straight
+x SINIK, (rac.) to chafe, to rub, to wipe, to remove by rubbing, to brush, to soap
+« SINIKWAHWEW, (v. a.) HAM, HUWEW, HIKEW, he polishes it, he rubs it
+« SINIKUNEW, (v. a.) NAM, NIWEW, NIKEW, he rubs it with his hand
+« SINIKUSIMOW, ok, (v. r.) he rubs himself against something
+« SINIKUSIMOWIN, a, (n. f.) the action of rubbing oneself against, etc.
+« SINIKUSKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he rubs it against, etc.
+« SINIKUSTAW EHUSUW, ok, (v. r.) he rubs himself, e.g., he soaps his beard
+« SINIKUSTAWEHIGAN, a, (n. f.) bar of soap, brush
+« SINIKUSTAHWEW, (v. a.) HAM, HUWEW, HIKEW, he rubs his beard with a brush
+« SINIKUSTAWENEW, etc., (v. a.) idem, with his hand
+« SINIKUSIMEW, (v. a.) TTITAW, SIMIWEW, TCHIKEW, he rubs it against, he removes it by rubbing, e.g. his grime
+« SINIKUTTAKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he rubs it, he brushes it, e.g., when washing the floor
+« SINIKUTTAHIGAN, a, (n. f.) brush
+
+594
+
+SIP
+
+« SINIKWAHIGAN, a, (n. f.) that which is used to polish, e.g., a file
+« SINIKUSTAWENEW, etc., (v. a.) he puts his hand on him, e.g. on the beard
+« SINIKUSTAWENISUW, ok, (v. r.) he passes his hand on his beard
+« SINIKUPUYEW, (v. a.) TAW, YIWEW, TCHIKEW, he polishes it by filing it, or, by rubbing it against a stone, or something rough
+« SINIKUPUTCHIGAN, a, (n. f.) file, polisher
+« SINIKWÂPINEW, etc., (v. a.) he wipes his eyes (somebody else's)
+« SINIKWÂPINISUW, ok, (v. r.) he wipes his own eyes
+x SIPA (adv.) underneath, under, below
+« SIPÂYIK, (adv.) idem, e.g. sipa pimuttew, he walks underneath, sîpâyik apiw, he is seated underneath
+« SIPÂPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he passes it, he pulls it underneath, e.g., when passing a rope under the ice
+« SIPÂSKUPITEW, etc., (v. a.) idem
+« SIPÂPITCHIGAN, a, (n. f.) large needle to pass wire, small rope which one passes in a hem
+« SIPÂSKUPITCHIGAN, a, (n. f.) wood, or, rope, which one passes underneath, e.g. to reach a net under the ice, sipâstam, he passes underneath
+« SIPÂYÂTTIK, (adv.) under a tree
+« SIPÂSKUPITCHIGANEYÂPIY, a, (n. f.) rope for passing underneath (something)
+
+SIP
+
+« SIPÂSIW, ok, (v. n.) he passes underneath
+« SIPÂSTIK, tree, piece of wood, which passes underneath
+« SIPAPIW, ok, (a. a.) he is seated under
+« SIPÂYÂSIW, ok, (a. a.) he passes under by sail, or, pushed by wind
+x SIPIY, a, (n. r.) river
+« SIPIWIW, (v. im.) there is a river
+« SIPIKKÂN, a, (n. f.) canal
+x SIP, (rac.) that which stretches, that which spreads, which enlarges, that which is resistant, solid, which lasts a long time
+« SIPEKITÂS, a, (n. f.) woolen undergarments which stretch
+« SIPEKISKAWOTÂS, a, (n. f.) idem, or, which is solid
+« SIPEKIWEYÂN, a, (n. f.) cloth which stretches
+« SIPEKINEW, (v. a.) NAM, NIWEW, NIKEW, he expands it, he stretches it
+« SIPEKIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, idem, by pulling it
+« SIPEKIPAYIW, ok, a, (a. a. and in.) it expands, streches
+« SIPEKISKISIW, ok, (a. a.) idem
+« SIPEKISIW, ok, (a. a.) idem
+« SIPEKISKAW, a, (a. in.) idem
+« SIPEKISKAWÂTJIGAN, ak, (n. f.) woolen stockings, breeches
+« SIPEKAHWEW, (v. a.) HAM, HUWEW, HIWEW, he stretches it, he expands it with effort
+« SIPEKASKISIN, a, (n. f.) rubber shoe
+« SIPEYÂSKWAN, (v. imp.) there is a clearing, in the forest, that is to say, the trees are not close to one another
+
+595
+
+SIP
+
+« SIPEYAW, (adv.) there is space, e.g. in the woods
+« SIPEYITCHIKEW, ok, (v. ind.) he bears, he endures
+« SIPEYITTAM, wok, (v. n.) he is patient
+« SIPEYITTAMOWIN, a, (n. f.) patience
+« SIPEYIMEW, etc., (v. a.) he endures it with patience, or, he thinks him to be patient, perseverant
+« SIPIW, ok, (a. a.) he expands, he stretches
+« SIPIYAWESIW, ok, (a. a.) he is patient, perseverant
+« SIPIYAWESIWIN, a, (n. f.) patience, perseverance
+« SIPIWISIW, ok, (a. a.) he is resistant, strong
+« SIPIWISIWIN, a, (n. f.) strength, vigour
+« SIPAN, wa, (a. in.) it is strong, resistant, e.g. a cloth
+« SIPAW, a, (a. in.) idem
+« SIPIKKUSIW, ok, (a. a.) he is blue
+« SIPIKKWAW, a, (a. in.) idem
+« SIPIKKASÂKAY, a, (n. f.) blue hood, piece of clothing
+« SIPIKKWEGIN, wa, (n. f.) blue cloth, sheet
+« SIPIKKWEKISIW, ok, (a. a.) he is blue (when speaking of Indian cloth, etc.)
+« SIPIKKWEGAN, wa, (a. in.) idem
+« SIPIKKWASIW, ok, (a. a.) he resists sleep for a long time
+« SIPINEW, ok, (a. a.) he is strong against evil, he resists sickness, he endures it courageously
+
+SIP
+
+« SIPINISKEYIW, ok, (a. a.) his arms resist a long time
+« SIPINEW, (v. a.) NAM, NIWEW, NIKEW, he makes it last, exist for a long time
+« SIPISIW, ok, (a. a.) he is resistant, he lasts a long time
+« SIPAW, a, (a. in.) idem
+« SIPIKIKKAW, ok, (a. a.) he is old a long time, he resists old age
+« SIPIKKISIW, ok, (a. a.) he is resistant, durable
+« SIPIKKAW, a, (a. in.) idem
+« SIPITTAWEW, (v. a.) he disobeys him. One always says this with reduplication, sâsipittawew, etc.
+« SASIPITTAM, wok, (v. n.) he is disobedient
+« SIPAHWEW, (v. a.) HAM, HUWEW, HIKEW, e.g. to stretch, to lay a skin over a piece of wood, to dry a wolf skin on a cast
+« SIPAHIGAN, a, (n. f.) cast for drying pelts
+« SIPASKISUW, ok, (a. a.) he is solidly fixed (in place)
+« SIPASKITEW, a, (a. in.) idem
+« SIPÂSKWÂHWEW, (v. a.) HAM, HUWEW, HIKEW, he packs it, e.g., to pack a horse's collar
+« SIPÂSKWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, idem
+« SIPUSTAHWEW, (v. a.) HAM, HUWEW, HIKEW, he joins all of the parts to close it, e.g., the opening of a bag
+« SIPUTINEW, (v. a.) NAM, NIWEW, NIKEW, he closes it, e.g., a door
+« SIPAPPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he closes it, by attaching it
+
+596
+
+SIS
+
+« SIPUTTEW, ok, (a. a.) he is resistant to walking
+x SIPWE,(prefix) which indicates: to begin to do something; e.g., sipwe-pikiskwew, he begins to speak; sipwe-mâtuw, he begins to cry. See. Ati
+« SIPWEYÂSIW, ok, (a. a.) he leaves by sail
+« SIPWEYÂSTAN, wa, (a. in.) it is carried away by the wind
+« SIPWATCHÂKWEW, ok, (v. n.) he dies, his soul leaves
+« SIPWEHAM, wok, (v. n.) he begins to sing, or, he leaves in a canoe
+« SIPWEPAYIW, ok, a, (a. a. and in.) he leaves, it begins
+« SIPWETTAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he leaves it, he takes it away
+« SIPWEPAYIHEW, etc., (v. a.) idem
+« SIPWETTEW, ok, (v. n.) he leaves
+« SIPWETTEWIN, a, (n. f.) departure
+« SIPWETISAHWEW, (v. a.) HAM, HUWEW, HIKEW, he makes him leave
+« SIPEKUPIY, a
+« SISISKUW, ok
+« SISIKWÂBISKAW
+x SISIKWAN, ak, (n. r.) small, banded parchment bag, in which small stones are kept; instrument for rhythmically shaking during conjurations
+x SISIKUTCH, (adv.) suddenly, all of the sudden
+« SISISKÂTCH, (adv.) idem
+« SISIKUTCHIHEW, etc., (v. a.) he surprises him, he takes him by surprise
+
+SIS
+
+« SISIKUTCHIWIYEW, etc., (v. a.) idem
+« SISIKUTCHIMEW, etc., (v. a.) he stuns him, he surprises him, by speaking to him
+« SISIKUTEYIMEW, etc., (v. a.) he is stunned by thinking of him
+« SISIKUTEYITTAM, wok, (v. n.) he is stunned, surprised
+« SISIKUTAPINEW, ok, (v. n.) he is sick all of the sudden, or, he dies suddenly
+x SISIB, a, (n. r.) duck
+« SISIBIPIMIY, a, (n. f.) duck fat
+« SISPÂSKWAT, a, (n. f.) sugar which the Indians make with wild maple
+« SISIPÂSKWATÂTTIK, wok, (n. f.) maple
+« SISIPÂSKWATIKÂKEW, ok, (v. n.) he makes sugar with it
+« SISPÂSKWATIKÂTEW, (v. a.) TAM, he sugars it
+« SISIPÂSKWATIKAWEW, etc., (v. a.) he makes sugar for him
+« SISIPÂSKWATÂTTIKUSKAW, (v. im.) there are many maples
+« SISIBASSINIY, a, (n. f.) small shot for ducks
+« SISIBWÂWI, a, (n. f.) duck egg
+« SISIBWASKIK, wok, (n. f.) tea boiler, duck
+« SISIBWASKIKUS, ak, (n. f.) teapot
+« SISIPUTCHIGAN, a
+« SISIPUYEW, (v. a.) TAW, YIWEW, TCHIKEW
+x SISOHIGAN, a, (n. r.) painting. See. Sisopekahigan
+
+597
+
+SIS
+
+« SISOHWEW, (v. a.) HAM, HUWEW, HIKEW, he paints it
+« SISONEW, (v. a.) NAM, NIWEW, NIKEW, he rubs it, he chafes it, or better:
+« SISOPEKINEW, (v. a.) NAM, NIWEW, NIKEW, idem
+« SISONIGAN, a, (n. f.) rub, liniment
+« SISOPEKINIGAN, a, (n. f.) idem
+« SISOPEKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he rubs it with a liquid. Also: he paints it
+« SISOPEKAHIGAN, a, (n. f.) rubbing with a liquid. Also: painting
+« SISOPEKAHIGANÂTTIK, wok, (n. f.) paintbrush
+« SISOSKIWOKINEW, (v. a.) NAM, NIWEW, NIKEW, he paints with the earth, or with lime, he whitens it
+« SISOSTAKAHIGAN, a, (n. f.) wax
+« SISUTTEW, ok, (v. n.)
+« SISWEPEKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he spreads water on him
+« SISIKIW, ok, (a. a.) he makes fire, e.g., a stone or a lighter which starts fire well
+x SISONÊ, (adv.) the length of
+« SISONEW, (v. a.) NAM, NIWEW, NIKEW, he touches it across its whole length
+« SISONEPAYIW, ok, a, (a. a. and in.) he (it) goes the whole length
+« SISONETCHIMEW, ok, (v. n.) he goes the whole length, being on the water
+« SISONEHAM, wok, (v. n.) idem
+« SISONESKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he goes the whole length of him, of it
+
+SIS
+
+« SISONEWUTTEW, ok, (v. n.) he walks the length
+x SISIKIYÂWATIM, wok, (n. f.) spotted, pivoted horse, word of the country
+« SISWEPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he extends it from one end to the other, he spreads it, he disperses it. See. Saswepayihew
+x SITTAPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he attaches it tight, or, he tightens it
+« SITTAHWEW, (v. a.) HAM, HUWEW, HIKEW, he knocks it tightly, e.g., to knock a peg in very tightly, or two pieces of wood fixed together very tightly
+« SITTAWISIW, ok, (a. a.) he is stiff, inflexible
+« SITTAWAW, a, (a. in.) idem, e.g. starched
+« SITTASTÂPEW, ok, (v. n.) he bends his bow stongly
+« SITTAWAHWEW, (v. a.) HAM, HUWEW, HIKEW, he makes it stiff, he starches it
+« SITTAWAHIGAN, a, (n. f.) starch
+« SITTAMOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he joins it together strongly
+« SITTISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he tightens it, he presses it, he compresses it, e.g., ni sittisken ni'skutâkay, my clothes tighten on me, hamper me, or, ni sittiskâkun ni'skutâkay
+« SITTWASPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he clicks it
+
+598
+
+SIT
+
+x SITTA, k, (n. r.) cypress, type of spruce
+« SITTÂPIKKWÂN, ak, (n. f.) knob which forms at the bottom of spruce branches
+x SITCHIPAYIW, ok, a, (a. a. and in.) he contracts, he tightens
+« SITCHIPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he tightens it, he contracts it
+« SITCHIPAYITCHIGAN, a, (n. f.) instrument for tightening, vice
+« SITCHISIN, wok, (a. a.) he is tightened, lying down
+« SITCHITTIN, wa, (a. in.) idem
+« SITCHISIMEW, (v. a.) TTITAW, SIMIWEW, TCHIKEW, he tightens it, he presses it
+« SITISKAMÂTUWOK, (v. m.) they press against one another, e.g. the (people in the) crowd press against one another
+« SATISKAMÂTUWIN, a, (n. f.) press
+« SITCHIW, ok, (v. n.) he forces, he makes an effort
+« SITCHIWIN, a, (n. f.) the action of forcing
+« SITCHIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he forces it, he holds it under pressure, he worries him
+« SITCHIWIYEW, etc., (v. a.) idem
++ SITUNEW, (v. a.) NAM, NIWEW, NIKEW, he supports it, he backs it up, or, situskawew
+« SITUWISIW, ok, (a. a.) he is supported, held up
+« SITUWIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he supports it, he backs it up
+« SITUWIYEW, etc., (v. a.) idem
+« SITUWÂSKUSIMEW, (v. a.) TTITAW, SIMIWEW, TCHIKEW, he places it on a support
+
+SIT
+
+« SITUWÂSKUSIN, wok, (a. a.) he is propped up against
+« SITUWÂSKUTTIN, wa, (a. in.) idem
+« SITAWAHWEW, (v. a.) HAM, HUWEW, HIKEW, he puts supports under him
+« SITAWAHIGAN, a, (n. f.) support, pillar, column
+« SITWÂSKWAHIGAN, a, (n. f.) strut, pillar
+« SITWÂSKWAHWEW, (v. a.) HAM, HUWEW, HIKEW, he props it up, he struts it
+x SIW, (rac.) sour, sweet, salty, bitter
+« SIWISIW, ok, (a. a.) he is sour, sweet, or, salty
+« SIWAW, a, (a. in.) idem
+« SIWIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he salts it, or, he sweetens it
+« SIWIMEW, (v. a.) NAM, NIWEW, NIKEW, idem
+« SIWÂGAMIW, (v. im.) he is sweet, salty, a liquid
+« SIWÂGAMITTAW, ok, (v. a. in.) he salts it, or, he sweetens it, when speaking of a liquid
+« SIWAGAMISWEW, (v. a.) SAM, SUWEW, SIKEW, he makes it salty, or, sweet, e.g. by boiling it
+« SIWÂGAMISIGAN, a, (n. f.) that which is used to salt, or, to sweeten
+« SIWITTÂGAN, a, (n. f.) salt
+« SIWITTÂGANÂBUIY, a, (n. f.) brine
+« SIWÂBUIY, a, (n. f.) vinegar
+« SIWIPAK, wa, (n. f.) sour leaf, rhubarb
+
+599
+
+SOK
+
+« SIWISKÂTÂSK, wok, (n. f.) sour root
+« SIWITTÂGANISÂBOSIGAN, a, (n. f.) purging salt, Epsom salt
+« SIWITTÂGANIKKEW, ok, (v. n.) he makes salt
+« SIWITTIN, wa, (c. in.) it is sour
+« SIWATEW, ok, (a. a.) he smells soreness in his body, he is hungry, he feels an empty stomach
+« SIWÂSUW, ok, (a. a.) the sun hurts his eyes
+« SIWÂSTEW,
+x SIWIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he rings it, e.g., a bell
+« SIWEPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, idem
+« SIWEPAYIW, ok, a, (a. a. and in.) he (it) rings, it makes a sound
+« SIWÂWEYÂGAN, a, (n. f.) bell, cowbell, or, sisoweyâgan
+x SOKAW, ok, (n. r.) white sugar
+« SOKÂWIMAKKAK, wa, (n. f.) barrel of white sugar
+x SOKK, (rac.) strongly, firmly, with power
+« SOKKAHÂTCH, (adv.) many, finally, e.g., sokkahâtch kisiwâsiw, finally he became angry (though he typically does not)m sokkahâtch ka kotâmân ni mitâten, I regret having acted so badly, tâpwe sokkahâtch ki kakebâtisin, you are rather irritated, sokkahâtch ki mayi-totawin, you are doing me a lot of harm
+« SAKKÂGAMIW, (v. imp.) he is very strong (when speaking of a liquid)
+
+SOK
+
+« SOKKÂPEKISIW, ok, (a. a.) he is very strong (when speaking of cloth, Indian cloth, etc.)
+« SOKKÂPEKAN, wa, (a. in.) idem
+« SOKKÂBISKUSIW, ok, (a. a.) he is very strong, when speaking of metal
+« SOKKÂBISKWAN, wa, (a. in.) idem
+« SOKKÂSKUSIW, ok, (a. a.) he is very strong, (when speaking of wood)
+« SOKKÂSKWAN, wa, (a. in.) idem
+« SOKKÂSKUNEW, (v. a.) NAM, NIWEW, NIKEW, he bends it strongly, e.g., a bow
+« SOKKÂTISIW, ok, (a. a.) he has a strong character
+« SOKKÂTAN, wa, (a. in.) idem
+« SOKKÂTISIWIN, a, (n. f.) strength of character, power
+« SOKKÂYOWISIW, ok, (a. a.) he is strong, powerful
+« SOKKÂYOWISIWIN, a, (n. f.) strength, power
+« SOKKEGIN, wa, (n. f.) strong cloth, Indian cloth, sheet
+« SOKKEKISIW, ok, (a. a.) he is strong (when speaking of goods)
+« SOKKEKAN, wa, (a. in.) idem
+« SOKKÂBEWIW, ok, (a. a.) he is a strong man
+« SOKKÂBEW, ok, (n. f.) a strong man
+« SOKKASTWÂW, ok, (v. n.) he behaves with strength, vigour, courage
+« SOKKASTWÂWIN, a, (n. f.) strength, courage
+« SOKKASWEW, (v. a.) SAM, SUWEW, SIKEW, he burns it a lot
+« SOKKASUW, ok, (a. a.) he is hard in the fire
+
+600
+
+SOK
+
+« SOKKATEW, a, (a. in.) idem
+« SOKKATÂMOW, ok, (v. n.) he has a loud voice, he sings loudly
+« SOKKATÂMOWIN, a, (n. f.) loud singing
+« SOKKATCHÂKWEW, ok, (a. a.) he has a strong soul
+« SOKKATCHÂKWEWIN, a, (n. f.) strength of the soul
+« SOKKATCHIW, ok, (a. a.) he is hard in the cold
+« SOKKATIN, wa, (a. in.) idem
+« SOKKEKUTCHIN, wok, (a. a.) he passes quickly, e.g. a horse who is running a race
+« SOKKEKUTTIN, wa, (a. in.) idem, e.g. an arrow loosed strongly
+« SOKKWEWEKUTCHIN, wok, (a. a.) idem
+« SOKKWEWEKUTTIN, wa, (a. in.) idem
+« SOKKEIMEW, etc. (v. a.) he thinks him to be strong, courageous, he rests on him
+« SOKKEYITTAM, wok, (v. n.) he is strongly decided
+« SOKKEYITTAMOWIN, a, (n. f.) strong, courageous resolution
+« SOKKEYIMOW, ok, (v. r.) idem, or, he believes himself to be strong, courageous
+« SOKKEYIMOWIN, a, (n. f.) strong, courageous resolution
+« SOKKEYITTÂKUSIW, ok, (a. a.) he is strong, resistant, courageous
+« SOKKEYITTÂKWAN, wa, (a. in.) idem
+« SOKKI, (adv.) strongly, much, very, e.g., sokki mâtuw, he cries a lot, sokki pikiskwew, he speaks with strength
+
+SOK
+
+« SOKKITTÂKUSIW, ok, (a. a.) he has a loud tone of voice
+« SOKKITTÂKWAN, wa, (a. in.) it is a loud sound
+SOKKIKÂBIWIW, ok, (v. n.) he stands up strongly
+« SOKKITEHEW, ok, (a. a.) he has a strong heart, he is courageous, valiant
+« SOKKITEHEWIN, a, (n. f.) strength of heart, bravery, valiance
+« SOKKAHYEW, (v. a.) STAM, YIWEW, TCHIKEW, he places it solidly, strongly
+« SOKKASKISUW, ok, (a. a.) he is fixed (in place) solidly
+« SOKKASKITEW, a, (a. in.) idem
+« SOKKASKIYEW, (v. a) TAW, YIWEW, TCHIKEW, he plants it solidly
+« SOKKISIW, ok, (a. a.) he is strong, robust
+« SOKKAN, wa, (a. in.) idem
+« SOKKISIWIN, a, (n. f.) strength
+« SOKKIYAWEW, ok, (a. a.) he has a strong, robust body
+« SOKKIKÂTEW, ok, (a. a.) he has strong legs
+« SOKKIPITUNEW, ok, (a. a.) he has strong arms
+« SOKKISTIKWÂNEW, ok, (a. a.) he has a strong head
+« SOKKITCHIWAN, (v. im.) there is a strong, rapid current
+« SOKKISTIMEW, (v. a.) TAW, MIWEW, TCHIKEW, he adds yet more water to him, e.g. to refill a boiler whose contents have diminished by boiling
+
+601
+
+SON
+
+« SOKKAMISIW, ok, (a. a.)
+« SOKKAMAW, a, (a. in.)
+SOKKWEWESIN, wok, (a. a.) he makes a great noise, e.g., by passing like a gust of wind
+« SOKKWEWETTIN, wa, (a. a.) idem
+x SOMIN, ak, (n. r.) grape
+« SOMINÂTTIK, wok, (n. f.) grapevine, grape wood
+« SOMINÂTTIKOKISTIKÂN, a, (n. f.) grapevine, grape field
+« SOMINÂBUIY, a, (n. f.) wine
+« SOMINÂBUWIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes wine out of it, he changes it into wine
+« SOMINÂBUKKEW, ok, (v. n.) he makes wine
+x SONIYAW, ok, (v. r.) money/silver
+« SONIYÂWIW, ok, (a. a.) he is money/silver
+« SONIYANS, ak, (n. f.) small piece of money/silver
+« SONIYÂWIKKÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he silvers it
+« SONIYÂWIKAMIK, wa, (n. f.) bank
+« SONIYÂWAKKESIW, ok, (n. f.) silver fox
+x SONISKWÂTAHWEW, (v. a.) HAM, HUWEW, HIKEW, he slides above
+« SONISKWÂTAHAM, wok, (v. n.) he skates
+« SONISKWÂTAHIKEW, ok, (v. n.) idem
+« SONISKWÂTAHIGAN, a, (n. f.) skate
+
+SOP
+
+x SOPAMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he sucks it, he suckles it
+x SOSÂNASKWAW, (v. im.) it is slippery (ice)
+« SOSÂSKUSIW, ok, (a. a.) he is icy, smooth (wood)
+« SOSÂSKWAN, wa, (a. in.) idem
+« SOSKUNEW, (v. a.) NAM, NIWEW, NIKEW, he lets it slide, or, he smoothes it, he polishes it with his hand
+« SOSKUPAYIW, ok, a, (a. a. and in.) he (it) slides
+« SOSKUPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he slides it
+« SOSKUSIW, ok, (a. a.) he is slippery
+« SOSKWAW, a, (a. in.) it is slippery
+« SOSKUHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it slippery, he polishes it, he smooths it like ice
+« SOSKWÂGAMIW, (v. im.) smooth liquid
+« SOSKWÂPEKISIW, ok, (a. a.) he is sleek, smooth (merchandise)
+« SOSKWÂPEGAN, wa, (a. in.) idem
+« SOSKWÂPEGIN, wa, (n. f.) smooth, sleek cloth
+« SOSKWÂBISKUSIW, ok, (a. a.) he is smooth, sleek (metal)
+« SOSKWÂBISKWAN, wa, (a. in.) idem
+« SOSKWÂSKUSIW, ok, (a. a.) idem (wood)
+« SOSKWÂSKWAN, wa, (a. in .) idem
+« SOSKWEKISIW, ok, (a. a.) he is frozen, sleek (cloth)
+« SOSKWEGAN, wa, (a. in.) idem
+« SOSKWATCHIWEW, ok, (v. n.) he slides, going down
+
+602
+
+SOW
+
+« SOSKWATCHIWEWIN, a, (n. f.) sliding
+« SOSKWATCHIWEBINEW, (v. a.) NAM, NIWEW, NIKEW, he slides it, by throwing it
+« SOSKWAHWEW, (v. a.) he irons it with pieces of metal
+« SOSKWAHIGAN, a, (n. f.) iron for ironing
+« SOSKWANÂTAHWEW, etc. See. Soniskwatahwew
+« SOSKWANÂTAHIGAN, a, See. Soniskwâtahigan
+« SOSKWÂWEW, ok, (a. a.) he has sleek, slippery, smooth hair
+« SOSKWÂTCH, (adv.) right away, immediately, without delay
+x SOSOWATIM, wok, (n. f.) mule
+« SOSOWIMISTATIM, wok, (n. f.) idem
+« SOSOWATIMOWIW, ok, (a. a.) he is a mule
+x SOSUW, ok, (n. r.) donkey
+SOSIMEW, ok
+SOSPUPAYIW, ok, a, he becomes thin, he thins
+SOSPUPAYIHEW, he makes him thin
+SOWÂTCH, or, NOWÂTCH, (adv.) See Seyâkes
+x SOWIW, ok, he stretches his hands on, etc.
+« SOWINISKEW, ok, (v. n.) he stretches his arms towards, etc.
+« SOWINISKEYIW, ok, (v. n.) idem
+« SOWINISKESTAWEW, (v. a.) TAM, TÂKEW, TÂTCHIKEW, he stretches his arms towards him, or on him
+« SOWITCHITCHEW, ok, (v. n.) he stretches his hands towards, etc.
+
+SOW
+
+« SOWITCHITCHESTAWEW, etc., (v. a.) he stretches his hands towards him, on his, he places his hands on him
+« SOWAKKEW, ok, (v. n.) e.g., a bird which glides about to rest, he begins to close his wings
+« SOWISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW
+TAKK, (rac.) cold, the action of the cold on something
+« TAKKISIW, ok, (a. a.) he is cold
+« TAKKISIWIN, a, (n. f.) the cold
+« TAKKAW, a, (a. in.) it is cold
+« TAKKÂYAW, ok, a, (a. a. and in.) he (it) is cold
+« TAKKÂBÂWAYEW, (v. a.) TAW, YIWEW, TCHIKEW, he cools it with water
+« TAKKÂBISKISIW, ok, (a. a.) he is cold (metal)
+« TAKKÂBISKAW, a, (a. in.) idem
+« TAKKÂSKISIW, ok, (a. a.) he is cold (wood)
+« TAKKÂSKWAN, wa, (a. in.) idem
+« TAKKIYOWEW, (v. imp.) cool air, wind
+« TAKKIYOWEPAYIW, (v. im.) idem
+« TAKKIGAMÂBUIY, a, (n. f.) cold liquid
+« TAKKIGAMÂBUKKEW, ok, (v. n.)  he cools a liquid
+« TAKKIGAMIW, (v. im.) he is cold (liquid)
+« TAKKIPIY, (n. f.) cold water
+« TAKKISIMEW, (v. a.) TTITAW, SIMIWEW, TCHIKEW, he makes it cold
+
+603
+
+TAK
+
+« TAKKINEW, (v. a.) NAM, NIWEW, NIKEW, he makes it cold, by touching it with his cold hand
+« TAKKIPISKWANEW, ok, (a. a.) he has a cold back
+« TAKKIPISKWANEWATCHIW, ok, (a. a.) his back is cold
+« TAKKIPAYIW, ok, a, (a. a. and in.) he (it) cools down
+« TAKKIPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he cools it
+« TAKKAPIW, ok, (a. a.) e.g., a cooked duck, which one leaves to cool
+« TAKKASTEW, a, (a. in.) idem
+x TÂKKINEW, (v. a.) NAM, NIWEW, NIKEW, he touches it with his hand
+x TÂKKOMEW, (v. a.) TAM, MIWEW, TCHIKEW, he speaks of him, he speaks on his account
+TAKKI, (adv.) always, without stopping
+TAKKINÊ (adv.) idem
+x TAKKAMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he darts it, he strikes it with a pointed instrument, he stabs it
+« TAKKATCHIGAN, a, (n. f.) dagger, spike
+« TAKKWAMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he chews it, he holds it in his teeth
+« TAKKWAMOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he presses it, he puts it in a press
+« TAKKWAMOTCHIGAN, a, (n. f.) a vice, a press
+« TAKKWAKEW, ok, (v. im.) he chews
+x TAKISKÂTCHIKEW, ok, (v. ind.) he kicks
+
+TAK
+
+« TAKISKÂTCHIKEWIN, a, (n. f.) the action of kicking
+« TAKISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he kicks it, he hits him with his foot
+« TAKISKÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, idem
+x TAKAKKÂYI, (adv.) it is beautiful, it is magnificent
+« TAKAKKISIW, ok, (a. a.) he is magnificent, highly priced
+« TAKAKKAW, a, (a. in.) idem
+« TAKAKKATIM, wok, (n.f.) beautiful, excellent horse
+« TAKAKKEYIMOW, ok, or, MISUW, ok, (v. r.) he has a high idea of himself
+« TAKAKKEYIMOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he encourages him, he comforts him
+x TAKUTCH, (adv.) above, on, e.g., takutch pimuttew, he walks above; takutch tettapiw, he is sitting above
+« TAKUTCHAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he puts it above, etc.
+« TAKWAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he adds it, etc.
+« TAKUNEW, (v. a.) NAM, NIWEW, NIKEW, idem
+« TAKUTCHIKÂBAWIW, ok, (a. a.) he is standing above
+« TAKUTCHIKÂBAWISTAWEW, (v. a.) TAM, TÂKEW, TÂTCHIKEW, he is standing on him
+TAKUTCHISIN, wok, (a. a.) he is lying above, he is placed above
+
+604
+
+TAK
+
+« TAKUTCHITTIN, wa, (a. in.) idem
+« TAKUSKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he walks on him, he tramples him underfoot
+« TAKUSKÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, idem
+« TAKUTCHÂMATIN, wa, (n. f.) the summit of the hill, of the mountain
+« TAKUTCHÂMATIN, (v. im.) it is the summit of the hill, or on the summit of the hillock, the hill
+« TAKUTCHÂMATCHIWEW, ok, (v. n.) he climbs on the top of the hill, of the mountain
+« TAKUTAPIW, ok, (a. a.) he is above, etc.
+« TAKUTASTEW, a, (a. in.) idem
+« TAKUTASTOWEW, etc., (v. a.) he puts it above him
+« TAKUTATATCHIWEW, ok, (v. n.) he reaches the summit
+« TAKU-MIYEW, etc., (v. a.) he gives him surplus, he gives him more
+« TAKUNAMÂWEW, etc., (v. a.) idem
+« TAKUPITCHIW, ok, (v. n.) he arrives with his lodge, he joins up with the camp
+« TAKUPISUW, ok, (a. a.) he is bound, attached
+« TAKUPIEW, a, (a. in.) idem
+« TAKUPISUNÂBISK, wa, (n. f.) pieces of metal for chaining prisoners, handcuffs
+« TAKUPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he attaches it, he joins it by binding
+
+TAK
+
+« TAKUPAYIW, ok, (v. n.) he arrives
+« TAKUSIN, wok, (v. n.) idem
+« TÂKUSINOWIN, a, (n. f.) arrival
+« TAKUSKEW, ok, (v. n.) he takes steps, he comes forth, he walks
+« TAKUSKEWIN, a, (n. f.) step, walking, e.g., peyak takuskewin, a step
+« TAKWÂSIW, ok, (a. a.) he arrives by sail, or, pushed by the wind
+« TAKWÂSKUW, ok ,(v. n.) he joins himself with the band, he arrives to join with the others
+« TAKUW, ok, (v. n.) idem
+« TAKUTTEW, ok, (v. n.) idem
+« TAKUN, inanimate suffix, which joins to the two following roots, e.g. namatakun, wa, he does not take steps there, ittakun, wa, there are some; for the year. See. Tew
+« TAKUWÂTCH, (adv.) close, step by step. See. Kisiwâk
+« TÂTAKUSIWÂTCH, (adv.) idem
++ TAK, (rac.) N.B. This root is seldom used, it appears to be pronounced tchak, more of ten than tak, which means: short, not long
+« TAKUKÂBAWIW, ok, (a. a.) he is short in stature
+« TAKUKÂTEW, ok, (a. a.) he has small legs
+« TAKWAHAMEW, ok, (v. n.) he takes small steps
+« TAKWÂ ASTOYUW, ok
+« TAKUKWÂYOWEW, ok, (a. a.) he has a short body
+« TAKUPITUNEW, ok, (a. a.) he has short arms
+
+605
+
+TAM
+
+« TAKUSIW, ok, (a. a.) he is short
+« TAKWAW, a, (a. in.) idem
+x TAKWÂKIN, wa, (n. r.) the autumn
+« TAKWÂKIN, (v. im.) it is autumn
+« TAKWÂKOK, (adv.) last autumn, ke takâkik, next autumn
+x TAKWAHWEW, (v. a.) HAM, HUWEW, HIKEW, he pounds it, he grinds it, he crushes it
+« TAKWAHIGAN, a, (n. f.) mortar for pounding
+« TAKWAHEMINÂN, a, (n. f.) cherry
+« TAKWAHEMINÂNÂTTIK, wok, (n. f.) cherry tree
+x TAKKUNEW, (v. a.) NAM, NIWEW, NIKEW, he holds it in his hands
+« TAKKUNIGAN, a, (n. f.) that which is used to hold, shaft, handle
+« TAKKWAHAM, wok, (v. a. in.) he holds the rudder
+« TAKKWAHIKEW, ok, (v. ind.) idem
+« TAKKWAHAMOTAK, wa, (n. f.) rudder
+« TAKKWAHAMWÂBUIY, a, (n. f.) idem
+« TAKKWAHAMWÂGAN, a, (n. f.) idem
+« TAKKWAHAMWÂGANÂTTIK, wa, (n. f.) idem
++ TAMASKÂPINEW, etc., (v. a.) he greases his eyes (somebody else's)
+« TAMASKÂPINISUW, ok, (v. r.) he greases his own eyes
+« TAMASKUW, ok, (v. n.) he greases his hair
+
+TAM
+
+« TAMASKUNEW, (v. a.) TAM, NIWEW, NIKEW, he greases it, he anoints it
+« TAMASKUSITINEW, etc., (v. a.) he anoints his feet
+« TAMASKUTCHITCHENEW, etc., (v. a.) he greases his hands
+« TAMASKUWIN, a, (n. f.) ointment, grease, pomade
+« TAMASKWÂN, a, (n. f.) idem
+x TÂISPI? or, TÂNISPI? (adv. interr.) (past) when? at what time? e.g., tâispi ki wâbamaw? when did you see him?
+« TÂNEYIKOK? (adv. interr.) (of quantity and future time) when? how many? e.g., tâneyikok ke wâbamat? when will you see him? tâneyikok ki wi-miyin? how many do you want to give me?
+« TÂNDA? (adv. interr. of place) where? (closer)
+« TÂNDÉ? (adv. inter.. of place) where? (farther) e.g., tandé wetutteyan? where did you come from? tandé eyât? where is he? tânda ka wanittâyan? what place did you lose it in?
+« TÂNISI? (adv. interr.) how? in what way? e.g., tânisi etweyan? what are you saying? tânisi ejinâkwak? what colour is it?
+« TÂNISI ITUKE, (adv.) I do not know, it is doubtful
+« TÂNIKA! (ex.) expression of desire, of longing, e.g., tânika anotch takusik! if only he arrived today! or, if only he arrives today. See. Tâpika
+« TÂNEKI? (adv. interr.) why?
+« TÂNIPIKO, (adv.) e.g., tânipiko ke itutteyân? I don't know where it would be better to go
+
+606
+
+TÂP
+
+« TÂNTATTO? (adv. interr. of number) how many? e.g., tântatto ayisiyiniwok ki wâbamâwok? how many men did you see? tantatto etasitwaw kit'emak? what number of horses have you got?
+« TÂNTATTO ITUKE, (adv.) the number is uncertain, I do not know
+TÂNIWA? (pron. interr. an.) where is he?
+« TÂNIWEKA? (pron. interr. plur. an.) where are they? (an.)
+« TÂNIMA? (pron. interr. inan.) where is it?
+« TÂNIMÂHI? (pron. interr. in.) where are they? (inan.)
++ TÂP, (rac.) to be at the place, as if, etc., seemingly
+« TÂPÂKKOWEW, (v. a.) TTAM, MIWEW, TCHIKEW, he adopts him
+« TÂPÂKKOMIWEW, (v. ind.) he adopts, he is related to, etc.
+« TÂPÂKKOMIWEWIN, a, (n. f.) adoption, the action of adopting
+« TÂPÂKKOTTUWOK, (v. m.) they are related
+« TÂPÂKKOTTUWIN, a, (n. f.) alliance
+« TÂPAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he replaces him
+« TÂPÂSKUSIMEW, (v. a.) TTITAW, SIMIWEW, TCHIKEW, he puts another in its place, he hafts it
+« TÂPÂSKUSIN, wok, (a. a.) he has a shaft
+TÂPÂSKUTTIN, wa, (v. in.) idem
+
+TÂP
+
+« TÂPÂSKWAHWEW, (v. a.) HAM, HUWEW, HIKEW, he fits a shaft on him
+« TÂPISIMEW, (v. a.) TTITAW, SIMIWEW, TCHIKEW, idem, also, he threads it, he passes it in
+« TÂPISIN, wok, (a. a.) he is hafted, threaded
+« TÂPITTIN, wa, (a. in.) idem
+« TÂPISKOTCH, (adv.) similarly, similar
+« TÂPITAWI, (adv.) idem
+« TÂPITAWEYIMEW, etc., (v. a.) he finds them all similar
+« TÂPITAWEYITTAMWOK, (v. n.) they all have the same idea
+« TÂPITAWIPAYIW, ok, a, (a. a. and in.) he (it) agrees, it all goes similarly
+« TÂPITAWEYITTUWOK, (v. m.) they agree with one another
+« TÂPISKOTCHIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he equalises it, he makes it similar, e.g., he makes it with the same weight
+« TÂPISKUTCHIPAYIW, ok, a, (a. a. and in.) it fits, it arranges itself in the same way
+« TÂPIPAYIW, ok, (a. a. and in.) idem
+« TÂPISKOTEYITCHIGAN, a, (n. f.) comparison
+« TÂPISKOTEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he finds it similar, he compares it
+« TÂPISKOTCHAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he makes them similar
+« TÂPISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he carries it around his neck
+
+607
+
+TÂP
+
+« TÂPISKÂGAN, a, (n. f.) handkerchief
+« TÂPISKAMÂWEW, etc., (v. a.) he succeeds him, he takes his place
+« TÂPAPIW, ok, he takes the place of somebody else
+« TÂPASTEW, a, (in.)
+« TÂPAPISTAWEW, etc., (v. a.) idem, he replaces it
+« TÂPISHWEW, (v. a.) HAM, HUWEW, HIKEW, he puts it on
+« TÂPIYÂWEMEW, (v. .a) TTAM, MIWEW, TCHIKEW
+« TÂPEYIMEW, etc., (v. a.) he guesses his thought(s), that is to say, his thought(s) agree with his, e.g., ni tâpeyimaw e wi-kîmit, I guess, I suspect that he wants to desert
+« TÂPINAWEW, (v. a.) NAM, NÂKEW, NÂTCHIKEW, he finds it similar, by looking at it
+« TÂPINÂKUSIW, ok, (a. a.) he appears similar
+« TÂPINÂKWAN, wa, (a. in.) idem
+« TÂPASINAHWEW, (v. a.) HAM, HUWEW, etc, he copies from him, and, he copies him
+« TÂPASINAHIGAN, a, (n. f.) copy
+« TÂPASINAHIKEWIYINIW, ok, (n. f.) copyist
+« TÂPITTEPISUN, ak, (n. f.) ear pendant
+« TÂPITTEPISUW, ok, (a. a.) he wears ear pendants
+« TÂPITCHEPISUN, ak, (n. f.) ring, for the finger
+« TÂPISKUSKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he puts his foot in
+
+TÂP
+
+« TÂPISKUSKÂTCHIGAN, a, (n. f.) stirrup
+« TÂPISKUSKÂTCHIGANEYÂBIY, a, (n. f.) band of leather for attaching stirrups
+« TÂPISIMINEW, ok, (v. n.) he threads on beads, seeds
+« TÂPISMINIKEW, ok, (v. n.) idem
+« TÂPISKÂGANEMINAK, (n. f.) bead necklace
+« TÂPISKIMINEW, ok, (v. n.) See. tâpisiminew
+« TÂPITONEPITCHIGAN, a, (n. f.) bridle
+« TÂPITONEPISUW, ok, (a. a.) he is bridled
+« TÂPITONEPITCHIGANEYÂBIY, a, (n. f.) bridle reins
+« TÂPOWEW, ok, (v. n.) he says similarly, that which he says agrees with, etc., e.g., when reciting a prayer without making any mistakes
+« TÂPOWEWIN, a, (n. f.) recitation by heart
+« TÂPOWESIMEW, (v. a.) TTITAW, SIMIWEW, TCHIKEW, he recites it similarly, by heart
+« TÂPISKUYÂWEMEW, etc., (v. a.) he consoles him, he remits him of his pain
+TAPASIS, (adv.) in the bottom, at the bottom
+x TAPASIW, ok, (v. n.) he flees, he runs away
+« TAPASIWIN, a, (n. f.) fleeing
+« TAPASIYÂMOW, ok, (v. n.) he flees with great fear
+« TAPASIYÂMOWIN, a, (n. f.) fleeing with great fear
+« TAPASIHEW, (v. a.) HIWEW, etc., he makes him flee, also: he flees from him
+« TAPASIWIYEW, etc., (v. a.) idem
+
+608
+
+TAP
+
+« TAPASITTAW, ok, (v. a. in.) he flees it
+« TAPASITTÂWIN, a, (n. n.) fleeing from something
+« TAPASISTAWEW, (v. a.) TAM, TÂKEW, TÂTCHIKEW, he flees him, he runs away from him
+x TAPATEYITTÂKUSIW, ok, (a. a.) he is low, in lowly conditions, humble, small, lowly
+« TAPATTEYITTÂKWAN, wa, (a. in.) idem
+« TAPATTEYIMISUW, ok, (v. r.) he is humble, he has low ideas of himself
+« TAPATTEYIMISUWIN, a, (n. f.) humility, low opinion of oneself
+« TAPATTEYIMISUSTAWEW, etc., (v. a.) he lowers himself before him
+« TAPATTEYIMOHEW, etc., (v. a.) he lowers himself, he humiliates himself
+« TAPATTEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he has a low opinion of him
+« TAPATTISIW, ok, (a. a.) he is short, of low stature, low
+« TAPATTAW, a, (a. in.) idem
+« TAPATCHIKÂBAWIW, (a. a.) idem
+« TAPATTISKWEYIW, ok, (v. n.) he lowers his head
+« TAPATTISKWEYISTAWEW, etc., (v. a.) he lowers his head before him
+« TAPATTEKUCHIN, wok, (a. a.) e.g. a bird which flies low, close to the ground
+« TAPATTEKUTTIN, wa, (a. in.) it is hanging, attached low
+
+TÂP
+
+x TÂPAKWEW, ok, (v. n.) he sets a trap, a snare, to catch beasts for furs
+« TÂPAKWÂN, a, (n. f.) trap, trapdoor
+« TÂPAKWÂTEW, etc., (v. a.) he catches it in a trap
+« TÂPAKAWEW, etc., (v. a.) he sets a trap for him
+TÂPIKA, (adv.) See. Kânika
++ TÂPWE, (ad.) it's true, truly
+« TÂPWE ITUKE (ad.) without doubt
+« TAPWE PIKO, (ad.) assuredly, certainly
+« TÂPWE PIKO ÂNI (ad.) very certainly
+« TÂPWE KANI, (adv.) truly, as a matter of fact, indeed
+« TÂPWEMAGAN, wa, (a. in.) it is true, it is the truth
+« TÂPWEW, ok, (v. n.) he speaks the truth
+« TÂPWEWIN, a, (n. f.) the truth
+« TÂPWEWINIWIW, (a. a.) it is the truth
+« TÂPWETTAWEW, (v. a.) TTAM, TTÂKEW, TTÂTCHIKEW, he believes it, he consents to what he says, he obeys him
+« TÂPWETTAM, wok, (v. n.) he consents, he obeys
+« TÂPWETTAMOWIN, a, (n. f.) consent, approval
+« TÂPWETTÂKUSIW, ok, (a. a.) he is credible
+« TÂPWETTÂKWAN, wa, (a. in.) idem
+« TÂPWEWOKEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he believes it, he believes in him, he has faith in him
+« TÂPWEWOKEYITTAMOWIN, (n. f.) (ayamihewi) faith
+
+609
+
+TAS
+
+« TÂPWEWOKEYITTAMOWINIWIW, (v. im.) (ayamihewi) it is faith
+« TÂPWEYEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks it to be true, real
+« TÂPWEYEYITTAMOWIN, a, (n. f.) belief
+« TÂPWEYEYITTÂKUSIW, ok, (a. a.) he is true
+« TÂPWEYEYITTÂKWAN, a, (a. in.) idem
+x TÂSAHWEW, (v. a.) HAM, HUWEW, HIKEW, he irons it, he sharpens it
+« TÂSAHIGAN, a, (n. f.) instrument for sharpening and ironing
+TÂSIPWA, (adv.) that's why
+x TASINEW, (v. a.) MAM, NIWEW, NIKEW, he loosens it, he lets go of the trigger (of a rifle)
+« TASINIGAN, a, (n. f.) trigger of a rifle
+x TASIKKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he is busy working on it, e.g., kekway ka tasikkaman? what are you busy working on>
+TASIHEW, TTAW, he is busy doing it, or better, tasikkamew, kkam
+TASIMEW, TTAM, he is busy speaking of him
+x TASIW, verbal suffix, e.g., tantatto itasiwok? how many of them are there?
+TASIPATOWÂBIW, ok
+x TASKAMAN, (v. im.) straight ahead, directly. See. Kaskaman
+« TASKAMUTTEW, ok, (v. n.) he goes straight, he makes a straight path
+
+TAS
+
+« TASKAMUTTEWIN, a, (n. f.) walking in a straight line
+« TASKAMIYAW, ok, (v. n.) he flies straight
+« TASKAMIPAYIW, ok, a, (a. a. and in.) he (it) goes straight
+« TASKAMISKUTTEW, ok, (v. n.) he makes a straight path on the ice
+« TASKAMAHAM, wok, (v. n.) he makes a straight path on the water
+x TÂSK, (rac.) to split, to separate
+« TÂSKIPAYIW, ok, a, (a. a. and in.) it is split
+« TÂSKÂKATOSUW, ok, (a. a.) he is split from dryness, heat
+« TÂSKÂKATOTEW, a, (a. in.) idem
+« TÂSKATAHWEW, (v. a.) HAM, HUWEW, HIKEW, he splits him by hitting on top of him
+« TÂSKINEW, (v. a.) NAM, NIWEW, NIKEW, he splits it with his hand
+« TÂSKISIW, ok, (a. a.) he is split
+« TÂSKIPUYEW, TAW, YIWEW, TCHIKEW, he splits it with a saw
+« TÂSKIPUTCHIKEW, ok, (v. ind.) he saws with a pitsaw
+« TÂSKIPUTCHIGAN, a, (n. f.) instrument for splitting by sawing, pitsaw
+« TÂSKISWEW, (v. a.) SAM, SUWEW, SIKEW, he cuts it by splitting it with scissors or a knife
+« TÂSKAMEW, (v. a.) TTAM ,MIWEW, TCHIKEW, he splits it with his teeth
+« TÂSKIKUTEW, TAM, SIWEW, TCHIKEW, he splits it with a knife
+« TÂSKIKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he splits it with an axe
+
+610
+
+TÂS
+
+« TÂSKIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he splits it by tearing it
+« TÂSKIPUTCHIKEWIKAMIK, wa, (n. f.) building where one saws
+« TÂSKISIKUPAYIW, ok, a, (a. a. and in.) it is split, cracked, e.g. ice
+« TÂSKISIKWAW, (v. im.) the ice is split
+« TÂSKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he splits it
+x TASOW, ok, (v. n.) he stands up, he gets on his feet
+« TASOWIN, a, (n. f.) the action of standing up
+« TASOPAYIW, ok, a, (a. a. and in.) it stands up
+« TASONEW, (v. a.) NAM, NIWEW, NIKEW, he stands it up with his hands
+« TASOPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he stands it up by pulling it, by making an effort with his arms
+« TASOKÂBAWIW, ok, (v. n.) he gets up standing
+« TASOTESKANEW, ok, (a. a.) he has straight horns
++ TASSOSOW, ok, (a. a.) he is caught in a trap, he is caught under a burden, he is crushed under something
+« TASSOTEW, a, (a. in.) idem
+« TASSOYEW, (v. a.) TAW, YIWEW, TCHIKEW, he catches him in a trap, and, he overwhelms him under a mass, a burden 
+x TÂSTÂKÂTCHIW, ok, (a. a.) he is slow, he takes time to act
+
+TÂS
+
+« TÂSTÂKÂTCHIWIN, a, (n. f.) slowness
+TÂSTASÂBIW, he looks up
+x TASTAWITCH, (adv.) between, between two
+« TASTAWÂYIK, (adv.) idem
+« TASTAWISIW, ok, (a. a.) he is between, etc.
+« TASTAWAW, a, (a. in.) idem
+« TASTAWIYES, (adv.) space between
+« TASTAWIWEYAW, (v. im.) idem
+« TASTAWIGAMAW, (v. in.) space between two lakes
+« TASTAWÂPITEHIGAN, a, (n. f.) fork
+« TASTAWÂPITEYAW, ok, a, (a. a. and in.) it is forked
+« TASTAWÂSKUTAW, ok, (v. a. in.) he puts it between two pieces of wood
+« TASTAWAHOKEW, ok, (v. n.) he places the lodge poles to fix the tent (in place)
+« TASTAWAHIGAN, a, (n. f.) scaffolding with poles
+x TASTAKISKWEYIW, a (n. f.) he holds his head up
+« TASTAWÂKABÂWISTAWEW, he is sitting in the middle of them
+x TASTASÂBIW, ok, (v. n.) he lifts his eyes
+« TATCHÂSTAPIW, ok, (a. a.) he hurries, he is lively
+« TATCHÂSTAPIWIN, a, (n. f.) haste, speed
+« TATCHASTÂPOWEW, ok, (v. n.) he speaks quickly, with haste
+« TATCHASTÂPOWEWIN, a, (n. f.) the action of speaking quickly
+« TATCHIWIYEW, (v. a.) TAW, YIWEW, TCHIKEW, he surprises him, he catches him off guard
+
+611
+
+TAS
+
+x TATCHÂMOSOW, ok, (v. n.) he sneezes
+« TATCHÂMOSOWIN, a, (n. f.) the action of sneezing, sneezing
+« TATCHÂMOSWEW, (v. a.) SAM, SUWEW, SIKEW, he makes him sneeze
+« TATCHÂMOSIGAN, a, (n. f.) medicine for sneezing, snuff. N.B. See. Tchatchâmow, which is the most common pronunciation
+x TÂTCHIKWÂTEW, etc., (v. a.) he shouts after him
+« TÂTCHIKWEW, ok, (v. n.) he cries (out)
+« TÂTCHIKWEWIN, a, (n. f.) a cry
+x TÂTCHIPUW, ok, (a. a.) he is fat, he remits himself of his thinness
+« TÂTCHIPUYEW, (v. a.) he makes him fat again
+TATCHIKÂTEW, ok, (a. a.) he is lame, crippled
+x TASWÂSKUW, ok, (v. r.) he spreads, he unfolds
+« TASWÂSKUPAYIHUW, ok, (v. r.) he spreads out to his full size
+« TASWEKATAHWEW, (v. a.) HAM, HUWEW, HIKEW, he spreads it by hitting it
+« TASWEKITCHIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he unfolds it, e.g., a cover
+« TASWEKAPIW, ok, (a. a.) he is unfolded, spread
+« TASWEKIPAYIW, ok, a, (a. a. and in.) idem
+« TASWEKASTEW, a, (a. in.) idem
+« TASWEKIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he spreads it, he unfolds it
+
+TAS
+
+« TASWEKISIMEW, TTITAW, he spreads it on the ground
+« TASWEKINEW, (v. a.) NAM, NIWEW, NIKEW, idem
+« TASWEKAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, idem
+« TASWAHYEW, etc., (v. a.) idem
+« TASWEKISIW, ok, (a. a.) he is spread out, unfolded
+« TASWEKAN, wa, (a. in.) idem
+x TATTAKUSIW, ok, (a. a.) he is smooth, polished, level
+« TATTAKWAW, a, (a. in.) idem
+« TATTAKWASKAMIK, (n. f.) flat terrain
+« TATTAKWASKAMIKAW, (v. im.) it is flat terrain
+x TATCHEB, (adv.) a bit of each, of every one, e.g. tatcheb miyik, give them all a piece
+x TATCHISIN, wok, (a. a.) he is too big to enter
+« TATCHITTIN, wa, (a. in.) idem
+« ATCHISIMEW, (v. a.) TTITAW, SIMIWEW, TCHIKEW, he cannot make it enter, being too big
+x TÂTOPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he tears it
+« TÂTOPAYIW, ok, a, (a. a. and in.) he (it) tears
+x TATTO, (adv.) as much as, etc.; e.g. eoko tatto, it is as much as, etc.; tântatto? how man; tatto kijikaw! every day; tatto pisim, every month
+« TATTOKEWOK, (a. a.) there are so many buildings, lodges
+
+612
+
+TÂW
+
+« TATTONISK, (n. f.) so many fathoms
+« TATTONISKESIW, ok, (a. a.) he has so many fathoms
+« TATTONISKEYAW, a, (a. in.) idem
+« TATTOSKÂNESIWOK, (a. a.) there are so many families, or, nations; kakiyaw tattoskânesitjik ayisiyiniwok, all of the nations
+« TATTWAYESIW, ok, (a. a.) it is so many more (furs)
+« TATTWAYEYAW, a, (a. in.) idem
+« TATTWAW, (adv.) repeatedly; e.g. tântattwaw? how many times? tattwaw kijikâki, every day
+« TATTWEYAK, (adv.) in so many fashions, ways, etc.; e.g., tântattweyak? in how many ways?
+TÂTPIHEW, (suffix) e.g., misiwe iji tâtpihew, he doesn't care anyway
+x TAW, (rac.) a space in the centre, or middle, where there is space, room, to hit the centre, the heart
+« TÂWITCH, (adv.) in the middle, on the middle of a lake, of a river; e.g., tâwitch akomow, he is sitting in the middle, e.g., a duck; tâwitch pimiskaw, he passes in the middle
+« TÂWOKÂM, (adv.) idem, in the middle of the water
+« TÂWÂKUNAK, (adv.) in the centre of the snow
+« TÂWÂKUNAKAW, (v. im.) there is space in the snow
+
+TÂW
+
+« TÂWISIW, ok, (a. a.) he has space, room
+« TÂWISIWIN, a, (n. f.) space, room
+« TÂWAW, a, (a. in.) there is space, e.g., someone enters into the house, or the lodge, one says to him: tawaw, there is rooom; as one says: have a seat
+« TÂWINEW, (v. a.) NAM, NIWEW, NIKEW, he makes room by removing it, or, placing it elsewhere
+« TÂWINAMÂWEW, etc., (v. a.) he makes room for him, he opens him a passage
+« TÂWISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he falls right on top, he arrives right on top of him
+« TÂWATIW, ok, (v .n.) he opens his mouth
+« TÂWÂYIK, (adv.) in the middle, in the midst
+« TÂWISIN, wok, (a. a.) he has a spae, e.g. a crack, a hole
+« TÂWITTIN, wa, (a. in.) idem
+« TÂWITCHITCHÂN, a, (n. f.) middle finger
+« TÂWIYETTIN, wa, (a. in.) e.g., a knife, an axe which has a chip
+« TÂWIYESIN, wok, (a. a.) he is chipped
+« TÂWIYESIMEW, (v. a.) TTITAW, SIMIWEW, TCHIKEW, he chips it
+« TÂWIKISIN, wok, (a. a.) he hits himself, he bumps into something which is in his way
+« TÂWIKITTIN, wa, (a. in.) idem
+« TÂWIKISIMEW, (v. a.) TTITAW, SIMIWEW, TCHIKEW, he bumps against, etc.
+
+613
+
+TÂW
+
+« TÂWITCHIWAN, (v. imp.) in the middle of the current
+« TÂWÂPITEW, ok, (a. a.) he has a space between his teeth
+« TÂWISTAWEW, etc., (v. a.) he makes room for him
+« TÂWIKAHIKEW, ok, (v. ind.) he opens a passage with an axe
+« TÂWIKAHWEW, (v. a.) HMA, HUWEW, HIKEW, he makes a passage in the middle of him, or it, with an axe
+« TÂWIKAHIKÂSUW, ok, (a. a.) the passage is opened
+« TÂWIKAHIKÂTEW, a, (a. in.) idem
+« TÂWÂTCHIKWEYÂWEHWEW, etc., (v. a.) he hits him on the neck
+« TÂWÂSKIGAN, a, (n. f.) the middle of the stomach. One also says this for: a half fathom
+« TÂWIPAYIW, ok, a, (a. a. and in.) it makes space, there is an opening
+« TÂWIPISKWANEHWEW, (v. a.) HAM, HUWEW, HIKEW, he hits him on the middle of the back, or, he shoots at the middle of the back
+« TÂWISTIKWÂNEHWEW, (v. a.) HAM, HUWEW, HIKEW, he hits him right on the head
+« TÂWÂHWEW, (v. a.) HAM, HUWEW, HIKEW, he hits him right in the centre, in the middle, in the heart, he inflicts him a mortal wound
+« TÂWAPISTAWEW, (v. a.) he makes a place for him to sit
+« TÂWÂSTAHWEW, (v. a.) HAM, HUWEW, HIKEW, See. Tâwâhwew
+
+TÂW
+
+« TÂWATINAW, (v. im.) valley, space between two hills, or mountains
+« TÂWATCHAW, (v. im.) between two elevations in the ground
+« TÂWASKAMIK, (n. f.) the middle of the ground
+« TÂWASKAMIKAW, (v. im.) it is the middle of the ground
+« TÂWÂSKWEYAW, (v. im.) the middle of a forest
+« TÂWÂTTIK, wok, (n. f.) the middle, the centre of a forest, of a tree
+« TÂWIW, ok, he hits in the middle, he hits accurately. One says this when someone wins a game
+x TWÂ, (rac.) to make a hole in the ice
+« TWÂHIPÂN, a, (n. f.) hole in the ice
+« TWÂHIGAN, a, (n. f.) idem
+« TWÂHWEW, (v. a.) HAM, HUWEW, HIKEW, he makes a hole there. This refers to the ice which one piereces to (get to) the water
+« TWÂHIPEW, ok, (v. n.) he makes a hole in the ice into the water
+« TWÂHIPÂNIKKEW, ok, (v. n.) See. Twâhipew
+« TWÂKUNESIN, wok, (a. a.) he sinks into the snow
+« TWÂKUNEHWEW, etc., (v. n.) he makes a hole in the snow
+« TWÂSIN, wok, (a. a.) he breaks the ice under his feet, he sinks under the ice
+« TWÂSIMEW, (v. a.) TTITAW, SIMIWEW, TCHIKEW, he wedges it under the ice
++ TAYÂKWATCH, (adv.) to the contrary, See. tiyakwatch
+
+614
+
+TEP
+
+x TÉ, (rac.) that which has trouble, difficulty, pain, sickness
+« TEHISTIKWÂNEW, ok, (a. a.) he has a headache
+« TEYÂBIW, or, TEWÂBIW, ok, (a. a.) his eyes hurt
+« TEYÂPITEW, or, TEWÂPITEW, ok, (a. a.) he has a toothache
+« TEYÂSKIKANEW, ok, (a. a.) his bones ache
+« TEHIPITUNEW, ok, (a. a.) his arms ache
+« TEHEW, ok, (a. a.) he has an ache in his heart
+« TEHEWIN, a, (n. f.) heartache
+« TEHISIW, ok, (a. a.) he feels pain
+« TEYÂPAHWEW, etc., (v. a.) he harms his face
+« TEYAPIW, or, TEWAPIW, ok, (a. a.) he suffers from being seated
+« TEYÂHWEW, etc., (v. a.) he harms him
+x TEH, (rac.) to stir
+« TEHWEW, (v. a.) HAM, HUWEW, HIKEW, he stirs it
+TEW, suffix (animate). See. takun, e.g., namatew, he is no more
++ TEP, (rac.) enough, that which is sufficient
+« TEPAHUNEW, (v. a.) NAM, NIWEW, NIKEW, he gives to everyone, he shares it in such a way as to be able to give some to everyone
+« TEPAHWEW, (v. a.) HAM, HUWEW, HIKEW, idem
+« TEPAKEYITTÂKUSIW, ok, (a. a.) he is worthy of
+« TEPAKEYITTÂKWAN, wa, (a. in.) idem
+
+TEP
+
+« TEPAKEYIMOW, ok, (v. r.) he finds it to be enough, he is satisfied
+« TEPAKEYIMOWIN, a, (n. f.) satisfaction
+« TEPAKIMEW, (v. a.) TTAM, NIWEW, TCHIKEW, he counts them all, to the end
+« TEPAPISTAWEW, etc., (v. a.) he is seated with him for quite a long time
+« TEPAPIW, ok, (a. a.) he is seated for quite a long time, or, tepapiwok, there is room to hold them all
+« TEPASTEW, a, (a. in.) there is enough room to hold them all
+« TEPÂSKIW, ok, (v. n.) he arrives on time
+« TEPÂSKISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he meets with him on time
+« TEPAKKAMIKISIW, ok, (a. a.) he has finished with everything that he was busy with
+« TEPAKKAMIKAN, wa, (a. in.) it is finished, all is satisfied
+« TEPAMOW, ok, a, (a. a. and in.) it holds enough
+« TEPAMOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it hold enough
+« TEPASKINEW, ok, a, (a. a. and in.) he is sufficiently full
+« TEPASKINEWIN, a, (n. f.) sufficience
+« TEPASKINAHEW, (v. a.) TTAW, HIKEW, TCHIKEW, he fills it sufficiently, enough
+« TEPEYITCHIKET, the Lord. See. Tibeyitchikew
+« TEPEYIMEW, etc., (v. a.) he is satisfied with the bad things that happen to him (to someone else), he rejoices in the misfortune of somebody else
+
+615
+
+TEP
+
+« TEPEYITTAM, wok, (v. n.) he is satisfied, he has enough of it
+« TEPEYIMOW, ok, (v. n.) he is consenting
+« TEPEYIMOWIN, a, (n. f.) consent, approval
+« TEPEYITTÂKUSIW, ok, (a. a.) he is worthy
+« TEPEYITTÂKWAN, wa, (a. in.) idem
+« TEPI, (prefix) which belongs to the same root, e.g., ni tepi mitjisun, I have eaten enough, tepi mâtuw, he has cried enough, tepi miyaw, one gives him enough
+« TEPIPAYIW, ok, a, (a. a. and in.) he is enough, it is enough, there is enough
+« TEPIPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it enough, he makes sure that there is enough
+« TEPIKINEW, (v. a.) NAM, NIWEW, NIKEW, he has enough to cover it
+« TEPIKIW, ok, (a. a.) he has pushed enough
+« TEPIKIN, wa, (a. in.) idem
+« TEPIYIKOK, (ad.) enough, sufficiently
+« TIPIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he pleases him, he satisfies him
+« TEPIYÂWEHEW, etc., (v. a.) idem
+« TEPISIW, ok, (a. a.) he is happy
+« TEPIYÂWESIW, ok, (a. a.) idem
+
+TEP
+
+« TEPISIWIN, a, (n. f.) happiness, satisfaction
+« TEPIYÂWESIWIN, a, (n. f.) idem
+« TEPIKKWÂMIW, ok, (a. a.) he has slept enough
+« TEPIMEW, etc., (v. a.) he says enough to him, or, he contents him with his words
+« TEPIMÂKUSIW, ok, (a. a.) he fills the place with his smell
+« TEPIMÂKWAN, wa, (a. in.) idem
+« TEPINEW, (v. a.) NAM, NIWEW, NIKEW, he can reach it with his hand
+« TEPINAMÂWEW, etc., (v. a.) he supplies him with enough
+« TEPISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he suits him well, e.g., ni tipiskawâwok ni wikwepânak, my pants suit me well, tepiskam omaskisina, his shoes suit him well
+« TEPISUW, ok, (a. a.) he has smoked enough
+« TEPIPEW, ok, (a. a.) he has drunk enough
+« TEPIPUW, ok, (a. a.) he has eaten enough
+« TEPISKITEHEW, ok, (a. a.) he has a tired, overwhelmed heart
+« TEPIPAYIHIKUW, ok, (v. pass.) he has enough, it is enough for him
+« TEPITTÂKUSIW, ok, (a. a.) he is well heard
+« TEPITTÂKWAN, wa, (a. in.) idem
+« TEPITTAWEW, (v. a.) TTAM, TTÂTCHIKEW, he hears him well, he grasps his voice enough, he hears him enough
+« TEPISIN, wok, (a. a.) he is suitable, he adjusts himself, he is right
+
+616
+
+TET
+
+« TEPITTIN, wa, (a. in.) idem
+« TEPISIMEW, (v. a.) TTITAW, SIMIWEW, TCHIKEW, he adjusts it, he joins it
+x TEPIYÂK, (ad.) (saltem) at least, e.g., tepiyâk ekawiya ekusi tota, at least don't do that
+x TEPWEW, ok, (v. a.) he cries out, he calls
+« TEPWEWIN, a, (n. f.) a cry
+« TEPWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he calls him, he cries out to him, also: he is published in the church, etc.
+« TEPWESKITTEW, ok, (v. n.) his ears ring
+x TET, (rac.) to be above, etc.
+« TETTAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he puts it above
+« TETTAPIW, ok, (a. a.) he is sitting above, that is to say, he is on horseback, e.g., someone who is on a horse
+TETTÂPÂTEW, ok, he is on horseback on him
+« TETTAPIWIN, ak, (n. f.) that upon which one goes horseback, the horse
+« TETTAPIWIN, a, (n. f.) seat, chair, bench
+« TETTAPIHEW, etc., (v. a.) he seats it above
+« TETCHIKWÂSKUTTIW, ok, (v. n.) he jumps above
+« TETCHIPAYIW, ok, a, (a. a. and in.) he climbs on, etc.
+« TETCHIPAYIHUW, ok, (v. r.) he throws himself above, he climbs above
+« TETCHIPAYIHUSTAWEW, etc., (v. a.) he climbs on someone, etc. N.B. Usually, this word is used in the shameless sense
+
+« TETCHIWEPINEW, (v. a.) NAM, NIWEW, NIKEW, he throws it above
+TESIKOTA, or, TESIKOTE, that's why, (ad.) See. Tâsipwa
+x TESIPITCHIGAN, a, (n. f.) scaffold, platform
+« TESIPITCHIGANIKKEW, ok, (v. n.) he makes a scaffold
+TETEPÂHAMÂWEW, etc., (v. a.) he puts his feet in his tracks, c.a.d. his footprints are the same size as somebody else's
+x TETIPISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he makes a circle around him by walking
+« TETIPEWEHAN, ok, (v. n.) he goes in a circle on the water
++ TWEHUW, ok, (v. n.) he falls, he lands (a bird)
+« TWEHUTOTAWEW, etc., (v. a.) he lands on him, or, in his presence
+« TWEHUSTAWEW, etc., (v. a.) idem
+TIKAK, (pron.) everyone, anyone. See. waniyu piko awiyak
+x TIKK, (rac.) to melt
+« TIKKÂBISKISWEW, (v. a.) SAM, SUWEW, SIKEW, he melts it (metal)
+« TIKKÂBISKISIW, ok, (a. a.) he is melted (metal)
+« TIKKÂBISKAW, a, (a. in.) idem
+« TIKKÂBISKISIGAN, a, (n. f.) lead, tin
+« TIKKÂBÂWAYEW, (v. a.) TAW, YIWEW, TCHIKEW, he melts it in water, he dissolves it
+« TIKKÂBÂWEW, ok, a, (a. a. and in.) he melts by the water
+
+617
+
+TIM
+
+« TIKKÂSUW, ok, (a. a.) he is melted by the sun
+« TIKKÂSTEW, a, (a. a.) idem
+« TIKKATCHITEW, a, (a. in.) the ground thaws
+« TIKKATCHAW, (v. im.) idem
+« TIKKIPAYIW, ok, a, (a. a. and in.) he melts, it melts
+« TIKKISIGAN, a, (n. f.) lead, tin
+« TIKKISIW, ok, (a. a.) he is melted, he melts
+« TIKKAW, a, (a. in.) idem
+« TIKKISUW, ok, (a. a.) he is melted on the fire
+« TIKKITEW, a, (a. in.) idem
+« TIKKISWEW, (v. a.) SAM, SUWEW, SIKEW, he melts it on the fire
+« TIKKINEW, (v. a.) NAM, NIWEW, NIKEW, he melts it in his hand
+« TIKKISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he melts it under his feet
+« TIKKISAMÂWEW, etc., (v. a.) he melts it for him
+« TIKKIPISIW, ok, (a. a.) he is likely to melt, easily meltable
+« TIKKIPAW, a, (a. in.) idem, e.g. like bone marrow fat
+« TIKKIPESWEW, (v. a.) SAM, SUWEW, SIKEW, he melts it, he reduces it to water, e.g. snow or ice
+« TIKKIPESUW, ok, (v. n.) he melts it and reduces it to water
+« TIKKIPESUW, ok, (a. a.) he is melted down to water
+« TIKKIPESTEW, a, (a. in.) idem
++ TIM, (rac.) deep, hollow
+« TIMIW, (v. im.) the water is deep, there is a hollow
+
+TIM
+
+« TIMASKAW, (v. im.) there is long, deep grass
+« TIMIKUNIW, (v. im.) deep snow
+« TIMIKUNAKAW, (v. im.) idem
+« TIMIPAKAW, (v. im.) thick foliage
++ TIM, (rac.) short. See. Tchim, which is the same root
+« TIMÂNASKATOTAK, wa, (n. f.) snag, stump
+« TIMISISIW, ok, (a. a.) he is short
+« TIMÂSIN, wa, (a. in.) idem
+« TIMISISIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he shortens it
+« TIMIKÂTEW, ok, (a. a.) he has short legs
+« TIMIKKWEW, ok, (a. a.) he has a short, narrow face
+« TIMIKKWEYÂWEW, ok, (a. a.) he has a short neck
+« TIMÂSKUSIW, ok, (a. a.) he is short (a piece of wood)
+« TIMÂSKWAN, wa, (a. in.) idem
++ TINÂSTAN, (v. im.) as far as one can see in a river
+x TIP, (rac.) to measure, to adjust, to settle on, to pay
+« TIPAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he adjusts to him, he takes him as a model
+« TIPÂHÂKÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, idem
+« TIPÂHÂKEW, ok, (v. n.) he takes (something) as a model
+« TIPAHWEW, (v. a.) HAM, HUWEW, HIKEW, he measures it, he pays him so much
+« TIPÂPISKOTCHIGAN, a, (n. f.) instrument for weighing, balance, scale
+
+618
+
+TIP
+
+« TIPÂPISKOYEW, (v. a.) TAW, YIWEW, TCHIKEW, he weighs it
+« TIPÂTCHIMEW, etc., (v. a.) he tells of him, he tells it
+« TIPÂTOTEW, (v. a.) TAM, etc, idem
+« TIPÂTCHIMOW, ok, (v. n.) he tells the news
+« TIPÂTCHIMOWIN, a, (n. f.) narration
+« TIPAKIMEW, etc., (v. a.) he judges him, he condemns him
+« TIPAKIMOW, ok, (v. n.) he judges, he condemns
+« TIPÂSKUNEW, (v. a.) NAM, NIWEW, NIKEW, he measures it with a piece of wood
+« TIPAHAMÂWEW, etc., (v. a.) he measures him, or, he pays him
+« TIPÂPÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he measures him with a line
+« TIPÂPÂN, a, (n. f.) line for measuring
+« TIPAHIKEW, ok, (v. ind.) he measures, he pays
+« TIPAHIKEWIN, a, (n. f.) payment
+« TIPAHIGAN, a, (n. f.) measure
+« TIPAHIKISINWÂN, a, (n. f.) measure for the cold, thermometer
+« TIPAHIPISIMWÂN, a, (n. f.) sundial, hour
+« TIPAHAMÂKEW, ok, (v. ind.) he pays for another
+« TIPAHAMÂKEWIN, a, (n. f.) payment
+« TIPAHAMÂKESTAMÂWEW, etc., (v. a.) he redeems it
+
+TIP
+
+« TIPAHAMÂKESTAMÂKESTAMÂKEWIN, a, (n. f.) redemption
+« TIPAHAMÂKUSIW, ok, (a. a.) he desires to be paid
+« TIPAHAMÂKUSIWIN, a, (n. f.) recompense
+« TIPASKINEW, ok, a, (a. a. and in.) he is filled until done
+« TIPASKINEPAHEW, (v. a.) TAW, HIWEW, TCHIKEW, he fills it with liquid
+« TIPASKINAHEW, etc., (v. a.) he fills it
+« TIPINISKATEW, (v. a.) TAM, SIWEW, TCHIKEW, he measures it with his arms, by the breast
+« TIPINEW, (v. a.) NAM, NIWEW, NIKEW, he measures it with his hand
+« TIPIPIPONWEW, ok, (a. a.) he is old, he is aged
+« TIPIPAYIW, ok, a, (a. a. and in.) it is accomplished, there is enough, consommatum est (it is finished)
+« TIPIPAYIHEW, (v. a.) TAW, HIWEW, TCHIKEW, he accomplishes it, he consumes it, he finishes it to the end
+« TIPISIGAN, a, (n. f.) model, model to size on
+« TIPISWEW, (v. a.) SAM, SUWEW, SIKEW, he sizes it on a model
+« TIPISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he is face to face with him
+« TIPISKAMOKIJIKAW, a, (v. in.) it is the birthday
+« TIPITATTO, (adv.) it is just as much
+« TIPITOTAM, wok, (v. n.) he satisfies, he does his duty
+« TIPITOTAMOWIN, a, (n. f.), (ayamihewi) holy satisfaction
+
+619
+
+« TIPITOTAWEW, etc., (v. a.) he satisfies him
+« TIPOTEW, (v. a.) TAM, SIWEW, TCHIKEW, See. Mamiskomew, he speaks on his account
+« TIPOTAMÂWEW, (v. a.) See. Mamiskotamâwew
+« TIPIHEW, etc., (v. a.) he follows him, he keeps pace with him walking, tat is to say, he walks well enough compared to him that he can follow him
+« TIPITTWAW, ok, (v. n.) he can follow the others
++ TIPÉ, (rac.) to be paster, possessor of, etc.
+« TIPEYITCHIKEW, ok, (v. ind.) he is master, lord
+« TIPEYITCHIKEWIN, a, (n. f.) domination, possession
+« TIPEYITTÂKUSIW, ok, (a. a.) he is worthy of possessing
+« TIPEYITTÂKWAN, wa, (a. in.)
+« TIPEYIMEW, etc., (v. a.) he is his master, he possesses him
+« TIPEYIMIWEW, ok, (v. ind.) master, possessor
+« TIPEYITTAM, wok, (v. n.) he governs, he commands
+« TIPEYITTAMOWIN, a, (n. f.) commandment
+« TIPEYITTAMÂWEW, etc., (v. a.) he possesses it for him
+« TIPEYITTAMOHEW, etc., (v. a.) he makes him possessor, he makes him the master
+« TIPEYIMISUW, ok, (v. r.) he is free, master of himself
+
+TIP
+
+« TIPEYIMISUWIN, a, (n. f.) freedom
+x TIPINAHOKAN, a, (n. f.) shelter against the wind, the bad weather
+« TIPINAWAHIGAN, a, (n. f.) idem
+« TIPINAWAW, (v. im.) there is shelter
+« TIPINAWAHAM, wok, (v. n.) he makes a shelter against the wind, the rain, the snow
+« TIPINAWAHWEW, etc., (v. a.) he shelters it
+« TIPINAWISIMOW, ok, (v. r.) he puts himself under a shelter
+« TIPINAWISIMOWIN, a, (n. f.) shelter
+x TIBISKAW, (v. im.) it is the night, it is nighttime
+« TIBISK, (suffix.) e.g. nipâtibisk, during the night, kape tibisk, the whole night, nijotibiskwa, two nights
+« TIBISKOK, (locative noun) last night, ke tibiskâk, next night, anotch ka tibiskâk, during tonight
+« TIBISKAWIPISIM, (n. f.) the moon
+« TIBISKIPAYIW, a, (a. in.) it is dark, gloomy
+« TIBISKINAM, wok, (v .n.) it is in the dark
+« TIBISKOKKEW, ok, (v. n.) idem
+« TIBISKÂWIMITJISUW, ok, (v. n.) he eats his dinner
+« TIBISKÂWIMITJISUWIN, a, (n. f.) dinner
+« TIBISKISIW, ok, (a. a.) he is taken by the night
+« TIBISKISIWIN, a, (n. f.) the action of being taken by the night
+
+620
+
+TIS
+
+x TIPISKOTCH, (adv.) face to face, opposite of
+« TIPISKOTCHIPAYIW, ok, a, (a. a. and in.) he is face to face
+« TIPISKOTCHIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he puts it face to face
+« TIPISKOTCHIPAYIHEW, etc., (v. a.) idem
+x TIPIYAW, or, TIPIYÂWE, (pron. ind.) self, own; e.g., niya tipiyawe, myself; kiya tipiyawe, yourself; wiya tipiyâwe, himself; tipiyâwe ototema, it is his own parent; tipiyaw ot'ayân, it is his own; tipiyawe ni wâbamaw, I saw him with my own eyes; tibiyaw ni wittamâk, it is he himself that said it to me
+« TIPIYÂWEWISIW, ok, (a. a.) he is the master of what he has; e.g. tipiyâwewisiw omokkumân, he is the master of his own knife; eoko piko ni tipiyâwewisin, it is the only thing over which I have ownership
+« TIPIYÂWEWISIWIN, a, (n. f.) property, possession
+« TIPIYÂWEHEW, etc., (v. a.) he makes him the owner
+« TIPIYÂWEWISIHEW, etc., (v. a.) idem
+x TISAMAW, ok, (v. n.) he makes smoke to drive away the mosquitos
+« TISAMÂNIKKEW, ok, (v. n.) idem
+« TISAMÂWIN, a, (n. f.) smoke for driving away mosquitos
+« TISAMÂNIKKEWIN, a, (n. f.) idem
+
+TIS
+
+« TISAMÂNIKKAWEW, etc., (v. a.) he makes him smoke
+TITTIMWEW, he whispers, he speaks secretly, tittimwekattawew, he whispers against him
+x TITTIP, (rac.) to toll, to twist around, to attach around, etc.
+« TITTIPAPPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he attaches it around, etc., he rolls it around
+« TITTPÂSKWAHWEW, (v. a) HAM, HUWEW, HIKEW, he twists it around a piece of wood
+« TITTIPEKINEW, (v. a.) NAM, NIWEW, NIKEW, he turns it, he twists it around, e.g., a piece of cloth
+« TITTIPEYEKIHEW, (v. a.) TTAW, etc., (idem
+« TITTIPEYEKISIN, wok, (a. a.) he is rolled around
+« TITTIPEYEKITTIN, wa, (a. in.) idem
+« TITTIPINEW, NAM, NIWEW, NIKEW, he rolls it
+« TITTIPÂNITTOWÂN, a, (n. f.) wheel for playing
+« TITTOPÂNITOWEW, ok, (v. n.) he plays with a wheel
+« TITTIPÂKUNEPAYIW, ok, a, (v. im.) there is an avalanche of snow
+« TITTIPINIGAN, a, (n. f.) wheel
+« TITTIPIPAYIW, ok, a, (a. a. and in.) he rolls, he turns on an axle
+« TITTIPIPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he turns it on an axe, he rolls it
+
+621
+
+TIT
+
+« TITTIPIPAYIHUW, ok, (v. r.) he rolls in all directions
+« TITTIPIW, ok, (v. n.) he rolls, e.g. a horse
+« TITTIPISIW, ok, (a. a.) he is rolled, twisted around
+« TITTIPISIN, wok, (a. a.) idem
+« TITTIPITTIN, wa, (a. in.) idem
+« TITTIPISIMEW, (v. a.) TTITAW, etc., he rolls it around
+« TITTIPITÂBÂNÂSK, wok, (n. f.) wheeled car
+« TITTIPITCHIGAN, ak, (n. f.) idem
+« TITTIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he makes it roll
+« TITTIPIKWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he edges it, he hems it
+« TITTIPIKWÂTCHIGAN, a, (n. f.) border, hem
+« TITTIPIKWÂSUW, ok, (a. a.) he is bordered, hemmed
+« TITTIPIKWÂTEW, a, (a. in.) idem
+« TITTIPÂPIKESIMEW, (v. a.) TTITAW, etc.
+« TITTIPÂWIYAKAHIGAN, a, (n. f.) hem
+« TITTIPAWIYAKAHIGANASKISIN, a, (n. f.) hammed shoe
+« TITTIPAWEHAM, wok, (v. n.) he curls it, he crimps it, e.g., hair
+« TITTIPAWEHAMAHUN, a, (n. f.) curl, crimp
+« TITTIPAWEHAMÂWEW, etc., (v. a.) he crimps his hair, he curls it
+« TITTIPEWEW, ok, (v. n.) he goes around
+« TITTIPEWESKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he makes the turn
+
+TIT
+
+« TITTIPEWEHAM, wok, (v. n.) he goes around on the water
+TIYAKWATCH, (adv.) on the contrary; e.g., tiyakwatch anotch atuskew, on the contrary he is working today (when he should be doing nothing); tiyakwatch pâppiw o ka ki mâtu, he laughs when he should ry; tiyakwatch eoko nama ki totam, he cannot do it (despite doing other, more difficult thing)
+« TIYAKUTCH, (adv.) idem
+x TIYASTAP, (adv.) strongly, quickly
+« TIYASTAPIPAYIW, ok, a, (a. a. and in.) it goes very quickly
+« TIYASTAPÂBAMEW, etc., (v. a.) he barely sees it pass, as he is moving quickly
+x TIYÂWINEW, (v. a.) NAM, NIWEW, NIKEW, he lessens it, he decreases it
+« TIYAWIHEW, (v. a.) TTAW, etc., he decreases it
+« TIYAWISIW, ok, (a. a.) he decreases it
+« TIYAWAW, a, (a. a.) idem
+« TIYAWISIWIN, a, (n. f.) a decrease
+« TIWEYAW, (v. imp.) or, tchiweyaw, echo which is heard from a far away
+x TOHUWÂN, a, (n. r.) ball (toy)
+« TOHUWEW, ok, (v. n.) he plays with the ball
+x TOKKÂBIW, ok, (v. n.) he opens his eyes
+
+622
+
+TOM
+
+« TOKKIPAYIW, ok, a, (a. a. and in.) it opens (seldom used)
+« TOKKINEW, (v. a.) NAM, NIWEW, NIKEW, he opens it
+« TOKKISKAWEW, (v. a.) KAM, etc., he opens it by putting his foot on it
+« TOKKAHYEW, (v. a.) STAW, etc., he opens it, by placing it
+x TOM, (rac.) to cree, to anoint
+« TOMÂPINEW, etc., (v. a.) he anoints his eyes (somebody else's)
+« TOMÂPINISUW, ok, (v. r.) he greases his own eyes
+« TOMÂBISKINEW, (v. a.) NAM, NIWEW, NIKEW, he creases it (metal)
+« TOMÂSKUNEW, etc., (v. a.) idem, (wood)
+« TOMIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he spreads grease on him, he greases him
+« TOMINEW, (v. a.) NAM, NIWEW, NIKEW, idem
+« TOMINIKÂKEW, ok, (v. n.) he uses it to grease (something)
+« TOMINIGAN, a, (n. f.) ointment
+« TOMINISUW, ok, (v. r.) he greases himself
+« TOMÂPOKKEW, ok, (v. n.) he seasons it with fat
+« TOMIKKWEW, ok, (v. n.) he searches the ground for roots and worms (like a badger)
+« TOMIKKWENEW, (v. a.) NAM, NIWEW, NIKEW, he searches it for roots and worms (like a badger)
+« TOMISIW, ok, (a. a.) he is oily, greasy
+« TOMAW, a, (a. in.) idem
+« TOMIHUW, ok, (v. r.) he greases himself
+« TOMISITENEW, etc., (v. a.) he greases (anoints) his feet (somebody else's)
+
+TOM
+
+« TOMISITENISUW, ok, (v. r.) he greases (anoints) his own feet
+« TOMITCHITCHENEW, etc., (v. a.) he anoints his hands (somebody else's)
+« TOMITCHITCHENISUW, ok, (v. r.) he anoints his own hands
+« TOMISTIKWÂNENEW, etc., (v. a.) he greases his head (somebody else's)
+« TOMISTIKWÂNENISUW, ok, (v. r.) he greases his own head
+« TOMISTIKWÂNEW, ok, (v. n.) idem
+« TOMISTIKWÂNÂGAN, a, (n. f.) ointment for greasing the head
+x TONESIW, ok, (a. a.) he is splayed
+« TONEYAW, a, (a. in.) idem
+« TONENEW, (v. a.) NAM, NIWEW, NIKEW, he splays it
+« TONEPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he splays it by pulling it
+« TONEYÂBISKISIW, ok, (a. a.) he is splayed, flared, e.g., a metal vase
+« TONEYÂBISKAW, a, (a. in.) idem
+« TONEYÂSKUSIW, ok, (a. a.) he is splayed, flared, e.g., a wooden vase
+« TONEYÂSKWAN, wa, (a. in.) idem
+x TOSKINEW, (v. a.) NAM, NIWEW, NIKEW, he elbows him, he pushes him with his hand, to get his attention
+« TOSKISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he heels him, he elbows him
+« TOSKUNITEW, (v. a.) TAM, SIWEW, TCHIKEW, idem
+x TOSTOPISIW, ok, (a. a.) he is soft, he is elastic, spongey
+« TOSTOPAW, a, (a. in.) idem, e.g., curdled milk
+
+523
+
+TOT
+
+« TOSTOKISIW, ok, (a. a.) he is elastic, moving, shaking
+« TOSTOGAN, wa, (a. in.) idem, e.g., shaking terrain
+x TOTAWEW, (v. a.) TAM, TÂKEW, TÂTCHIKEW, he does (something) to him, e.g, mayi-totawew, he does him harm, miyo-totawew, he does him good, eka ekusi totaw, do not do that to him, k'eji miweyittamowane kita totâkawiyan ekusi totaw kitch'ayisiyiniw, do unto your neighbour what you wish to be done unto you
+« TOTAM, wok, (v. n.) he acts, he does something, e.g., nama nando totam, he does nothing, tota ka totaman, age quod agis (do what you are doing)
+« TOTAMOWIN, a, (n. f.) action, act
+« TOTAMÂWEW, etc., (v. a.) he does it for him
+« TOTAMÂKEW, ok, (v. ind.) he does it for somebody else
+« TOTAMÂWEWIN, a, (n. f.) action for somebody else
+« TOTCHIKÂSUW, ok, (a. a.) it is done, executed
+« TOTCHIKÂTEW, a, (a. in.) idem
+x TOTOSIM, ak, (n. r.) breast, udder
+« TOTOSÂBUIY, a, (n. f.) milk, liquid from the breast
+« TOTSÂBUWIPIMIY, a, (n. f.) butter, fat from the liquid of the breasts
+« TOTOSÂBUWIPIMIKKEW, ok, (v. n.) he makes butter
+« TOTOSÂBUWIKAMIK, wa, (n. f.) creamery
+
+TOT
+
++ TOTEWISIW, ok, (verbal suffix) e.g., nistotewisiw, he is alone with his family, or, nistotew, mitchetotewisiwok, there are many families
+« TOTEW, ok, idem
+« TOWA, suffix, e.g., ekotowa, of this sort, in this way, or, omatowa
+« TOWIKKÂNISIW, ok, (suffix.) e.g., ekotowikkânisiw, he is of this type
+TOYEK, (adv.) See. meyânkwâm
+x TCHAKÂPAHWEW, (v. a.) he hits him in the face with a piece of wood
+« TCHAKÂMATINAW, (v. im.) it is steep (a mountain)
+« TCHAKÂBITCHIN, wok, (a. a.) he harms himself in the face, in the eyes, with a piece of wood, a branch that hits him
+« TCHAKATAYESKAWEW, etc., (v. a.) he hits it with his heel, being a horse, he spurs him, he heels him
+« TCHAKATAYESKÂTCHIGAN, a, (n. f.) spur
+« TCHAKEYAHWEW, etc., (v. a.) he winds him by hitting him
+« TCHAKEYISIN, wok, (v. n.) he gets winded by falling
+« TCHAKITCHIN, wok, (a. a.) or, tchatchakitchin, he harms him by striking him, or better, he feels like something that stings him, darts him
+« TCHAKÂSUW, ok, (a. a.) the Sun shines on him
+« TCHAKÂSTEW, a, (a. in.) the Sun shines on it
+
+624
+
+TCH
+
+« TCHAKÂSIKEW, (v. im.) the sun shines on, e.g., a beam of light which shines in an apartment, through a window, a door
+« TCHAKÂSKOPAYIW, ok, a, (a. a. and in.) it jostles, it spills
+« TCHAKÂSKOPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he jostles it
+« TCHAKISAHIGAN, ak, (n. f.) gun flint, flint, fire-lighting flint
+« TCHAMOKKAHAM, wok, (v. n.) he hits the water with his tail (a beaver)
+« TCHAMOKKIHIKEW, ok, (v. n.) idem
+« TCHÂKÂYOWEW, ok, (a. a.) he holds up his tail
+« TCHÂKIPAYIW, ok, a, (a. a. and in.) he is swollen, raised, bloated
+« TCHÂKKISUW, ok, (a. a.) he burns. See. kisisuw
+« TCHÂKKITEW, a, (a. in.) idem
+« TCHÂKKISWEW, (v. a.) SAM, SUWEW, SIKEW, he burns it. See. kisiswew. N.B. These three words are seldom used
+x TCHAKKISKAWEW, etc., (v. a.) he harms him by hitting him
+« TCHAKATAHWEW, etc., (v. a.) he pecks him, he hits him on the nose
+« TCHAKATAHIKEW, ok, (v. ind.) he pecks
+x TCHAKIPEHWEW, (v. a.) HAM, HUWEW, HIKEW, he makes dots, he depicts small marks
+
+TCH
+
+TCHAKIPEHIGAN, a, (n. f.) dot, small mark; this is how one refers to the small marks of Cree syllabic characters
+« TCHAKASINAHWEW, (v. a.) HAM, HUWEW, HIKEW, he writes dots
+« TCHAKASINAHIGAN, a, (n. f.) writing with dots, or, letter of the alphabet
+« TCHAKASTEW, a, (a. in.) it is marked with dots
+« TCHAKIPASÉS, ak, (n. f.) grey goose, spotted with dots
+« TCHATCHAKIW, ok, (n. r.) pelican
+TCHATCHAKAYUW, ok, (n. r.) or, takayuw, ok, starling
+TCHAKIKKWEW, ok, (a. a.) he is speckled, spotted
+TCHANNAWIW, ok, (a. a.) he is busy anyway
+TCHATCHIK, (adv.) e.g. nama tchatchik, for nothing, for a trifle, something unimportant, nama tchatchik otchiyâwesiw, he gets angry for nothing
+TCHATCHAM, (adv.) idem
++ TCHATCHÂMOW, ok, (v. n.) he sneezes
+« TCHATCHÂMOWIN, a, (n. f.) the action of sneezing
+« TCHATCHÂMOSUW, ok, (v. r.) he makes himself sneeze
+« TCHATCHÂMOSIGAN, a, (n. f.) medicine for sneezing, snuff
+« TCHATCHÂMOSWEW, etc., (v. a.) he makes him sneeze
++ TCHESKWA! (adv.) wait a bit, stop a moment, e.g., tcheskwa ki ka miyitin, wait a bit, I am going to give to you
+
+625
+
+TCH
+
+« TCHESKWA ITÂB, (adv.) in another time
+« TCHESKWA PITA (adv.) stop for a moment
++ TCHESTATAY, (n. r.) nerve, muscle. Usually, this word is said with a pronoun, even in the indefinite, e.g. otchestatay
+TCHÉ! (ex.) expression of disapproval. See. Ayis (proper for men only)
+TCHI? sign of interrogation, e.g., ki ki wâbamaw tchi? or ki ki tchi wâbamaw? or nametchi ki ki wâbamaw? have you seen it? haven't you seen it? tchi? right? kit ayamihânâtuke? you are praying, no doubt, tchi? right? na, is the same thing as tchi, but much less used
+x TCHIK, (rac.) close, that which is touching, etc.
+« TCHIKI, (adv.) close, nearby
+« TCHIKÂYIK, (adv.) idem
+« TCHIKAKÂM, (ad.) close to the water
+« TCHIKIPEK, (ad.) idem
+« TCHIKAPWEW, ok, (v. n.) he roasts it in front of the fire
+« TCHIKASKAMIK, (adv.) close to the ground
+« TCHIKAKASKAMIKAW, (v. im.) it is close to the ground
+x TCHIKAWÂSIS, (adv.) a bit, in a small quantity. See. Apisis
+« TCHIKAWÂSISIW, ok, (a. a.) there are not many
+« TCHIKAWÂSISIN, wa, (a. in.) idem
+
+TCH
+
+« TCHIKAWÂSISWAW, (adv.) not many times
+« TCHIKAWÂSISIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he does it, he places it, in small numbers
+x TCHIKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he chops it, he cuts it, he shapes it with an axe
+« TCHIKAHIKEW, ok, (v. ind.) he chops it
+« TCHIKAHIGAN, a, (n. f.) axe, instrument for chopping
+« TCHIKAHIGANÂTTIK, wok, (n. f.) axe handle
+x TCHIKAKKWÂTEW, (v. a.) TAM, etc., he throws him something which which he hits him
+« TCHIKAKKWEW, ok, (v. n.) (game) he throws something to the white
+« TCHIKAKKWEWEPAHWEW, (v. a.) HAM, HUWEW, HIKEW, he topples him by throwing something to him
+x TCHIKÂSTENEW, (v. a.) NAM, NIWEW, NIKEW, he shadows him, he provides him shade
+« TCHIKÂSTESIN, wok, (a. a.) he has his shadow
+« TCHIKÂSTETTIN, wa, (a. in.) idem
+« TCHIKÂSTEPEKISIN, wok, (a. a.) idem, in the water
+« TCHIKÂSTEPEKITTIN, wa, (a. in.) idem
+« TCHIKÂSTESIMOWIN, a, (n. f.) the shadow
+« TCHIKÂSTESIMEW, (v. a.) TTITAW, SIMIWEW, etc., he makes him have his shadow
+« TCHKÂSTESKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he shades it, he covers it in his shadow
+
+626
+
+TCH
+
+« TCHIKÂTTOW, (adv.) almost, approaching, approximately; e.g., tchikâttow eka takusin, he is almost at the point of arriving; tchikâttow eoko, it is approximately this. See. Kekâtch
+TCHIKWÂYOWEW, ok, (a. a.) he has a hairless tail
+TCHIKANEW, (v. a.) NAM, NIWEW, NIKEW, he marks it, he darts it with his finger
+x TCHIKEYITTÂKUSIW, ok, (a. a.) he is estimable, likable
+« TCHIKEYITTÂKWAN, wa, (a. in.) idem
+« TCHIKEYITTÂKUSIWIN, a, (n. f.) likability, affability
+« TCHIKEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he is attached to him, he esteems him
+« TCHIKEYITTAM, wok, (v. a. in.) he has a taste, a zeal for it
+« TCHIKEYITTAMOWIN, a, (n. f.) taste, zeal
+« TCHIKIYAWESIW, ok, (a. a.) he is happy
+« TCHIKIYÂWESIW, ok, (a. a.) he likes to get angry
+x TCHIKINÂK, wok, (n. r.) louse egg
+x TCHIKWA, plur. tchikwok, (n. r.) type of large mosquito with long legs
+x TCHIMÂN, a, (n. r.) canoe (seldom used)
+« TCHIMÂGAN, a, (n. f.) canoe companion, otchimâgana, his spouse (seldom used)
+
+TCH
+
+« TCHIMEW, etc., (v. a.) he goes in a canoe with him
+« TCHIMÂHAW, ok, (v. n.) he fishes with a dragnet
+« TCHIMÂHÂGAN, a, (n. f.) dragnet
+« TCHIMÂHÂWAYAPIY, ak, (n. f.) idem
+x TCHIMÂ, (rac.) to plant, to lift in the air
+« TCHIMAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he plants it
+« TCHIMASKIYEW, (v. a.) TAW, etc., idem
+« TCHIMASKISUW, ok, (a. a.) he is planted
+« TCHIMASKITEW, a, (a. in.) idem
+« TCHIMASUW, ok, (a. a.) idem
+« TCHIMATEW, a, (a. in.) idem
+« TCHIMATINEW, (v. a.) NAM, NIWEW, NIKEW, he holds it up with his hand
+x TCHIM, (rac.) short. See. Tim
+« TCHIMÂYOWEW, ok, (a. a.) he has a short tail
+« TCHIMITCHITCHEW, ok, (a. a.) he has a short hand
+« TCHIMIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he shortens it by tearing it
+« TCHIMISWEW, (v. a.) SAM, SUWEW, SIKEW, he cuts it short
+« TCHIMISITEW, ok, (a. a.) he has short feet
+« TCHIMIYÂWEW, ok, (a. a.) he has a short body
+« TCHIMÂPEKISIW, ok, (a. a.) he is short, e.g. a cloth
+« TCHIMÂPEGAN, wa, (a. in.) idem
+x TCHIPAY, ak, a dead person (cadaver)
+« TCHIPÂKKÂN, ak, (n. f.) idem; (e.g. Tchipayak nimihituwok, the dead dance, that is to say, the Aurora Borealis appears)
+
+627
+
+TCH
+
+« TCHIPÂKKOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes a feast to the dead
+« TCHIPÂKKOTCHIKEWIN, a, (n. f.) feast for the dead
+« TCHIPEMATISUSTAWEW, etc., (v. a.) he is afraid of such a dead person
+« TCHIPAMATISUW, ok, (a. a.) he is afraid of the dead
+« TCHIPETTAWEW, etc., (v. a.) he hears the voice of a dead person
+« TCHIPAYIWAT, a, coffin, casket
+« TCHIPAYIKAMIK, wa, (n. f.) tomb, sepulcher
+« TCHIPATCHISTAHWEW, (v. a.) HAM, HUWEW, HIKEW, he pieces through him, e.g., with an arrow
+x TCHIPETAKWAKUP, a, (n. f.) blue blanket
+« TCHIPETAKWASKAW, (v. im.) the grass is green
+« TCHIPETAKWEGIN, wa, (n. f.) blue cloth
+« TCHIPETAKISIW, ok, (a. a.) he is blue (cloth)
+« TCHIPETAKWEGAN, wa, (a. in.) idem
+« TCHIPETATAKWANEW, ok, (a. a.) he has blue wings
+x TCHIPUSIW, ok, (a. a.) he is pointed
+« TCHIPWAW, a, (a. in.) idem
+« TCHIPWÂSKISUW, ok, (a. a.) he is planted sharply
+« TCHIPWÂSKITEW, a, (a. in.)
+
+TCH
+
+« TCHIPWÂTÂSKAHIGAN, a, (n. f.) skewer for roasting
+x TCHISÂWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he cuts it in little, thin pieces
+« TCHISÂWESIW, ok, (a. a.) he is thinly chopped
+« TCHISÂWETTIN, wa, (a. in.) idem
+« TCHISÂWÂN, a, (n. f.) type of stew made with chopped meat
+« TCHISIMEW, etc., (v. a.) he cheats him, he plays him, he betrays him
+« TCHISIMIWEW, ok, (v. ind.) he cheats
+« TCHISIMIWEWIN, a, (n. f.) cheating, trickery
+« TCHISIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he cheats him
+« TCHISIHIWEW, ok, (v. ind.) he cheats
+« TCHISIHIWEWIN, a, (n. f.) cheating
+« TCHISIKKEMOW, ok, (v. n.) he is a cheater
+« TCHISIHUW, ok, or, HISUW, ok, (v. r.) he cheats himself, he is wrong
+« TCHISIHUWIN, a, (n. f.) the action of cheating onself, being wrong
+x TCHIPEHEW, etc., (v. a.) he considers it, he examines it closely, he surveys it
+« TCHIPEKKAWEW, etc., (v. a.) idem
+TCHISKÂPITEW, ok, (v. n.) or better, Kitchiskâpitew, he grinds his teeth
+x TCHIST! (adv.) See! Pay attention! Look! Also, in the sentence; e.g., tchist eji miwâsik, see how beautiful it is!
+
+628
+
+TCH
+
+x TCHISTA, (rac.) to prick, to pierce with a point, a nail
+« TCHISTAHWEW, (v. a.) HAM, HWUEW, HIKEW, he pierces it, he pricks it
+« TCHISTAHIGAN, a, (n. f.) instrument for piercing, pricking
+« TCHISTÂSKWAHWEW, etc., (v. a.) he nails it to a piece of wood
+« TCHISTÂSKWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, idem. This is how one says: he crucifies him
+« TCHISTÂSKUWÂSUW, ok, (a. a.) he is attached to a piece of wood, he is crucified
+« TCHISTÂSKWÂN, a, (n. f.) planted piece of wood, fixed in the ground
+« TCHISTÂSKWAW, a, (v. n.) he plants a piece of wood in the ground
+« TCHISTANIKKWANÂTEW, etc., (v. a.) he puts ropes on his shoes
+« TCHISTANIKKWANÂN, a, (n. f.) shoelace
+« TCHISTANIKKWANEYÂPIY, a, (n. f.) idem
+« TCHISTAHASKUSIWÂGAN, a, (n. f.) pitchfork for hay
+« TCHISTAHÂSEPUN, a, (n. f.) fork
+« TCHISAHÂSEPUW, ok, (v. n.) he uses a fork, to eat
+x TCHISKIMEW, etc., (v. a.) he pipes up to him, he calls him, he gets his attention, e.g., getting a horse's attention by whistling
+x TCHISTÂPÂSUW, ok, (v. r.) he buttons himself, he attaches his clothing
+« TCHISTÂPÂSUN, a, (n. f.) button, hook
+
+TCH
+
+« TCHISTÂPÂSUNEYÂPIY, a, (n. f.) chain for hooking
+« TCHISTÂPÂTEW, (v. a.) TAM, SIWEW TCHIKEW, he buttons it, he hooks it
+« TCHISTAKAHWEW, (v. a.) HAM, HUWEW, HIKEW
+« TCHISTAKAHIGAN, a, (n. f.)
+x TCHISTÂWEW, ok, (v. n.) he makes an echo, he resounds
+« TCHISTÂWEYAW, (v. im.) there is an echo
+« TCHISTÂWESIN, wok, (a. a.) he makes an echo
+« TCHISTÂWETTIN, wa, (a. in.) idem
+« TCHISTÂWESIMEW, (v. a.) TTITAW, SIMIWEW, TCHIKEW, he makes him echo
+x TCHISTINEW, (v. a.) NAM, NIWEW, NIKEW, he pinches him with his fingers
+« TCHISTIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, idem
+« TCHITCHIKINEW, (v. a.) NAM, NIWEW, NIKEW, he scratches it there, or he has an itch
+« TCHITCHIKIPITEW, etc., (v. a.) idem
+« TCHITCHIKIW, ok, (a. a.) he scratches himself, having an itch
+« TCHITCHIKIWIN, a, (n. f.) the action of scratching onself
+« TCHITCHIKUM, a, (n. f.) war; otchitchikumiw, ok, he has a wart
+TCHISTCHIPIPAYIW, ok, a, (a. a. and in.) he shakes, he shivers
+« TCHISTCHIPAYIW, ok, a, (a. a. and in.) idem
+« TCHISTCHISINEW, NAM, NIWEW, NIKEW, he dusts it
+
+629
+
+TCH
+
+TCHIKEMA, (adv.) assuredly, without any doubt. N.B. This is also a sort of irony; e.g., tchikema kita wi-ayamihaw! Of course he would want to pray! Though this also means: he will certainly pray (it depends on the circumstances and on what is being discussed); tchikema nama ni ka otinen? is it to be believed that I will not take it? tchikema kakiyaw ki ka nipinânow, we will certainly all die; tchikema nama ki ka nipinânow? is it to believed that we are not to die?
+x TCHOWE, (rac.) that which resonates, resounds
+« TCHOWEKANAPISIS, ak, (n. f.) small bird, an insect which makes noise when flying
+« TCHOWEKKATTEW, (v. imp.) the noise of crackling fire
+« TCHOWEKUTEW, (v. im.) the noise, the whistling which a bullet makes when splitting the air
+« TCHOWEKUTCHIN, wok, (a. a.) the noise which it makes when passing, e.g., a bird which splits the air, a horse which races by
+« TCHOWEKUTTIN, wa, (a. in.) idem
+« TCHOWESKITTEW, ok, (v. n.) his ears are ringing
+« TCHOWEPAYIW, ok, a, (a. a. and in.) he resonates, he whistles, he resounds
+x TCHOTCHONAMAW, ok, impudice tangit seipsum (he touches himself shamelessly)
+« TCHOTCHONAMÂWEW, impudice tangit eum vel eam (he touches him or her shamelessly)
+
+TCH
+
+« TCHOTCHONAMÂTUWOK, sodomiam faciunt (they commit sodomy)
+« TCHOTCHONAMÂWIN, a, impudici tactus in seipso (shameless touching of oneself)
+WÂH! (ex.) expression of shock, of surprise
+« WÂWÂH! (ex.) it can't be. See. Watchistakâtch
+x WÂK, (rac.) hooked, curved, bent back
+« WÂKISIW, wok, (a. a.) he is curved back
+« WÂKAW, (a. in.) idem
+« WÂKINEW, (v. a.) NAM, NIWEW, NIKEW, he curves it
+« WÂKIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, idem
+« WÂKÂBISKISIW, ok, (a. a.) he is curved, hooked, (metal)
+« WÂKÂSKIPAYIW, ok, a, (a. a. and in.) he becomes hooked, curved (wood)
+« WÂKÂASKWAN, wa, (a. in.) idem
+« WÂKAYOS, ak, (n. f.) black bear
+« WÂKAYOSKAW, (v. im.) there are many black bears
+« WÂKÂYOWEW, ok, (a. a.) he has a curved tail
+« WÂKITCHIKAHIGAN, a, (n. f.) pickaxe, pick
+« WÂKIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he curves it, he makes it curved
+« WÂKIPAYIW, ok, a, (a. a. and in.) he curves, he becomes bent
+
+630
+
+WÂK
+
+« WÂKIW, ok, (v. n.) he turns back, he takes another direction
+« WÂKIKIKKAW, ok, (a. a.) he is bent by age
+« WÂKINÂGAN, ok, (n. f.) (juniper) red spruce; it is named as such because one uses this wood to make the ribs (curves) of bark canoes
+« WÂKINÂGANÂTTIK, wok, (n. f.) red spruce wood
+« WÂKINÂGANISKAW, (v. im.) there are many red spruces
+« WÂKINIGAN, a, (n. f.) curve, circle, everything that is curved
+« WÂBÂW, ok, ribs (curves) of a bark canoe
+« WÂKIPISKWANEW, ok, (a. a.) he has a curved back
+« WÂKIPISKWANEYIW, ok, (v. n.) he curves his back by bending himself
+« WÂISKISIW, ok, (a. a.) he curves, he is flexible
+« WÂKISKAW, a, (a. in.) idem
+« WÂKITESKANEW, ok, (a. a.) he has curved back horns
+« WÂKINOKEW, ok, (v. n.) he builts it in a curve, in a circle, he makes a curved cabin of branches
+« WÂKINOKÂN, a, (n. f.) round cabin which resembles the cabins used for steam bathes
+« WÂKITCHÂN, ak, (n. f.) white seed which forms the root of the wild lily (mouse seed)
++ WÂKK, (rac.) relation, kinship, alliance
+« WÂKKOMÂGAN, ak, (n. f.) relative, ally
+« WÂKKOMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he is his relative, he is allied with him
+
+WÂK
+
+« WÂKKOMIWEWIN, a, (n. f.) kinship
+« WÂKKOTAHEW, etc., (v. a.) he allies with them, he makes them relatives together
+« WÂKKOTAHISUW, ok, (v. r.) he allies, he becomes a relative with
+« WÂKKOTUWOK, (v. m.) they are relatives
+« WÂKKOTTUWIN, a, (n. f.) kinship, alliance
+x WÂKWAN, ak, (n. r.) fish eggs
+x WÂKWA, plur. wâkwok, (n. r.) idem
++ WAKK, (rac.) weak, easy to succumb, suitable for
+« WAKKÂSIW, ok, (v. a.) he is sensitive to pain
+« WAKKEWISIW, ok, (a. a.) he is weak, sensitive to pain
+« WAKKEWAN, wa, (a. in.) idem
+« WAKKEWISIWIN, a, (n. f.) sensitivity
+« WAKKÂNEW, etc., (v. a.) for the little bit that he touches him, he causes him pain
+« WAKKÉ, (prefix.) e.g. wakke-watchiw, he is sensitive to the cold, wakkemâtuw, he cries easily, wakke-kisiwâsiw, he gets angry easily
+« WAKKEYÂPEKISIW, ok, (a. a.) he is weak (cloth)
+« WAKKEYÂPEGAN, wa, (a. in.) idem
+« WAKKEYÂPISKUSIW, ok, (a. a.) idem (metal)
+
+631
+
+WAN
+
+« WAKKEYÂPISKAW, a, (a. in.) idem (metal)
+« WAKKEYÂSKUSIW, (a. a.) idem (wood)
+« WAKKEYÂSKWAN, wa, (a. in.) idem (wood)
+x WANASKUTCH, (adv.) on the tip, at the end, e.g., wanaskutch miteyanik, on the tip of the tongue
+« WANASKITTIK, (adv.) idem
+« WANASKUTCHITCHÂN, a, (n. f.) fingertips
+« WANASKUTCHITCHEW, ok, (a. a.) he has fingertips
+« WANASKUSIW, ok, (a. a.) he has a tip, and end
+« WANASKUWIW, ok, (a. a.) idem
+« WANASKWÂSKUSIW, ok, (a. a.) he has a tip, an end, he ends there (a tree)
+« WANASKWÂSKWAN, wa, (a. in.) idem
+« WANASKWÂTTAK, wa, (n. f.) the front, or the back, the end of a canoe
+x WAN, (rac.) to lose, to obscure, to step aside, to perplex
+« WANÂHÂTTEW, etc., (v. a.) he loses his tracks
+« WANÂHAMEW, ok, (v. n.) he loses the tracks, the marked path
+« WANÂHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he causes him to be perplexed, he troubles him, he misguides hi smind, he causes him a loss
+« WANÂMEW, etc., (v. a.) he causes him loss, he corrupts him by his words
+« WANÂKWANÂSTEW, (v. im.) confused mirage
+
+WAN
+
+« WANÂSTEW, (v. im.) idem
+« WANÂTISIW, ok, (a. a.) he has an unsteady, irresolute, indecisive character
+« WANÂTAN, wa, (a. in.) it is fickle, uncertain
+« WANAKEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he is indecisive, irresolute on his account
+« WANAKEYIMOW, ok, (v. a.) he is indecisive, irresolute
+« WANEYIMEW, ok, etc., (v. a.) idem, he has no set idea about him, he is indecisive about him
+« WANEYIMOW, ok, etc., (v. a.) he he does not know what to decide
+« WANEYITTAM, wok, (v. n.) better, wâwâneyittam, he is indecisive, irresolute, he does not know what to do, he is confused
+« WANEYITTAMOWIN, a, (n. f.) doubt, confusion, irresolution
+« WANÂMOW, ok, (v. n.) he cheats himself, he is wrong, he misleads himself
+« WANÂMOWIN, a, (n. f.) false speech, words
+« WANOWEW, ok, (v. n.) he cheats himself by speaking, he is wrong in speaking, he errs
+« WANOWEWIN, a, (n f.) mistake in speaking, error
+« WANÂPAMEW, (v. a.) TTAM, KKEW, TCHIKEW, he loses sight of it
+« WANASKASOHEW, etc., (v. a.) See. Wanâhew
+« WANASKASOMEW, etc., (v. a.) See. Wanâmew
+« WANEYITTAMIHEW, etc., (v. a.) he confuses him, perplexes him, troubles him
+« WANEYITTAMIMEW, etc., (v. a.) idem, by speaking
+
+632
+
+WAN
+
+« WANIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he loses it
+« WANIHIKEW, ok, (v. ind.) he sets traps, trapdoors
+« WANIHIGAN, a, (n. f.) trap, trapdoor
+« WANIHIKAMÂWEW, etc., (v. a.) he sets traps for him
+« WANIHUW, ok, (v. r.) he gets lost, he is lost
+« WANIHUWIN, a, (n. f.) loss, the action of getting lost
+« WANISIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he is wrong, he makes a mistaking in doing it
+« WANISITCHIKEW, ok, (v. ind.) he makes a mistake
+« WANIKISKISIW, ok, (v. n.) he forgets, he falls unconscious
+« WANIKISKISIWIN, a, (n. f.) forgetting, losing consciousness
+« WANIKISKISOTOTAWEW, (v. a.) TAM, TÂKEW, TCHIKEW, he forgets it
+« WANIMITTIMEW, ok, (v. n.) he is on the wrong way
+« WANIMOTCH, (adv.) in secret, in hiding, two-way
+« WANIMOTCHITEHEWINA, (n. f.) secrets of the heart
+« WANIMOTISIW, ok, (a. a.) he is hidden, he has a hidden character
+« WANIMOTISIWIN, a, (n. f.) secret, secret, hidden action
+« WANIMOTAN, wa, (a. in.) it is hidden, jumbled
+« WANINAWEW, (v. a.) NÂKEW, NÂTCHIKEW, he mistakes him in seeing him, he takes him for somebody else
+« WANINÂKUSIW, ok, (a. a.) he disappears
+
+WAN
+
+« WANINÂKWAN, wa, (a. in.) it disappears from view; also: it begins to get dark, it is almost night
+« WANINEW, ok, (a. a.) he is enraged, furious, he loses his wits
+« WANISIN, wok, (a. a.) he is lost, astray
+« WANITTIN, wa, (a. in.) idem
+« WANISIMEW, (v. a.) TTITAW, SIMIWEW, TCHIKEW, he loses him, he makes him get lost
+« WANÂSIW, ok, (v. n.) he is wrong, he errs
+« WANISIW, ok, (v. n.) idem
+« WANISINOWIN, a, (n. f.) bewilderment, the action of being astray
+« WANITTÂSUW, ok, (v. n.) he makes a loss, he experiences harm
+« WANITTÂSUWIN, a, (n. f.) loss, damage
+« WANI-ITTIW, ok, (v. n.) he transgresses, he cheats himself, he does wrong, he errs
+« WANI-ITTIWIN, a, (n. f.) transgression, error
+« WANITIBISKAW, (v. im.) it is a dark night
+« WANITIBISKIPAYIW, (v. im.) it becomes dark, gloomy
+« WANITBISKISIW, ok, (a. a.) it is gloomy, also, he is in the dark
+« WANITIBISKINAM, wok, (v. n.) he does not see, he is in the dark
+« WANITIBISKOKKEW, ok, (v. n.) idem
+« WANITIBISKINAMÂWEW, etc., (v. a.) he snatches the light from him, he puts him in darkness
+
+633
+
+WAN
+
+« WANITIBISKANOK, (adv.) in the dark
+« WANITOTAM, wok, (v. n.) he makes a mistake, he cheats himself, he is wrong
+« WANITOTAMOWIN, a, (n. f.) mistake, error, fault
+« WANITTOYUW, ok, (v. n.) he makes a mistake in operating
+« WANITTOYUWIN, a, (n. f.) erroneous action
+« WANISKAM, wok, (v. n.) he makes tracks, prints, a trail in every direction
+« WANWEKKAKEW, (v. a.) KÂKEW, etc., he confuses him, e.g., by speaking to him in a language that he doesn't understand, he perplexes him
+« WANWEWITAM, wok, (v. n.) he makes noise, he disturbs one's attention, he obscures. N.B. By placing the prefix wani before verbs which suit it, you can form a multitude of other words, e.g., wani itwew, he is wrong in his words, wani pitukew, he takes the wrong door to enter, etc.
+« WANISAHEW, etc., (v. a.) he bewitches him
+« WANISIWAHAM, wok, (v. n.) he sings songs of war
+x WANISKAW, ok, (v. n.) he gets up, from lying down
+« WANISKÂWIN, a, (n. f.) rising
+« WASNISKÂNEW, (v. a.) NAM, NIWEW, NIKEW, he raises it up, e.g., waniskânam waskahiganikkân, he raises the frame of a house
+
+WAN
+
+« WANISKÂNAMÂWEW, etc., (v. a.) he gets him up
+WANIYU, (pron.) every, every one, e.g., waniyu kita ki totam, anyone can do this
+WANIYU AWIYAK, (pron.) idem
+x WAPAW, (v. im.) strait, narrowing of a lake
+« WAPÂSKWEYAW, (v. im.) strait, narrowing of the woods, of a forest, or wiputawâskweyaw
+x WÂP,(rac.) white, to whiten, everything to do with whiteness
+« WÂPISIW, ok, (n. f.) swan, large white bird
+« WÂPISIW, ok, (a. a.) he is white (seldom used)
+« WÂPAW, a, (a. in.) idem
+« WÂPISKISIW, ok, (a. a.) this is the word used to say: he is white
+« WÂPISKAW, a, (a. in.) idem (the ordinary word)
+« WÂPIW, ok, (v. n.) he sees, he has the faculty of vision
+« WÂPIWIN, a, (n. f.) sight
+« WÂPIHEW, etc., (v. a.) he makes him see, he gives him sight
+« WÂPAGAMIW, (v. in.) light of a white colour
+« WÂPÂKKESIW, ok, (n. f.) white fox
+« WÂPÂNISKWEW, ok, (a. a.) he has white hair
+« WÂPÂPISKISIW, ok, (a. a.) he is white (metal)
+« WÂPÂPISKAW, a, (a. in.) idem
+« WÂPÂPISKASSINIY, ak, (n. f.) crystal
+
+634
+
+WÂP
+
+« WÂPÂSKUSIW, ok, (a. a.) he is white (wood)
+« WÂPÂSKWAN, wa, (a. in.) idem
+« WÂPÂSPINEW, ok, (a. a.) he has leprosy
+« WÂPÂSPINEWIN, a, (n. f.) leprosy
+« WÂPAMEK, wok, (n. f.) whale
+« WÂPAMEKUPIMIY, a, (n. f.) whale oil
+« WÂPAMEW, (v. a.) TTAM, KKEW, TCHIKEW, he sees him
+« WÂPAMUW, ok, (v. r.) he looks at himself in a mirror
+« WÂPAMISUW, ok, (v. r.) idem
+« WÂPAMUN, a, (n. f.) mirror
+« WÂPAMUNÂPISK, wa, (n. f.) window pane, crystal, glass
+« WÂPAMÂWASUW, ok, (v. n.) she gives birth, she sees her child
+« WÂPAMÂWASUWIN, a, (n. f.) giving birth
+« WÂPAYOWEW, ok, (a. a.) he has a white tail
+« WÂPANÂSKÂYOWEW, ok, (a. a.) idem
+« WÂPAYOMIN, ak, (n. f.) rice
+« WÂPAN, (v. im.) it is dawn, it is day
+« WÂPAKI, (adv.) or, ke wâpak, tomorrow, awas wâpaki, after tomorrow
+« WAPANOTÂK, (adv.) to the east, from the rising side
+« WÂPANOK, (adv.) idem
+« WÂPANATAK, (n. f.) day star, morning star
+« WÂPANATCHÂKUS, (n. f.) idem
+« WÂPANAHAN, (v. im.) the wind comes from the east
+
+WÂP
+
+« WÂPAJISKIY, a, (n. f.) white earth. See. wâpatonisk
+« WÂPASK, wok, (n. f.) white bear
+« WÂPASKIK, wok, (n. f.) boiler of white metal
+« WÂPPÂSIW, ok, (a. a.) it is morning
+« WÂPPÂSIWIN, a, (n. f.) the action of being morning
+« WÂPASTIM, wok, (n. f.) white horse, or dog
+« WÂPATIM, wok, (n. f.) idem
+« WÂPANINIW, ok, he sees the day
+« WÂPANISIW, ok, it reaches the morning
+« WÂPÂSWEW, (v. a.), SAM, SUWEW, SIKEW, he whites it by fire, or by the Sun
+« WÂPÂSUW, ok, (a. a.) he is white from teh fire, or, the Sun
+« WÂPANOWASK, wa, (n. f.) hemlock, poison
+« WÂPANOW, ok, (n. f.) type of sorcerer who peforms enchantments
+« WÂPANOWIN, a, (n. f.) sorcery
+« WÂPATOW, ok, (n. f.) white mushroom
+« WÂPATTIHEW, or, YEW, etc., (v. a.) he makes him see, he shows him
+« WÂPATTEHIKOWISIWIN, a, (n. f.) vision, revelation
+« WÂPAWIY, ak ,(n. f.) white hair of the porcupine
+« WÂPIKAY, ak, (n. f.) small, very soft white stone
+« WÂPEGIN, wa, (n. f.) white sheet, merchandise
+« WÂPEKISIW, ok, (a. a.) he is white (sheet)
+« WÂPEGAN, wa, (a. in.) idem
+
+635
+
+WÂP
+
+« WÂPEKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he whitens it
+« WÂPIPIYEW, ok, (n. f.) white partridge
+« WÂPITCHITCHÂK, wok, (n. f.) white crane
+« WÂPIKISEYINIW, ok, (n. f.) old person with white hair
+« WÂPIKWANEW, a, (n. f.) flower
+« WÂPIKWANIW, ok, a, (v. im.) he is in bloom
+« WÂPIKWÂNIWAN, (v. im.) there are flowers, it is in bloom
+« WÂPIMINAK, (n. f.) white beads
+« WÂPINEWISIW, ok, (a. a.) he goes pale, faint
+« WÂPINEWISIWIN,a, (n. f.) pallour
+« WÂPIPEHIGAN, a, (n. f.) white painting
+« WÂPISIKWAW, (v. im.) it is the colour of ice, e.g. maskikiy ka wâpisikwak, camphor
+« WÂPISITEW, ok, (a. a.) he has white feet
+« WÂPISKÂSKUSIW, ok, (a. a.) he is white (wood)
+« WÂPISKÂSKWAN, wa, (a. in.) idem
+« WÂPISKEKIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he whitens it, (a piece of cotton)
+« WÂPISKEGIN, wa, (n. f.) white cotton, cloth
+« WÂPISKEKISIW, ok, (a. a.) he is white (cotton)
+« WÂPISKEGAN, wa, (a. in.) idem
+« WÂPISKEYÂPEKISIW, ok, (a. a.) idem (a rope)
+
+WÂP
+
+« WÂPISKEYÂPEGAN, wa, (a. in.) idem (a rope)
+« WÂPISKAYOWINISSEW, ok, (a. a.) he has white clothes
+« WÂPISKIKÂTEW, ok, (a. a.) he has white legs
+« WÂPISKIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he whitens it, he makes it white
+« WÂPISKIHUW, ok, (v. r.) he is dressed in white
+« WÂPISKIPEHWEW, (v. a.) HAM, HUWEW, HIKEW, he paints it in white
+« WÂPISKWAKUP, a, (n. f.) white blanket
+« WÂPEKINIGAN, a, (n. f.) this is the tobacco which the savages send one another, which is wrapped in a white skin or piece of cotton. This object always accompanies ambassadors, and is smoked in counsel or rejected, according to whether one accepts the peace, or rejects what is proposed
+« WÂPISKOWEW, ok, (a. a.) he is ashy, pale
+« WÂPISKOWES, ak, (n. f.) ashy, he has pale skin
+« WÂPISKASÂKAY, a, (n. f.) white hood, white clothing
+« WÂPISTÂN, ak, (n f.) marten. N.B. One almost always uses this in the diminutive, wâpistânis, ak
+« WÂPISTIKWÂN, a, (n. f.) white head
+« WÂPISTIKWÂNEW, ok, (a. a.) he has a white head
+« WÂPITEW, ok, (a. a.) faded, pale, brown, a dirty colour
+
+636
+
+WÂS
+
+« WÂPITEYAW, ok, a, (a. a. and in.) idem
+« WÂPITTAKAHIGAN, a, (n. f.) chalk, or, wâpigan, a
+« WÂPUS, wok, (n. f.) rabbit, hare, mistâpus, large hare of the prairies
+« WÂPUSWEYÂN, ak, (n. f.) hare skin with hair
+« WÂPOWEYÂN, a, (n. f.) white blanket
+« WÂPÂWAKKAW, (v. im.) white mud, white sand
+« WÂPATÂWOKKAW, (v. im.) idem
+x WÂS, (rac.) in the form of a bay, a cove in a lake
+« WÂSAKÂM, (adv.) around the water of the lake
+« WÂSAKÂMEW, ok, (v. n.) he goes around the lake, the water
+« WÂSAKÂMEWIN, a, (n. f.) the action of going around the water
+« WÂSAKÂMUTTEW, ok, (v. n.) he walks around the water
+« WÂSWEW, (v. a.) SAM, SUWEW, SIKEW, he cuts it all around
+« WÂSÂPEW, ok, (v. n.) he sizes it around, e.g., sizing ropes around a skin
+« WÂSÂHIGAMAW, (v. im.) there is a bay (in a lake)
+x WÂSK, (same root) around, all around, encircling
+« WÂSKÂPAYIW, ok, a, (a. a. and in.) he turns in a circle, around
+« WÂSKÂPAYIHUW, ok, (v. r.) he turns around, making movements
+« WÂSKÂPÂWIWOK, (a. a.) they are standing in a circle
+
+WÂS
+
+« WÂSKÂPÂWISTAWEWOK, (v. a.) they stand around him
+« WÂSKAW, (adv.) in a circle, around
+« WÂSKAPIWOK, (a. a.) they are sitting in a circle
+« WÂSKAPISTÂTUWOK, (v. m.) idem
+« WÂSKAPISTAWEWOK, (v. a.) they are sitting in a circle around him
+« WÂSKAPISTAMWOK, (v. a. in.) they are sitting around it
+« WÂSKÂHIGAN, a, (n. f.) house, building, trade fort
+« WÂSKÂHIGANIKKEW, ok, (v. n.) he makes a house
+« WÂSKÂHIGANIKKAWEW, (v. a.) he makes him a house
+« WÂSKÂHIGANIKKEWIYINIW, ok, (n. f.) he who makes houses, carpenter
+« WÂSKÂKUNEKWÂTCHIGAN, a, (n. f.) rise of a shoe
+« WÂSKÂNEW, (v. a.) NAM, NIWEW, NIKEW, he surrounds him, e.g., a field
+« WÂSKÂPAYISTAWEW, etc., (v. a.) he goes around him, on horseback
+« WÂSKÂSAKESWEW, (v. a.) SAM, SUWEW, SIKEW, he cuts the skin in a circle for him. This is the word for: he circumcises him
+« WÂSKÂSAKESUWEWIN, a, (n. f.) circumcision
+« WÂSKÂSKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he walks, he prowls around him
+« WÂSKÂSIMEW, (v. a.) TTITAW, etc., he deposits it in a circle
+
+637
+
+WÂS
+
+« WÂSKAHYEW, (v. a.) STAW, YIWEW, TCHIKEW, he places it in a circle
+« WÂSKÂTTEW, ok, (v. n.) he walks in a circle
+« WASKIW, ok, (v. n.) he turns back, he returns
+« WÂSKATAYEGIN, wa, (n. f.) faded leather skin, hung on the back
+« WÂSPISUN, a, (n. f.) maillot, type of bag in which the savages wrap their small children
+« WÂSPISUW, ok, (a. a.) he is laced in a maillot, he is laced, tressed (Translator's Note: A maillot is a bag used to wrap and carry small children)
+« WÂSPITEW, a, (a. in.) it is laced, tressed
+« WÂSPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he wraps it up, laces it, when attaching it
+« WÂSPITÂPÂN, a, (n. f.) sled wrap, piece of leather which is used to wrap up the load on a sled
+« WÂSPITÂPEW, ok, (v. n.) he laces, e.g., he laces a sled
+x WÂS, (rac.) clear, luminous, shining
+« WÂSISUW, ok, (a. a.) he is shining, luminous
+« WÂSITEW, a, (a. in.) idem
+« WÂSEYAW, ok, a, (a. a. and in.) it is shining, luminous
+« WÂSEYÂWIN, a, (n. f.) light, clarity
+« WÂSEYÂPISKISIW, ok, (a. a.) it is shining (metal)
+« WÂSEYÂPISKAW, a, (a. in.) idem
+« WÂSEYÂPISKISUW, ok, (a. a.) it is shining by the fire, e.g. a piece of iron reddened in the fire
+
+WÂS
+
+« WÂSEYAPISKITEW, a, (a. in.) idem
+« WÂSASKUTEW, (v. im.) it becomes light, there is light
+« WÂSASKUTEPAYIW, ok, a, (a. a. and in.) there is lightning
+« WÂSASKUTEPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes him light up, he makes there be lightning
+« WÂSASKUTENIGAN, a, (n. f.) candle, lamp
+« WÂSASKUTENIGANÂBISK, wa, (n. f.) metal candlestick
+« WÂSASKUTENIGANÂTTIK, a, (n. f.) wooden candlestick
+« WÂSASKUTENAMÂGAN, a, (n. f.) lantern
+« WÂSASKUTENAMÂWEW, etc., (v. a.) he procures light for him, he lights it up
+« WÂSEGAMIW, (v. im.) there is clear, transparent water
+« WÂSENAMÂGAN, a, (n. f.) frame, window
+« WASENAMÂWIN, a, (n. f.) idem
+« WÂSENAMÂWINÂBISK, wa, (n. f.) pane
+« WÂSENAMÂWINEGIN, wa, (n. f.) mosquito net, cotton in frames
+« WÂSENAMÂWINAPPIN, wa, (n. f.) parchment frame made of skin
+« WÂSESKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he lights it up, he makes it luminous
+« WÂSESKAMÂWEW, etc., (v. a.) he gives him light
+« WÂSESKWAN, (v. im.) the sky, the weather is clear
+
+638
+
+WÂS
+
+« WÂSESKWÂSTAN, (v. im.) the weather clears by the wind
+« WÂSASKWETOW, ok, (n. f.) mushroom
+« WÂSESIKWAW, (v. im.) it is shining, e.g., crystal, ice; ka wâsesikwak, alum
+« WÂSIKUNASTEW, (v. im.) snow which shines from afar
+« WÂSENEW, (v. a.) NAM, NIWEW, NIKEW, he makes it shine
+« WÂSENAMÂWEW, etc., (v. a.) he lights it up, he procures him light
+« WÂSESKUSIW, ok, (a. a.) he is shining, luminous
+« WÂSIKKWÂSUW, ok, (a. a.) he is brilliant like the Sun
+« WÂSIKKWÂSTEW, a, (a. in.) idem
+« WÂSIKKWEKAHIKEW, ok, (v. ind.) he shoots white
+« WÂSIKKWEKAHWEW, etc., (v. a.) he polishes it, he makes it shine with an axe
+« WÂSWEW, etc, (v. a.) he lights it up, that is to say, by making light to catch fish, with a spear or, he fishes by torchlight
+« WÂSWAW, ok, (v. n.) he works the fish by torchlight
+« WÂSWÂWIN, a, (n. f.) the action of working fish by torchlight
+« WÂSTENAMÂGAN, a, (n. f.) candle, light
+« WÂSTENAMÂGANÂBISK, wa, (n. f.) metal candlestick
+« WÂSTENAMÂGANÂTTIK, wa, (n. f.) wooden candlestick
+« WÂSTENAMÂGANIKKAWEW, etc., (v. a.) he makes him a candlestick
+
+WÂS
+
+« WÂSTENAMÂWEW, etc., (v. a.) he lights it up, he illuminates it
+« WÂSTENIKKÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he spreads the light there
+« WÂSTEPAYIW, ok, a, (a. a. and in.) he becomes luminous
+x WÂSTINIKEW, ok, (v. n.) he shifts his hands, he parries the blows with his hands, and, he makes signs with his hands
+« WÂSTINAMÂWEW, etc., (v. a.) he makes a sign to him with his hand, or another thing
+« WÂSTEHWEW, (v. a.) HAM, HUWEW, HIKEW, he uses it to make signs
+« WÂSTEHAMÂWEW, etc., (v. a.) See. Wâstinamâwew
+x WASKAMISIW, ok, (a. a.) he improves, he becomes better, or better: he is right in the head, has all of his knowledge
+« WASKAMI-AYAW, ok, (a. a.) idem
+« WASKAMISIWIN, a, (n. f.) lucidity, knowledge of what one is doing
+« WASKAMEYITTAM, wok, (v. n.) he is in full knowledge (of what he is doing)
+« WASKAMEYITTÂKUSIW, ok, (a. a.) he acts reasonably
+« WASKAMEYITTÂKUSIWIN, a, (n. f.) good sense
+« WASKAMEYIMEW, etc., (v. a.) he thinks him to be in good sense
+x WASKITCH, (adv.) above, outside, on the outside; waskitchâyik, on the outside
+« WASKITAPIW, ok, (a. a.) he is sitting above
+
+639
+
+WAS
+
+« WASKITASTEW, a, (a. in.) idem
+« WASKITASKAMIK, (adv.) down here, on the ground
+« WASKITCHITCHIN, wok, (a. a.) he is lying, placed above
+« WASKITCHITTIN, wa, (a. in.) idem
+« WASKITAHYEW, (v. a.) STAW, TIWEW, TCHIKEW, he places it above
+« WASKITATEWENAM, wok, (v. n.) he walks on the snow or on the ice, without sinking in
+« WASKITCHIPEKINAM, wok, he walks on the water
+« WASKITCHIPEW, idem
+« WASKITCHIPEK, on the water
+« WATENAM, wok, (v. n.) he walks on the snow without sinking in
+« WASKITATEWEYAW, (v. im.) the snow is hard enough to carry
+« WASKITATENIKWAN, (v. im.) idem
+« WATENIKWAN, (v. im.) idem
+« WASKWESIN, wok, (a. a.) he bounces
+« WASKWETTIN, wa, (a. in.) idem
+« WASKWESIMEW, (v. a.) TTITAW, SIMIWEW, TCHIKEW, he bounces him
+« WASKWEPAYIW, ok, a, (a. a. and in.) he bounces, it rebounds
+« WASKWEPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he rebounds it
+« WASKWENEW, (v. a.) NAM, NIWEW, NIKEW, he pushes it to the side
+x WASKAWIW, ok, (v. n.) he stirs, he moves
+« WASKAWINEW, (v. a.) NAM, NIWEW, NIKEW, he stirs it, he puts it in motion
+
+WAS
+
+« WASKAWIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes him stir, move
+« WASKAWIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he stirs it by pulling
+« WASKAWIPAYIW, ok, a, (a. a. and in.) he stirs, he swarms
+« WASKAWIPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he stirs it, he swarms it
+« WASKAWÂKINAM, wok, (v. n.) he stirs the water
+« WASKWÂGAMIPAYIW, ok, a, (a. a. and in.) the water stirs, experiences a movement
+x WASKOW, a, (n. r.) cloud
+« WASKOWAN, (v. im.) there are clouds
+x WASKWEY, ak, (n. r.) birch, and, birch bark
+« WASKWEYÂBUIY, a, (n. f.) birch syrup, birch juice
+« WASKWESKAW, (v. im.) there are birches in quantity
+« WASKWEYÂTTIK, wok, (n. f.) birch wood
+« WASKWEYÂTTIKUSKAW, (v. im.) there is lots of birch wood
+« WASKEYOSI, a, (n. f.) birch canoe
+« WASKWEYÂGAN, a, (n. f.) vase, dish made with birch bark. See. Kâkwey
+x WÂSPÂWEHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he awakens him by making a noise
+« WÂSPÂWEMEW, etc., (v. a.) idem, by speaking
+
+640
+
+WAT
+
+« WÂSPÂWEPAYIW, ok, (a. a.) he awakens
+x WASAKAY, a, (n. r.) his skin
+x WASASWEPAYIW, ok, a, (a. a. and in.) he disperses, he scatters
+« WASASWEPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he scatters it, he disperses it, he spreads it
+« WASASWEWEPINEW, etc., (v. a.) idem
+« WASASWETISAHWEW, (v. a.) HAM, HUWEW, HIKEW, he disperses it from one side to the other
+« WASWEPEKINATCHIKEW, ok, (v. ind.) he makes the water rebound, he sprinkles
+« WASWEPEKINATTOWEW, etc., (v. a.) he sprinkles it
+« WASWEPEKAHWEW, (v. a.) HAM, HUWEW, HIKEW, idem
+« WASWEPEKINATCHIKEWIN, a, (n. f.) sprinkle
+x WATAKAMISIW, ok, (a. a.) he is lively, angry, hot-tempered, prompt
+« WATAKAMISIWIN, a, (n. f.) hot temper, to be quick to anger
+« WATAKAME, (prefix) to be subject to, etc., e.g. watakame kisiwâsiw, he is subject to anger, watakame kiyâskiw, he is subject to lies, See. Nitta, and, Wakke
+x WATCHEKAMISIW, ok, (a. a.) he is prompt, lively, agile, active
+« WATCHEKAMISIWIN, a, (n. f.) agility, activity
+« WATCHEKAMEYIMEW, etc., (v. a.) he thinks him to be agile, lively
+
+WAT
+
+« WATCHEKAMEYITTAM, wok, (v. n.) he finds the thing easy, to his taste
+« WATCHEPISIW, ok, (a. a.) he is active, agile
+« WATCHEPPIW, ok, (a. a.) idem
+« WATCHEPISIWIN, a, (n. f.) activity, agility
+« WATCHEPEYITTAM, wok, (v. n.) he goes with good heart, it is to his taste
++ WATJIY, a, (n. r.) mountain, assiniy-watjiy, rocky mountain
+« WATJIWIW, or, WAN, (v. im.) it is mountainous
+« WATCHISTUN, a, (n. r.) nest
+« WATCHISTUNAPIW, ok, or, KIKATCHISTUNAPIW, (a. a.) she is on her nest
+« WATCHISTUNIKKEW, ok, (v. n.) she makes her nest
+« WATCHASK, wok, (n. f.) muskrat
+« WATCHASKWEYÂN, ak, (n. f.) rat skin with hair
+« WATCHASKWÂTI, a, (n. f.) rat lodge
+WATCHISTAKÂTCH! (ex.) how strange! is it possible! it's not possible! e.g., watchistakâtch namawiya ituke ekusi kita totam! that isn't possible! he will not do it! watchistakâtch k'etweyan! what you are saying is too much!
+x WATCHISKAW, ok, (v. n.) he limps
+« WATCHISKÂWIN, a, (n. f.) the action of limping
+
+641
+
+WÂW
+
+x WATIKKWAN, a, (n. f.) knot, and, branch
+« WATIKKWANIWIW, or, WAN, (v. im.) there are knots
+x WATAPIY, a, (n. f.) small spruce root which one uses for sewing bark canoes
+« WATAPIWIW, or, WAN, (v. im.) there are spruce roots
+« WATAPIWAT, a, (n. f.) basket
+x WÂTI, plur, wâta, (n. r.) hole in the gorund
+« WÂTISKAW, (v. im.) there are many holes
+« WÂTIKKAN, a, (n. f.) cellar, pit
+« WÂTIKKEW, ok, (v. n.) he digs a pit, a cellar
+« WATOW, ok, (n. r.) debris from scraping skin, the part that one removes from the skin after having taken the skin off
+« WATOW, a, (n. f.) clotted, coagulated blood
+« WÂHÂKAY, ak, (n. r.) fish scales. See. Wâkay, ak
+« WÂWÂTCH, (conj.) and, even. See. Mina
+x WÂWÂSKESIW, ok, (n. r.) stag, doe
+« WÂWÂSKESIWISIPIY, (n. f.) Labiche River
+« WÂWÂSKESIWISÂKAHIGAN, (n. f.) Lake Labiche
+x WÂWÂKISTIKWEYAW, (v. im.) it is a curved river
+« WÂWÂKITTIN, wa, (v. im.) idem, winding
+« WÂWÂKAMOW, (v. im.) curved trail
+« WÂWÂKATINAW, (v. im.) mountain which goes meandering on
+
+WÂW
+
+x WÂWÂNEYITTAMOWIN, a, (n. f.) See. the root Wan
++ WÂWÂNISIW, ok, (a. a.) he is in need
+« WÂWÂNISIWIN, a, (n. f.) need, lack
+« WÂWÂNIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he needs him
+« WÂWÂNAKATEW, ok, (a. a.) he is in famine
+WÂWÂNAKATEWIN, a, (n. f.) famine, drought
+x WAWÉ, (rac.) to adorn, to ornament, to prepare for a departure
+« WAWESIW, ok, (v. r.) he gets himself in order, he adorns himself, he grooms himself
+« WAWESIHUW, ok, (v. r.) idem
+« WAWESIWIN, a, (n. f.) grooming
+« WAWESIHUWIN, a, (n. f.) idem
+« WAWESIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he arranges it, he adorns it, he prepares it (for a departure)
+« WAWEYIHEW, etc., (v. a.) idem
+« WAWEYIW, ok, (v. n.) he gets himself in order, he makes his preparations to depart
+« WAWESIHUWÂKEW, ok, (v. r.) he makes an ornament of it, he adorns it
+« WAWESITTAMAWEW, etc., (v. a.) he prepares him, he arranges it for him
+x WAWEYÂPAMEW, (v. a.) TTAM, KKEW, TCHIKEW, he examines it, he looks at it attentively
+« WAWEYASKIWOKINEW, (v. a.) NAM, NIWEW, NIKEW, he arranges it with care, he polishes it, e.g., earth, mortar, gum
+
+642
+
+WÂW
+
+WÂWIYÂWITTAM, wok, (v. n.) he hears. See. Pettam
+x WAWIYATEYITTÂKUSIW, ok, (a. a.) he is funny, comical, a joker
+« WÂWIYATEYITTÂKWAN, wa, (a. in.) it is funny, comical
+« WÂWIYATEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he finds him funny, comical
+« WÂWIYATWEW, ok, (v. n.) he says jokes, funnies
+« WAWIYATWEWIN, a, (n. f.) jokes, buffoneries
+« WÂWIYASITTÂKUSIW, ok, (a. a.) he is a jokester to listen to
+« WÂWIYASITTÂKWAN, wa, (a. in.) it is funny, comical to hear
+« WÂWIYASITTAWEW, (v. a.) TTAM, TTÂKEW, TTÂTCHIKEW, he finds him to be a jokester, comical to listen to
+« WÂWIYASINAWEW, (v. a.) NAM, NÂKEW, NÂTCHIKEW, he finds him strange, comical to look at
+« WÂWIYASIHEW, etc, (v. a.) he makes jokes, buffoneries, he plays a good trick on him
+« WÂWIYASIMEW, etc., (v. a.) he speaks to him in a comical fasion
+« WAWIYATISIW, ok, (a. a.) it is good for him (that which he was going to do)
+« WÂWIYATISIWIN, a, (n. f.) trick played on someone
+« WÂWIYATISIKKEW, ok, (v. n.) he makes jokes, buffoneries
+
+WÂW
+
+WÂWIYAKKWEW, ok, (v. n.) he says dishonest words. See. Wiyakkwew
+WÂWI, plur. wâwa, (n. r.) egg. N.B. Awew is the verbal suffix to indicate eggs, e.g., mânâwew, he collects eggs, mânâwân, place where one collets eggs
+« WÂWIGAN, a, (n. f.) lower back, backbone
+x WÂWIY, (rac.) round, like a globe
+« WÂWIYÂNIGAN, a, the whole vertebral column, also, the ridge of a building
+« WÂWIYÂPISKUSIW, ok, (a. a.) he is round (metal)
+« WÂWIYÂPISKAW, a, (a. in.) idem (metal)
+« WÂWIYÂSKUSIW, ok, (a. a.) idem (wood)
+« WÂWIYÂSKWAN, wa, (a. in.) idem (wood)
+« WÂWIYEYÂTCHIWAN, (v. im.) gulf, torrent of water
+« WÂWIYEYÂSIKEW, ok, (a. a.) (pisîm) the Sun or the Moon has a circle
+« WÂWIYESIW, ok, (a. a.) he is round, he is made round, e.g., wâwiyesiw, pisim, the Moon is full
+« WÂWIYEYAW, a, (a. in.) idem
+« WÂWIYESIWIN, a, (n. f.) roundness, circle
+« WÂWIYEYÂWIN, a, (n. f.) idem, (inanimate)
+« WÂWIYEYÂTTIYEW, (v. im.) full Moon
+
+643
+
+WÂY
+
+« WÂWIYEHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it round
+« WÂWIYEKIJIK, (n. f.) the roundness of the firmament
+« WÂWIYEPAYIW, ok, a, (a. a. and in.) it goes around
+« WÂWIYEPIWOK, (a. a.) they are seated around
+« WÂWIYESTEW, a, (a. in.) it is placed in a circle
+« WÂWIYEYÂKINEW, (v. a.) NAM, NIWEW, NIKEW, he forms it in a circle, around
+« WÂWIYEYÂPISKINEW, etc., (v. a.) idem (metal)
+« WÂWISIW, ok
+x WÂWIS, (adv.) a fortiori (from the stronger (argument)), even more so, e.g., wâwis ituke, probably, without doubt
+« WÂWISITUKE, (adv.) even more so, without doubt
++ WAYASITA, (n. r.) small foot of an animal
+« WAYASITAPPINEW, ok, (a. a.) he has a pain in his small foot
+x WÂYÂKUNAHWEW, (v. a.) HAM, HUWEW, HIKEW, he buries him under the snow
+« WÂYEHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he digs it
+« WÂYIPEYÂN, a, dug out place, depression
+« WÂYIPEYAW, (v imp.) pool
+« WÂYISIW, ok, (a. a.) he is dug out, concave
+« WÂYAW, a, (a. in.) idem
+« WÂYISIWIN, a, (n. f.) concavity
+« WÂYÂPISKATAHWEW, (v. a.) HAM, HUWEW, HIKEW, he digs it into a concavity
+
+WÂY
+
+« WÂYITCHITCHÂN, (n. f.) hollow of the hand
+« WÂYATCHAW, (v. im.) concave, lowland terrain
+« WÂYATINAW, (v. im.) passage, concavity in a mountain, valley between two hills
+x WAYA, (rac.) to go outside, on the outside
+« WAYATCHÂWIW, ok, (v. n.) he leaves, he goes out on the current
+« WAYAWISKAWEW, he leaves his body, or, his home
+« WAYAWIW, ok, (v. n.) he goes outside. N.B. This also means: he expels, he answers the call of nature
+« WAYAWIWIN, a, (n. f.) the action of going outside, exit
+« WAYAWITTAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he transports it outside
+« WAYAWITISAHWEW, (v. a.) HAM, HUWEW, he sends it outside, he throws it outside
+« WAYAWIYÂBATTEW, (v. im.) the smoke leaves, like from a chimney
+« WAYAWIYÂSIKAWIW, (v. im.) it oozes, it leaks outside
+« WAYAWIPATTAW, ok, (v. n.) he leaves by the current
+« WAYAWIYÂMOW, ok, (v. n.) he leaves by fleeing
+« WAYAWIPAYIW, ok, a, (a. a. and in.) he goes outside, it goes on the outside
+« WAYAWIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he pulls it outside
+« WAYAWISTAWEW, etc., (v. a.) he leaves through him
+« WAYAWITIMIK, (adv.) outside
+
+644
+
+WAY
+
+« WAYAWITIMÂYIK, (adv.) on the outside
+« WAYAWITISINEW, (v. a.) NAM, NIWEW, NIKEW, he pushes it outside, with his hand
+« WAYAWIWEPINEW, (v. a.) NAM, NIWEW, NIKEW, he throws it outside
+« WAYAWIWEPAHWEW, (v. a.) HAM, HUWEW, HIKEW, he throws it, he spills it outside by hitting it
+« WAYAWIYAW, ok, (v. n.) he leaves by flying
+WAYAKASK, (n. r.) palate of the mouth
+x WAYESKÂNISIW, ok, (a. a.) he is unfortunate, e.g., by losing his sight, a limb, his children, or, by some misfortune
+« WAYESKÂNISIWIN, a, (n. f.) misforune, woe
+« WAYESKÂNIMEW, etc., (v. a.) idem, by his words
+« WAYESKÂNEYIMEW, etc., (v. a.) he ginds him unfortunate, woeful
+« WAYESKÂNEYITTÂKUSIW, ok, (a. a.) he is in misery, unfortunate
+x WAYESIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he cheats him, he tricks him
+« WAYESIHIWEW, ok, (v. ind.) he cheats, he tricks
+« WAYESIHIWEWIN, a, (n. f.) trickery, deceit
+« WAYESIHISUW, ok, (v .a.) he is in an illusion
+
+WAY
+
+« WAYESIHISUWIN, a, (n. f.) self-illusion
+« WAYESITOTAWEW, etc., (v. a.) See. wayesihew
+« WAYESIMEW, etc., (v. a.) he says treacherous, cheating, false words to him
+« WAYESINEHWEW, (v. a.) HAM, HUWEW, HIKEW, he cheats him
+« WAYESINEHIKEWIN, a, (n. f.) deceit
++ WÂYO, (adv.) far, a great distance
+« WÂYOWIS, (adv.) a bit far
+« WÂYOWESKAMIK, (adv.) very far
+« WÂYONEW, he waits for him from far away with his hand
+x WAYESÂBIW, ok, (a. a.) he has an eye-ache from the snow, he has snow sickness
+« WÂYESÂBIWIN, a, (n. f.) snow sickness
+x WEMISTIKOJIMOWIN, a, (n. f.) French language, Canadian
+« WEMISTIKOJIMOTOTAWEW, etc., (v. a.) he speaks to him in French
+« WEMISTIKOJIW, ok, (n. f.) a Frenchman, a Canadian, a White, a civilised man
+« WEMISTIKOJIWIW, ok, (a. a.) he is French, he is a civilised man
+« WEMISTIKOJISKWEW, ok, Frenchwoman, female Canadian
+« WEMISTIKOJISKWEWIW, ok, (a. a.) she is French, etc.
+« WEMISTIKOJIMOW, ok, (v. n.) he speaks French
+« WEMISTIKOJIKIJWEW, ok, (v. m.) idem
+
+645
+
+WEP
+
+« WEMISTIKOJIKIJWÂTEW, etc., (v. a.) he speaks to him in French
+« WEMISTIKOJIKIJWEWIN, a, (n. f.) French speech
+« WEMISTIKOJIWASKIY, (n. f.) France
+« WEMISTIKOJIMOTTITAW, ok, (v. a. in.) he translates it into French
+« WEMISTIKOJIWIMASINAHIGAN, a, (n. f.) French book
+x WEKOSISSIK, (v. ind. subj.) a son, the son
+x WEP, (rac.) to throw out, to throw, to reject, to be taken away by, etc.
+« WEPÂHAMÂWEW, etc., (v. a.) he casts a spell on him
+« WEPÂPOKOW, ok, (a. a.) he is taken away by the current
+« WEPÂPOTEW, a, (a. in.) idem
+« WEPÂPOWAYEW, (v. a.) TAW, YIWEW, TCHIKEW, he erases it with water
+« WEPÂWAYEW, etc, (v. a.) idem
+« WEPÂSIW, ok, (a. a.) he is carried away by the wind
+« WEPÂSTAN, wa, (a. in.) idem
+« WEPÂSTIMEW, (v. a.) TTAW, NIWEW, TCHIKEW, he winnows it
+« WEPÂSTCHITCHIGAN, a, (n. f.) sieve
+« WEPATEMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he casts it out of his mouth
+« WEPAHÂKUNÂGAN, a, (n. f.) instrument for throwing off snow
+« WEPAHÂKUNÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he removes the snow on him, he throws off the snow that is there
+« WEPAHÂKUNEW, ok, (v. n.) he throws, he sweeps the snow
+
+WEP
+
+« WEPAHIKEW, ok, (v. ind.) he sweeps
+« WEPAHIGAN, a, (n. f.) broom
+« WEPAHIKANIKKEW, ok, (v. n.) he makes a broom
+« WEPAHWEW, (a. a.) HAM, HUWEW, HIKEW, he sweeps it
+« WEPÂHÂSKWÂN, a, (n. f.) sling
+« WEPÂHÂSKWEW, ok, (v. n.) he slings, he throws something with a sling
+« WEPÂHÂSKWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he slings it
+« WEPEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he leaves it to himself, and, he throws it, he pushes it out, he rejects it in his mind
+x WEBEYIMOW, ok, he abandons himself to his fate, he rejects his body, he sacrifices himself
+« WEPINISUW, ok, or, NUW, ok, (v. r.) idme
+« WEPEYIMOWIN, a, (n. f.) abandonment of oneself to, etc.
+« WEPEYITTAMÂWEW, See. wepâhamâwew
+« WEPINÂSUW, ok, (v. n.) he makes a sacrifice
+« WEPINÂSUWIN, a, (n. f.) sacrifice, offering
+« WEPINÂSUSTAWEW, etc., (v. a.) he offers him a sacrifice
+« WEPINÂSUSTAMÂWEW, etc., (v. a.) he offers a sacrifice for him
+« WEPIMEW, etc., (v. a.) he incites him, he pushes him to do something, by his words
+
+646
+
+WES
+
+« WEPIMOW, ok, (v. n.) he speaks to excite (someone) to, etc.
+« WEPIMOWIN, a, (n. f.) proper speech to excite, to encourage, etc.
+« WEPINEW, (v. a.) NAM, NIWEW, NIKEW, he rejects him
+« WEPINIKÂSUW, ok, (a. a.) he is rejected, put to the side
+« WEPINIKÂTEW, a, (a. in.) idem
+« WEPINISKWEWEW, ok, (v. n.) he rejects his wife
+« WEPINAMÂWEW, etc., (v. a.) he throws him, he discards him
+« WEPINISKEW, ok, (v. n.) he lets go of his arm to hit
+« WEPINASKWÂTEW, WEPIPAYIW, ok, a, (a. a. and in.) he falls, he overturns himself, he staggers
+« WEPIPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he overturns him, he defeats him
+« WEPIPAYIHITUWOK, (p. m.) two people holding one another's bodies, trying to overturn the other
+« WEPISIMEW, etc., (v. a.) he overturns him to the ground, he defeats him
+x WEHWEW, ok, (n. r.) wild goose
++ WESÂ, (adv.) e.g. wesa mistahi, much too much, namawiya wesâ, not too much, namawiya wesâ kissin, it isn't too cold out, wesa ki kakebâtisin, you are too foolish
+« WESÂMIK! (ex.) is it possible! it can't be! that's unbelievable! e.g., wesâmik mistahi matchi ayiwiw! it is unbelievable how mean he is! wesâmik ke pakamahusk! it's not possible that he'll come here to hit you! namawiya wesâmik, ekusi kitchitotak! he won't come here just to do that! wesâmik awiyak metchi-ayiwitji! is it possible that there could be somebody so cruel!
+
+WES
+
+« WESÂMIKITUKE! (ex.) that's impossible!
+x WESKATCH, or, WESKAT, (adv.) a long time ago, formerly, in the olden days
+« WESKATCHÊS, (adv.) idem, it was already a bit of a long time ago
+« WESKATCHINÂKUSIW, ok, (a. a.) he appears ancient
+« WESKATCHINÂKWAN, wa, (a. in.) idem
+« WESKATISIWIN, a, (n. f.) antiquity
+« WESKATISIW, ok, (a. a.) he is ancient
+WESKWÂTEMIK, (n. r.) part of the lodge that is opposite the door
+x WET, (rac.) to find easy, easily, that which is easily done
+« WETCHIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he comes to the end easily
+« WETCHIHUW, ok, (v. r.) he makes himself easy to be grabbed, or killed, or seen, e.g. a bird which passes by the sights of a rifle, a beast which falls in a trap, a person who lets himself be taken easily, she gives in the trap
+« WETAPIKKÂTRW, (v. a.) TAM, SIWEW, TCHIKEW, he ties it quite easily
+
+647
+
+« WETTISIW, ok, (a. a.) he is easy, in ease
+« WETTAN, wa, (a. in.) idem
+« WETTEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he finds it easy, easily done
+« WETCHINATEW, (v. a.) TAM, SIWEW, TCHIKEW, he kills him easily
+« WETTAKISIW, ok, (a. a.) he is not expensive
+« WETTAKITTEW, a, (a. in.) idem
+« WETTAKIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he values him at a low price
+« WETTATAYESIW, ok, (a. a.) it is not expensive (fur)
+« WETTATAYEYAW, a, (a. in.) idem
+« WETINA, (adv.) easily, readily, with ease, calmly
+« WETISIW, ok, (a. a.) he is haired, he has great locks of hair
+« WETWEW, ok, (v. n.) he sells at a low price
+x WESPINATCH, (adv.) against all expectation, for little, for a trifle
+« WESPINATCHIYAWEHEW, etc., (v. a.) he angers him over nothing
+« WESPINATCHIYAWESIW, he is angry over nothing
+« WESPINATCHIYAWESIWIN, a, (n. f.) angry without reason
+x WEWESTÂHAMAW, ok, (v. n.) he swats
+« WEWESTÂHAMÂN, a, (n. f.) swatter
+« WEWESTÂHAMÂWEW, etc., (v. a.) he swats it
+
+WES
+
+x WESTAHWEW, etc., (v. a.) someone who kills an animal, and placing the meat in a cache, leaves a signal there (a scarecrow) to keep away carnivorous beasts
+« WESTATAWEW, ok, (v. n.) idem
+« WESTAHIGAN, a, (n. f.) sign, scarecrow
+WETJITAWI, (adv.) very, many; e.g. wetjitawi miyo-pimâtisiw, he lives exceedingly well; wetjitawi iyinisiw, he is very wise. See. Otjitaw
+x WEWEK, (rac.) to wrap
+« WEWEKAPITCHIGAN, a, (n. f.) headband
+« WEWEKAPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he places a headband on him
+« WEWEKINEW, (v. a.) NAM, NIWEW, NIKEW, he wraps it
+« WEWEKINIGAN, a, (n. f.) wrap
+« WEWEKIW, ok, (v. r.) he wraps himself
+« WEWEKISTIKWÂNEW, ok, (a. a.) he has a wrapped head
+« WEWEKISTIKWÂNEPITEW, etc., (v. a.) he wraps his head (somebody else's)
+« WEWEKISTIKWÂNEHEW, etc., (v. a.) idem
+« WEWEKISTIKWÂNEPISUW, ok, (v. r.) he wraps his own head
+x WEWEP, (rac.) to rock, to stir, to wobble
+« WEWEPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he rocks it
+« WEWEPÂYOWEW, ok, (v. n.) he wags his tail
+« WEWEPIPAYIW, ok, a, (a. a. and in.) it swings, it wobbles
+
+648
+
+WI
+
+« WEWEPÂSIW, ok, (a. a.) he wobbles in the wind
+« WEWEPÂSTAN, wa, (a. in.) idem
+« WEWEPIPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he swings it, he brandishes it
+« WEWEPIPAYITCHIGAN, a, (n. f.) swing
+« WEWEPISUW, a, (n. f.) rocking chair
+« WEWEPIKEYIW, ok, (v. n.) he swings, his body wobbles
+« WEWEPISKWEYIW, ok, (v. n.) he wobbles his head
+« WEWEPISKWEYISTAWEW, etc., (v. a.) he wobbles his head before him
+x WEYOTISIW, ok, (a. a.) he is rich, he abounds, he fertilises
+« WEYOTAN, wa, (a in.) idem
+« WEYOTISIWIN, a (n. f.) richness, abundance
+« WEYOTCHI-AYAW, ok, a, (a. a. and in.) he abounds
+« WEYOTCHIPAYIW, ok, a, (a. a. and in.) it abounds, it becomes abundant
+« WEYOTISIHEW, etc., (v. a.) he enriches it
+« WEYOTEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he thinks him to be rich
+« WEYOTEYIMOW, ok, (v. r.) he believes himself to be rich
+WI, prefix before the verb, sign of volition; e.g., wi-sipwettew, he wants to leave; namawiya ni wi-miyaw, I do not want to give (it) to him; wi-wittamâwiyani, if you want to confess it to me
+WI, means the same thing as the prefix, being on the point of, etc., ; e.g., wi-nipiyani, when you are to die; wa-mitjisuyani ayamiha, when you are going to eat, pray. N.B. Wi makes wa, to the positive
+
+WI
+
+WI, means still, to begin to, etc.; e.g. wi-nottekatewok, they begin to get hungry, thatis to say, they begin to feel the famine; ekwa wi-miyo ayaw, he begins to be better. Though these three wi, in principle, are the same, and only express the idea of the verb 'to want', their meaning changes according to the meaning of the sentence
+WIKKÂTCH, (adv.) never (usually with negation); e.g., nama wikkâtch ni wâbamaw, I never see it; namawiya miweyittam wikkâtch, he is never happy; wikkâtch tchi pittukew, does he ever enter?
+WIKKÂTCH, (adv.) better yet; wâwikkâtch, rarely, from time to time. See. Ayâskaw, e.g., wâwikkâtch ayamihaw, he only rarely prays
+x WIKI, (n. r.) his residence; niki, my residence; kiki, your residence, nikinân, our residence, etc.
+WIKISKAWEW, he resides in him
+« WIKIW, ok, (v. n.) he resides, he sojourns
+« WIKIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he resides with him, or, he is married to her, he stays with her
+
+649
+
+WIK
+
+« WIKITTUWOK, (v. m.) they reside together, they are married together
+« WIKITTUWIN, a, (n. f.) marriage, union, kitchi, Christian marriage
+« WIKIMÂGAN, ak, (n. f.) companion, spouse; e.g., owikimâgana, his spouse, or her spouse
+« WIKIMÂGANIMEW, etc., (v. a.) he resides with him, he has him as a companion, also, she has him as a spouse
+« WIKIMÂGANIKKAWEW, etc., (v. a.) he gives him as a companion, he makes him have a living companion
+« WIKITTUW, ok, (v. m.) he is married, kitchi wikittuw, he is married in Christian fashion
+« WIKITTAHEW, etc., (v. a.) he unites them together; kitchi wikittahew, he marries them
+« WIKITASKIWEMEW, etc., (v. a.) he is his compatriot, he resides in the same country as him
+x WIKK, (rac.) agreeable to the taste, to the smell, likable
+WIKKASKOKISEYIN, the man of the fragrant grass, this is the name of the chief of the Cree
+« WIKKIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he loves him, he cherishes him
+« WIKKIMÂMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he finds him agreeable to the smell
+« WIKKIMÂKUHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he perfumes him
+« WIKKIMÂKUHUW, ok, (v. n.) he perfumes himself
+« WIKKIMÂKUHUN, a, (n. f.) perfume, aromatic
+
+WIK
+
+« WIKKIMÂKUHUWIN, a, (n. f.) idem
+« WIKKIMÂKUSIW, ok, (a. a.) he is fragrant
+« WIKKIMÂKWAN, wa, (a. in.) idem
+« WIKKIMÂKUSIWIN, a, (n. f.) good odour, perfumery
+« WIKKIMÂSWEW, (v. a.) SAM, SUWEW, SIKEW, he burns incense, perfumes
+« WIKKIMÂSIGAN, a, (n. f.) incense smoke, perfume which one burns
+« WIKKASKOSAMÂWEW, etc., (v. a.) he burns fragrant grass for him
+« WIKKASKOSWEW, etc., (v. a.) he burns fragrant grass
+« WIKKASKOSIGAN, a, (n. f.) fragrant grass which one burns, perfume smoke
+« WIKKIMÂSUW, ok, (a. a.) he is fragrant
+« WIKKIMÂSTEW, a, (a. in.) idem
+« WIKKIMÂSÂWEW, ok, (v. n.) he burns perfumes
+« WIKKIMÂSÂWEWIN, a, (n. f.) the action of burning perfumes
+« WIKKIPEW, ok, (v. n.) he likes to drink, he is a drunkard
+« WIKKIPEWIN, a, (n. f.) love of drunkenness
+« WIKKIPWEW, (v. a.) STAM, he likes the taste of it, he likes this food
+« WIKKIPUW, ok, (v. n.) he eats with appetite, he finds what he is eating to be good
+« WIKKOMEW, etc., (v. a.) he invites him to eat at a feast
+« WIKKOKEW, ok, (v. n.) he has a feast
+
+650
+
+WIK
+
+« WIKKOKEWIN, a, (n. f.) feast
+« WIKKOTTUW, ok, (v. m.) he has a feast
+« WIKKOTTUWOK, (v. m.) they invite one another to a feast
+« WIKKOTTUHEW, etc., (v. a.) he holds him a feast
+« WIKKWÂSTIMWEW, ok, (v. n.) she calls her dog
+« WIKKWÂSTIMWÂTEW, etc., (v. a.) she calls it (her dog)
+« WIKKITISIW, ok, (a. a.) he is sweet, pleasant to the taste
+« WIKKASIN, wa, (a. in.) idem
+x WIKUPIY, a, (n. r.) willow bark, with which one makes ropes, baskets
+« WIKUPIYÂBIY, a, (n. f.) willow bark rope
+x WIKKWAY, a, (n. r.) bladder
+« WIKKWÂS, a, (n. f.) small piece of skin of a bladder
+x WIKKWE, (rac.) round, like a barrel, a circle
+« WIKKWESIW, (a. a.) he is round
+« WIKKWEYAW, (a. in.) idem
+« WIKKWESIWIN, a, (n. f.) roundness
+« WIKKWETINAW, (v. im.) round hill, mountain
+« WIKKWEKUTEW, (v. a.) TAM, SIWEW, TCHIKEW, he sculpts it round
+« WIKKWEKWÂTEW, etc., (v. a.) she sews it round
+« WIKKWEKWÂSUW, ok, (v. n.) he sews it round
+« WIKKWEKWÂSWEW, (v. a.) SAM, SUWEW, SINEW, he shapes it round
+
+WIK
+
+« WIKKWEPÂN, ak, (n. f.) pants, breeches
+x WIKK, (rac.) to remove with effort, to save from danger
+« WIKKWATCHIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he removes it, e.g., a nail, somehing which is planted, also: he saves it, he removes him from his bad path
+« WIKKWATCHIW, (v. n.) he escapes, he evades, e.g., a trapped animal who breaks its bonds and flees, he runs away
+« WIKKWATCHIHUW, ok, (v. r.) idem
+« WIKKOW, ok, (v. n.) idem
+« WIKKWATCHIPAYIHUW, ok, (v. r.) idem
+« WIKKWATCHIWIN, a, (n. f.) evasion, deliverance
+« WIKKWATCHIHUWIN, a, (n. f.) idem
+« WIKKOWIN, a, (n. f.) idem
+« WIKKWATINEW, (v. a.) NAM, NIWEW, NIKEW, he removes it with his hand
+« WIKKWATCHIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he removes it by pulling with effort
+« WIKKWATAHWEW, (v. a.) HAM, HUWEW, HIKEW, he pulls it out, he removes it
+« WIKKWATAHIGAN, a, (n. f.) instrument for removing, pliers
+x WIMA, (rac.) to make a detour to avoid a meeting
+« WIMÂSKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he makes a detour, he passes at a distance so as not to meet him, to not pass close to him
+
+651
+
+WIN
+
+« WIMÂTTEW, ok, (v. n.) he makes a detour
+« WIMÂTTEWIN, a, (n. f.) detour, while walking
+« WIMÂKIJWEW, ok, (v. n.) he speaks in a circuitous, ambiguous manner, or, wâwimâwew
+WIMÂKIJWEWIN, a, (n. f.) circuitous speech, parable
+« WIMÂTTAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes him take a detour
+x WINI, plur. wina, (n. r.) marrow
+« WINITTAK, wa, (n. f.) marrow, heartwood
+x WIN, (rac.) to dirty, to stink, detestable
+« WINEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he has digust, disdain, aversion for him
+« WINEYITTÂKUSIW, ok, (a. a.) he is disgusting
+« WINEYITTÂKWAN, wa, (a. in.) idem
+« WINEYITTÂKUSIWIN, a, (n. f.) disgusting thing
+« WINIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he sullies it, he desecrates it
+« WINIHUW, ok, (v. r.) he sullies himself, he pollutes himself
+« WINIHUWIN, a, (n. f.) sullying, pollution
+« WINIMÂSWEW, (v. a.) SAM, SUWEW, SIKEW, he burns something whose odour is disgusting
+
+WIN
+
+« WINIMÂSUW, ok, (a. a.) he has a disgusting odour
+« WINIMÂSTEW, a, (a. in.) idem
+« WINIMÂSUWIN, a, (n. f.) abominable odour
+« WINISIW, ok, (a. a.) he is dirty, sullied, impure
+« WINAW, a, (a. in.) idem
+« WINIMÂKUSIW, ok, (a. a.) he spreads a bad odour
+« WINIMÂKWAN, wa, (a. in.) idem
+« WINISAKÂTTIP, ak, (n. f.) small quadruped which resembles a badger
+« WINISIWIN, a, (n. f.) defilement, impurity
+WI-OTÂNI, (prep.) it's him, if, e.g., wiyotâni kaskittâyâni, that is to say, if I come to the end
++ WIPPISIW, ok, (a. a.) he is hollow, like a pipe
+« WIPPAW, a, (a. in.) idem
+« WIPPISIWIN, a, (n. f.) cavity
+« WIPPIPEKAW, (v. im.) cavity in the water
+« WIPPIPEKÂSTAN, (v. im.) idem (from the wind)
+« WIPPAHWEW, (v. a.) HAM, HUWEW, HIKEW, he pierces it, he digs it, something cylindrical
+« WIPPÂSKUSIW, ok, (a. a.) he is hollow (a tree)
+« WIPPÂSKWAN, (a. in.) idem (a tree)
+« WIPPIKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he hollows it out, e.g., he hollows out a tree to make a canoe
+« WIPPIKAHIGAN, a, (n. f.) hollowed out tree, wooden canoe
+
+652
+
+WIS
+
++ WIPIS, a, (n. r.) arrow, (often used with the diminutive)
+« WIPISIS, a, (n. f.) idem, owipisisiw, he has arrows
+« WIPPEMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he lies with him
+« WIPPETTUWOK, (v. m.) they lie together
+WIPITTWÂNISIB, ak, (n. r.) duck, of the third type
+x WIPUSKAW, (v. im.) forest where a fire has passed, (burnt)
+WIPATCH, (adv.) quickly, promptly. See. Kiyipa
+x WISAK, (rac.) to suffer, to feel a pain, bitterness
+« WISAKISIW, ok, (a. a.) he is bitter, harrowing, harsh
+« WISAKAN, wa, (a. in.) idem
+« WISAKISIWIN, a, (n. f.) bitterness, harshness
+« WISAKÂGMIW, (v. im.) it is bitter, e.g., a liquid
+« WISAKÂBIW, ok, (a. a.) he has pain in his eyes
+« WISAKÂPASUW, ok, (a. a.) idem (from smoke)
+« WISAKÂBIWIN, a, (n. f.) pain in the eyes
+« WISAKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he harms him, he hits him
+« WISAKINEW, (v. a.) NAM, NIWEW, NIKEW, he harms him by touching him
+« WISAKIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he harms him, e.g., by pulling his arm, his ekin, etc.
+
+WIS
+
+« WISAKISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he harms him by hitting him with his foot
+« WISAKEYITTAM, wok, (v. n.) he suffers
+« WISAKEYITTAMOWIN, a, (n. f.) pain
+« WISAKISIN, wok, (a. a.) he harms himself by falling, by hitting himself against
+« WISAKIPAYIW, ok, (a. a.) idem
+« WISAKISIMEW, (v. a.) TTITAW, SIMIWEW, TCHIKEW, he harms him by throwing him to the ground, by hitting him
+« WISAKASEW, ok, (a. a.) he has sensitive skin, he suffers in his skin
+« WISAKASEWIN, a, (n. f.) pain of the skin
+« WISAKASEYÂPAHWEW, etc., (v. a.) he hits him on the skin
+« WISAKEYITTAMOSTAMAWEW, etc., (v. a.) he suffers for him, in his place
+« WISAKIMIN, a, (n. f.) bitter seed, cranberry
+« WISAKISKÂKUW, ok, (v. pass.) it causes him harm, e.g, his food causes him indigestion
+« WISAKAMEW, etc., (v. a.) he hurts him by biting him
+« WISAKAPPINEW, ok, (a. a.) he has a sickness which makes him suffer
+« WISAKATWEMOW, ok, (v. n.) he cries bitterly
+« WISAKATWEMOWIN, a, (n. f.) bitter crying
+
+653
+
+WIS
+
+« WISAKITEHEW, ok, (a. a.) he has pain in his heart, (from difficulty)
+« WISAKITEHEWIN, a, (n. f.) pain of the heart, grief
+« WISAKITEHESKÂKUW, ok, (v. pass.) it gives him grief, it hurts his heart
++ WISAKKETJÂK, (n. r.) fantastical man of various Northern tribes, to whom they attribute a supernatural power, with a great number of ruses, tricks, and follies. He is seen as the principal spirit, and the founder of these nations. Among the Salteaux, one calls him Nenâboj, among the Blackfoot, Nâpiw
+« WISAKKETJAKOW, (a. a.) it is a curve, a cheat
+x WISASO, (adv.) all of the sudden, atchiyaw, e.g., someone who all of the sudden becomes angry, but who soon calms down, wisaso kisiwâsiw
+« WISASOWESTIN, (v. im.) violent wind, sudden hurricane
+« WISASWEYIMEW, etc., (v. a.) he loves him all of the sudden, but only for a moment
+« WISASWEYIMOW, ok, (v. n.) he is happy for a moment. See. Sasweyimow
+« WISASWEYIMOWIN, a, (n. f.) happiness for a moment
+x WISÂKKAWEW, etc., (v. .a) he attracts him to him, he charms him in a way to make him follow him
+« WISÂMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he invites him to accompany him
+
+WIS
+
+« WISÂWITAM, wok, (v. n.) he invites to go with him
+« WISÂWITAMOWIN, a, (n. f.) invitation to accompany
+x WISI, plur. wisa (n. r.) fleshy part which covers the stomach
+x WISINAW, a, (n. r.) castoreum, liquid contained within the two glands of the beaver
+x WISISOMIKKUSIW, ok, (a. a.) he is a bright red
+« WISISOMIKKWAW, a, (a. in.) idem
+WISÂPUSKITEW
+x WISKAWÂHEW, etc., (v. a.) he arrives on him without being seen, he takes him out of the blue
+WISKOWIN, (adv.) dubitanter (doubtingly), dubium est (he is doubtful)
+x WISKWASWEW, (v. a.) SAM, SUWEW, SIKEW, he blackens it, he darkens it by smoking it
+« WISKWASUW, ok, (a. a.) he is smoked, blackened by smoke
+« WISKWASTEW, a, (a. in.) idem
+« WISTEPAKKWAY, a, (n. f.) old piece of leather, skin of the lodge, all smoked
+« WISTEPAKKWAYWIKAMIK, wa, (n. f.) old lodge completely blackened by smoke
+x WISKATJÂN, ak, (n. r.) magpie, winter bird
+« WISKATJÂNISIB, ak, (n. f.) duck which resembles a magpie
+WISKWA, (n. r.) his companion (when speaking of the wives of a bigamist)
+x WISKWENEW, (v. a.) NAM, NIWEW, NIKEW, he wraps it, he rolls it up
+
+654
+
+WIT
+
+« WISKWENIGAN, a, (n. f.) wrap
+« WISKWEPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he rolls it up, he attaches it, e.g., the opening of a bag
+« WISKWEPITÂGAN, a, (n. f.) medicine bag of the jugglers
+« WISKWESTIKWÂNEPITEW, etc., (v. a.) he wraps his head (somebody else's)
+x WISOPIY, a, (n. r.) gall
+WISTA, (pron.) him too, and him
+« WISTAWAW, (pron) them too, and them
+« WISTANÂKATCH, (adv.) (irony) up to him, etiam (besides); e.g., wistanâkatch ka wi-pikiskwet, up to him who wants to speak
+« WISTÂKAWIYA, (pron.) him too; e.g., wistâkawiya kitimâkisiw, he too is miserable
+x WISTI, plur. wista, (n. r.) lodge of a beaver, rat, etc.
+« WISTIKKÂN, a, (n. f.) hay mill, grindstone for hay or other things
+« WISTIKKÂNIS, a, (n. f.) small hay mill
+« WISTIKKEW, ok, (v. n.) he makes a hay mill
+« WISTISKAW, (v. im.) there are many beaver's lodges, rat lodges, etc.
+WISTIN, (v. im.) violent wind. See. Kistin
+x WIT, and, WITCH, (rac. and prefix) accompaniment, to do something together
+« WITASKIW, ok, (v. n.) he has the same country, he makes peace
+« WITASKIWIN, a, (n. f.) peace, the action of making peace
+
+WIT
+
+« WITASKIMEW, etc., (v. a.) he makes peace with him
+« WITASKIMÂGAN, ak, (n. f.) ally, compatriot
+« WITASKITTUWOK, (v. m.) they make peace, they make an alliance
+« WITAPIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he is sitting with him, he holds him in company
+« WITCHETTAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he unites them, he puts them together
+« WITCHETTUWIN, a, (n. f.) society, brotherhood
+« WITCHETTUWOK, (v. m.) they unite in a society, or, they walk together
+« WITCHEWÂGAN, ak, (n. f.) companion, associate; e.g., owitchewâgana, his companion, his associate, his spouse, etc., his disciple
+« WITCHEWÂGANIHEW, (v. a.) TTAW, HIWEW, etc., he makes them companions, he associates with them
+« WITCHEWÂGANITTUWOK, (v. m.) they get together
+« WITCHEWÂGANITTUWIN, a, (n. f.) society, association
+« WITCHEWÂGANIKKAWEW, etc. (v. a.) he gives him as an associate
+« WITCHEWÂGANIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he has him as his associate, as his disciple
+« WITCHEWEW, (v. a.) TTAM, he accompanies him, he goes with him
+« WITCHETTUWOK, (v. m.) they go together, they accompany one another
+« WITCHETTUWIN, a, (n. f.) union, association
+« WITCHIHIWEW, (v. ind.) he accompanies, he is associated, he is part of the association
+
+655
+
+WIT
+
+« WITCHIHIWEWIN, a, (n. f.) accompaniment
+« WITCHIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he helps him, he rescues him
+« WITCHITONÂMEW, etc., (v. a.) he communicates with him
+« WITOJEMEW, etc., (v. a.) he has children with her
+« WITOKKEMEW, etc., (v. a.) he lives in the same lodge as him
+« WITISÂMEW, etc., (v. a.) he is from the same family as him
+« WITCHIWIYÂSSEMEW, etc., (v. a.) he has the same origin as him, he is his flesh and blood
+« WITCHIWIYÂSSETTUWOK, (v. m.) they have the same flesh and blood, they belong to the same origin
+« WITASKÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he pairs them, he matches them
+« WITASKÂTCHIGAN, a, (n. f.) pair, match, assemblage
+« WITCHIMITJISUMEW, (v. a.) he eats with him
+« WITCHI-AYAMIHÂMEW, (v. a.) he prays with him
+« WITCHI-AYAMIMEW, (v. a.) he converses with him
+« WITCHI-PIKISKWEMEW, (v. a.) idem
+« WITCHIKÂBAWISTAWEW, (v. a.) he stands around him
+« WITCHIHIKOWISIW, ok, (a. a.) he is rescued by Heaven
+« WITCHIHIKOWISIWIN, a, (n. f.) divine rescue
+
+WIT
+
+« WITCHI-ISPITISIMEW, (v. a.) he has the same age as him
+« WITCHI-IJINÂKUSIMEW, (v. a.) he resembles him
+« WITCHI-IJIHIKÂSOMEW, (v. a.) he has the same name as him
+« WITCHI-KAKWÂTAKISIMEW, (v. a.) he suffers with him
+« WITCHI-METÂWEMEW, (v. a.) he plays with him
+« WITCHI-MIYÂWÂTAMOMEW, (v. a.) he rejoices with him
+« WITCHI MÂTUMEW, (v. a.) he cries with him
+« WITCHI-MÂKUSEMEW, (v. a.) he celebrates with him, he has a feast with him
+« WITCHI-MINIKKWEMEW, (v. a.) he drinks with him
+« WITCHI-NAKAMOMEW, (v. a.) he sings with him
+« WITCHI-NIPUMEW, (v. a.) he dies with him
+« WITCHI-KAPESIMEW, (v. a.) he camps with him
+« WITCHI-NIPÂMEW, (v. a.) he sleeps with him
+« WITCHI-PITTWÂMEW, (v. a.) he smokes with him
+« WITCHI PISIKWÂTISIMEW, (v. a.) he does bad things with her
+« WITCHI-TEHEMEW, (v. a.) he has the same heart, the same desires as him
+« WITCHI-ATUSKEMEW, (v. a.) he works with him
+« WITCHI-ATUSKEMÂGAN, ak, (n. f.) work companion
+« WITCHI-ATUSKEYÂGAN, ak, (n. f.) co-servant
+x WITCHEKISIW, ok, (a. a.) he reeks, he has a bad smell
+
+656
+
+WIT
+
+« WITCHEKAN, wa, (a. in.) idem
+« WITCHEKISIWIN, a, (n. f.) stench
+« WITCHEKISIN, wok, (a. a.) he is putrid
+« WITCHEKITTIN, wa, (a. in.) idem
+« WITCHEKASKUSIY, a, (n. f.) onion
+x WITTAMÂWEW, etc., (v. a.) he discovers him, he confesses to him
+« WITTAM, wok, (v. n.) he confesses, he makes a confession, he publishes
+« WITTAMOWIN, a, (n. f.) confession, publication
+« WITTAMÂKEW, ok, (v. ind.) he declares
+« WITTAMÂTUWOK, (v. m.) they warn one another, they declare something to one another
+« WITTAMÂTUWIN, a, (n. f.) mutual warning
+x WITISIW, ok, (a. a.) he is haired
+« WITISIWIN, a, (n. f.) great hairiness
+WISOTI, (adv.) e.g., wisoti ijinâkwanoban, or well: kayatte ijinâkwanoban, it was, however, formerly that way
+WITOSPAMEW, he is at the table with him
+x WITTIKOW, ok, (n. r.) cannibal
+« WITTIKOWIW, ok, (a. a.) he is a cannibal
+« WITTIKOWIWIN, a, (n. f.) cannibalism
+
+WIW
+
+x WIWÂHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he loads him with a burden
+« WIWÂHUW, ok, (v. r.) he loads himself with a burden
+« WIWÂHUWIN, a, (n. f.) burden, heavy load
+« WIWÂTCHIGAN, ak, (n. f.) pack animal
+x WIWA, (n. r.) his wife, his spouse; niwa, my wife
+« WIWIW, ok, (a. a.) he has a wife, he is married
+« WIWIMAW, ok, (v. ind.) married woman
+x WIYA, (pron. person. 3rd pers. sing.) him
+« WIYAWAW, (pron. person. 3rd. pers. plur.) them
+WIYA, (conj.) as for; e.g., niya wiya, as for me; kiya wiya, as for you
+x WIYAKÂGAMIW, (v. im.) lukewarm water
+« WIYAKÂGAMITTAW, ok, (v. a. in.) he makes the water lukewarm
++ WIYAK, (rac.) to defile, to spoil, to ruin, to destroy
+« WIYAKISIW, ok, (a. a.) he is spoiled, tainted, ruined
+« WIYAKAN, wa, (a. in.) idem
+« WIYAKISIWIN, a, (n. f.) loss, destruction, damage
+« WIYAKIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he spoils it, he ruins it
+« WIYAKIHUW, ok, (v. r.) he ruins himself, he perverts himself
+« WIYAKIHUWIN, a, (n. f.) ruin, depravity
+« WIYAKIMEW, etc., (v. a.) he defiles him with his words
+
+657
+
+WIY
+
+« WIYAKISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he ruins it, he spoils it by trampling it with his feet, or, by carrying it on him, e.g., those who would carry sacred ornaments our of derision
+« WIYAKITTAMÂWEW, etc., (v. a.) he ruins it for him, he spoils it for him
+« WIYAKKWEW, ok, (v. n.) he says dishonest, dirty words
+« WIYAKKWEWIN, a, (n. f.) shameless, dishonest speech
+« WIYAKKWÂTEW, (v. a.) TAM, SIWEW, TCHIKEW, he judges against him, he says insults, dirty words, etc. to him
+« WIYAMÂTTAMÂWEW, etc., (v. a.) he spends his provisions on him
++ WIYÂMEW, (v. a.) TAM, MIWEW, TCHIKEW, he carries it on him, e.g., a piece of clothing. One also says: wiyâmew, he has her as a wife, it is his asset
+« WIYÂTTAHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he covers him, he gives him clothes
++ WIYANIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he butchers him, he puts him in pieces, a killed animal
+« WIYANITTÂGAN, ak, (n. f.) already-butchered animal
+« WIYANITTÂKEW, ok, (v. ind.) he butchers
+« WIYANITTÂKEWIN, a, (n. f.) butchering
+x WIYÂPAMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he aims at him, or oyâbamew, he aims at him to shoot him
+« WIYÂPATCHIKEW, ok, (v. ind.) he aims, or, oyâbatchikew
+
+WIY
+
+« WIYÂPATCHIGAN, a, (n. f.) sights of a rifle, oya etc.
+x WIYÂS, a, (n. r.) meat, flesh
+« WIYÂSIW, ok, (a. a.) he is fleshy, owiyâsiw, he has meat
+« WIYÂSIWIW, ok, (a. a.) idem
+« WIYÂSIWAN, wa, (a. in.) idem
+x WIYAW, a, (n. r.) his body
+« WIYÂWISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he sustains him, he feeds him, he maintains his body, also: he lives in him
+« WIYAWISKÂKUW, ok, (v. pass.) it sustains him
+x WIYATTE, (ada.) or, oyatte. See. Eyiwek, good enough
+x WIYATTIKUSIW, ok, (a. a.) he is joyous
+« WIYATTIKWAN, wa, (a. in.) idem
+« WIYATTIKUSIWIN, a, (n. f.) joy, rejoicing
+WIYÂWIPATCH, (adv.) expression of recognition, since, e.g., wiyâwipatch e wi miyiyan, since you want to just give it to me, wiyâwipatch e mekwa miyo-kijikâk, ni ka kiwân, while the weather is good, (I take advantage of it) I will return
+WIYESKWÂTAM, (adv.) not any time soon. See. Iskwatâm
+x WIYINOW, ok, (a. a.) he is fat
+« WIYIN, plur. wiyinwa, (n. f.) the fat part
+« WIYINOHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he fattens him up
+« WIYINOWISIW, ok, (a. a.) he is fat
+
+658
+
+WIY
+
+« WIYINOMAGAN, wa, (a. in.) it is fat
++ WIYEW, (v. a.) TTAM, YIWEW, TCHIKEW, he calls him by his name, he names him
+« WITCHIKÂSUW, ok, (a. a.) he named, proclaimed
+« WIYOWIN, a, (n. f.) name, owiyowiniw, he has a name
+x WIYIP, (rac.) tha twhich is dirty, of a brownish colour
+« WIYIPAWEW, ok, (a. a.) he is brown
+« WIYIPÂYOWEW, ok, (a. a.) he has a brown tail
+« WIYIPISIW, ok, (a. a.) he is dirty, unclean
+« WIYIPAW, a, (a. in.) idem
+« WIYIPISIWIN, a, (n. f.) dirtiness, uncleanliness
+« WIYIPIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he dirties it
+« WIYIPIKKWEW, ok, (a. a.) he has a dirty face
+« WIYIPINEW, (v. a.) KAM, NIWEW, NIKEW, he dirties him by touching him
+« WIYIPISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he dirties it by carrying it (a piece of clothing, a shirt), or, by walking on it, etc., e.g., the floor
+« WIYIPITCHITCHEW, ok, (a. a.) he has dirty hands
+« WIYIPISITEW, ok, (a. a.) he has dirty feet
+« WIYIPISTIKWÂNEW, ok, (a. a.) he has a dirty head
+x WIYITIP, a, (n. r.) the brain
+
+YÂ
+
+YÂHEW, (v. a.) HIWEW, etc., he surpasses him, he finishes before him
+« YÂHIWEW, ok, (v. ind.) he finishes his work before the others
+« YÂHIWEWIN, a, (n. f.) victory, the acton of finishing before the others
+x YÂKK, (rac.) light, nimble, agile, to lighten
+« YÂKKÂPISKUSIN, ok, (a. a.) he is light (metal)
+« YÂKKÂPISKAW, a, (a. in.) idem
+« YÂKKÂSKUSIW, ok, (a. a.) idem (wood)
+« YÂKKÂSKWAN, wa, (a. in.) idem
+« YÂKKÂSTIMUN, a, (n. f.) sail of a vessel
+« YÂKKÂSTIMUNÂTTIK, wa, (n. f.) mast
+« YÂKKÂSTIMUNEGIN, wa, (n. f.) sailcloth
+« YÂKKÂSTIMOW, ok, (p. n.) he goes by sail
+« YÂKKÂSTIMEW, (v. a.) TAW, etc., he makes it go by wind
+« YÂKKITISIW, ok, (a. a.) he is light
+« YÂKKASIN, wa, (a. in.) idem
+« YÂKKITISIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he lightens it
+« YÂKKIHEW, etc., (v. a.) idem
+« YÂKKIHUW, ok, (v. r.) he lightens himself
+« YÂKKITISIWIN, a, (n. f.) lightness
+« YAKKIPAYIW, ok, a, (a. a. and in.) it becomes light
++ YAKK, (rac.) to increase, to expand, to grow, to widen
+
+659
+
+« YAKKES, (adv.) further, increasing
+« YÂKKIKIW, ok, (a. a.) he grows
+« YAKKIKIN, wa, (a. in.) idem
+« YAKKIKIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he increases it, he multiplies it
+YAKKIMOHEW, etc., (v. a.) idem
+« YAKKIMOW, ok, (v. n.) he expands, he increases, he becomes more numerous
+« YAKKIPAYIW, ok, a, (a. a. and in.) idem
+« YAKKIHEW, etc., (v. a.) he multiplies him, he increases him, e.g., yakkittamâwinân tâpwewokeyittamâwin, adauge nobis fidem (increase our faith)
+« YAKKINEW, (v. a.) NAM, NIWEW, NIKEW, he pushes it forward with his hand
+« YAKKISKAWEW, (v. a.) KAM KÂKEW, KÂTCHIKEW, he pushes it forward with his foot
+« YAKKIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he pulls it forward
+« YAKKAHWEW, (v. a.) HAM, HUWEW, HIKEW, he pushes it forward, e.g., pushing something forward with a piece of wood
+« YAKKITISAHWEW, (v. a.) HAM, HUWEW, HIKEW, he sends it, he leads it, he hunts it ahead of him
+x YÂKKI, (adv.) in the old days it seems, (constat, videtur (it seems certain, it appears)) e.g., ekusi itwâniw yâkki, it seems that one said this, a long time ago, e.g., n't'em yâkki, it was my horse, a long time ago. N.B. In a narration of things that one has not seen, this adverb is used favorably, yâkki ot ayâttay peyak ayisiyiniw, a long time ago, there was a man, ekusi ot'iji hikâsuttay yâkki, (videtur sic nominatum esse (he is seen to be named this way))
+
+YÂK
+
++ YÂKWÂMEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he is attentive around him, considerate, he busies himself with him a lot, he courts him, he is persistent around him. N.B. For this rac. and its derivations, it is the same thing as ayâkwâmeyimew
+« YÂKWÂMEYIMOW, ok, (v. n.) he is persistent, he gives more and more of his care
+« YÂKWÂMEYIMOWIN, a, (n. f.) perseverance, attention
+« YÂKWÂMIMEW, etc., (v. a.) he encourages him, he speaks to him about it constantly
+« YÂKWÂMISIW, ok, (a. a.) he is on guard, cautious, suspicious (cautus, providus (cautious, careful)), perseverant
+« YÂKWÂMISIWIN, a, (n. f.) perseverance, foresight, caution
+x YÂS, (rac.) to descend, to lower oneself
+« YÂSÂPEKINEW, (v. a.) NAM, NIWEW, NIKEW, he lowers it, he lowers it by means of a rope, e.g., to lower a flag, a sail, etc.
+« YÂSINEW, (v. a.) he lowers it with his hand
+« YÂSIPAYIHUW, ok, (v. r.) he lowers himself, he slides down
+« YÂSIPAYIW, ok, a, (a. a. and in.) he descends, he goes down
+« YÂSIPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he lowers it, he makes it go down
+
+660
+
+YÂW
+
+« YÂSITINEW, etc., (v. a.) he sends it to the bottom, he lowers it to the ground
+« YÂSITISAHAMÂWEW, etc., (v. a.) he lowers it to the ground for him
+« YÂSISTAWEW, etc., (v. a.) he descends towards him, e.g., Jesus Christ ki ki pe-yâsistâkonow, Jesus Christ came down to us
+« YÂSITOTAWEW, etc., (v. a.) idem
+« YÂSIW, ok, (v. n.) he descends, he lowers himself towards the ground
+« YÂSIWIN, a, (n. f.) descent, the action of descending on the ground
+« YÂSASKEW, ok, (v. n.) he descends on the ground
+x YÂTTOKAMIK, (ad.) See. Ayâtokamik, in another house, in another lodge
+x YÂW, (rac.) indicates that there is not enough, insufficient, to be willing to miss something before reaching it, below
+« YÂWÂPAMEW, (v. a.) TTAM, KKEW, etc., he cannot see it because it is too far, his vision is not long enough to see it
+« YÂWINAWEW, (v. a.) NAM, NÂKEW, NÂTCHIKEW, idem. N.B. All of this root reinforces the idea of nottow. See. higher
+« YÂWINÂKUSIW, ok, (a. a.) he is out of sight, he is imperceptible
+« YÂWINÂKWAN, wa, (a. in.) idem
+« YÂWINEW, (v. a.) NAM, NIWEW, NIKEW, he cannot grasp it with his hand, he cannot reach it
+« YÂWÂSITTAWEW, (v. a.) TTAM, TTÂKEW, TTÂTCHIKEW, he cannot understand his voice, he cannot understand, because there is too great of a distance
+
+YÂW
+
+« YÂWISITTÂKUSIW, ok, (a. a.) he is out of reach to be heard, to be understood
+« YÂWEW, (v. im.) it is heard from far away, e.g., a noise, a sound, barely perceptible
+« YÂWETTIN, (v. im.) idem
+« YÂWIPAYIW, ok, a, (a. a. and in.) he lacks, he comes up short
+« YÂWIPAYIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he comes up short, he cannot finish it
+« YÂYÂWÂTCH, or, YÂWÂTCH, (adv.) See. Nottow, wespinatch
+« YÂYAWATCHIPAYIW, ok, a, (a. a. and in.) he lacks it, it turns out to be less than it should be, etc.
+« YÂYÂWATCHIYÂWEW, etc., (v. a.) he angers him over a little thing
+« YÂWISIW, ok, (a. a.) e.e., a bladder blown up by the wind, and which empties itself
+« YÂWAW, a, (a. in.) idem
+« YÂWASKENAM, wok, (v. n.) he loses the bottom, e.g., when walking in water
+« YÂYÂWATEYIMEW, (v. a.) TTAM, MIWEW, TCHIKEW, he finds him incapable of it
+x YÂYÂNAM, wok, (v. n.) he swims
+x YÂYIKIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, to split, to tear with effort
+
+661
+
+YEY
+
+« YÂYIKIPAYIW, ok, a, (a. a. and in.) it tears
+« YÂYAHWEW, (v. a.) HAM, HUWEW, HIKEW, he rubs it
+« YÂYISKIPITEW, (v. a.) TAM, SIWEW, TCHIKEW, he tears it from, etc, he pulls it off
+« YÂYISKWENEW, (v. a.) NAM, NIWEW, NIKEW, he rubs his face softly, e.g., when embracing him, in offering him peace
+YÂYO, (adv.) or IYÂYOW, indicates inclination, a strong propensity, e.g, yâyow wi-kisiwâsiw, he has a strong propensity for anger
+x YEKAW, (v. imp.) or, IYEKAW, there is sand
+« YAKAWÂGAMIW, (v. im.) sandy water
+« YEKÂWIMASKUTEW, (v. im.) prairie covered in sand
+« YEKÂWISKAW, (v. im.) it is sandy
+« YEKÂWAN, (v. im.) idem
+« YEKÂTÂWOKKAW, a, (n. f.) sandbank
+x YEYIHEW, etc., (v. a.) he incites him to do so, by his example, he gives him an example
+« YEYIMEW, etc., (v. a.) idem, by his words
+x YEYEW, ok, (v. n.) he breathes, he draws breath
+« YEYEWIN, a, (n. f.) breath, respiration
+« YEYESUW, ok, (v. n.) he breathes with all his lungs, e.g. a dog who is quite hot, he is breathless
+« YEYESUWIN, a, (n. f.) action of being breathless
+
+YIK
+
+x YIKITCHIKÂWIW, ok, (a. a.) he is lazy, nonchalant
+« YIKITCHIKÂWIWIN, a, (n. f.) laziness, nonchalance
++ YIKISTIKWEYAW, (v. im.) there is a fork in the road or river
+« YIKITTOWISIW, ok, (a. a.) he splits into a fork, he is forked
+« YIKITTOWAW, a, (a. in.) ide
+« YIKITTOWITESKANEW, ok, (a. a.) he has a forked crossing, he has forked horns
+« YIKITAWAMUW, a, (a. in.) trail which forks
+x YIK, (rac.) to milk, to make (something) come out by pressing
+« YIKÂHWEW, (v. a.) HAM, HUWEW, HIKEW, he extracts it, he makes it come out, e.g., making grease come out of a bladder by pressing it
+« YIWAW, a, (n. f.) it deflates
+« YIWIPAYIW, ok, a, (a. a. and in.) he deflates, e.g., having swelling, he stops being swollen
+« YIKUHWEW, (v. a.) HAM, HUWEW, HIKEW, he milks it
+« YIKINEW, (v. a.) NAM, NIWEW, NIKEW, he milks it, he makes liquid come out
++ YIYIKISIW, ok, (a. a.) he is forked, like fingers
+« YIYIKAW, a, (a. in.) idem
+« YIYIKASTIS, ak, (n. f.) glove
+« YIYIKISITAN, a, (n. f.) toe
+« YIYIKITCHITCHÂN, a, (n. f.) finger
+x YIWAHWEW, (v. a.) HAM, HUWEW, HIKEW, he grinds it, he crushes it
+« YIWATAHWEW, etc., (v. a.) idem
+
+662
+
+YOS
+
+« YIWAHIKEW, ok, (v. ind.) he crushes, he grinds
+« YIWAHIGAN, ak, (n. f.) or, iyiwahigan, ak, dried and crushed meat
+x YIYIPPIW, ok, (a. a.) he is agile, active, diligent
+« YIYIPPIWIN, a, (n. f.) activity, diligence
+x YIKWÂKUNEHWEW, (v. a.) HAM, HUWEW, HIKEW, he covers him with snow, he buries him under the snow
+« YIKWÂKUNEW, ok, (a. a.) he is under the snow
+x YIKWASKWAN, (v. im.) or iyikwaskwan, the weather is overcast
+YO-HO! (ex.) of surprise, also, expression of incredulity
+x YOSK, (rac.) soft, weak, tender
+« YOSKISKIWOKAW, (v. im.) soft, muddy ground
+« YOSKATCHAW, (v. im.) soft terrain
+« YOSKÂTISIW, ok, (a. a.) he is soft
+« YOSKÂTAN, wa, (a. in.) idem
+« YOSKÂTISIWIN, a, (n. f.) softness
+« YOSKISIW, ok, (a. a.) he is soft
+« YOSKAW, a, (a. in.) idem
+« YOSKISIWIN, a, (n. f.) weakness
+« YOSKIHEW, (v. a.) TTAW, HIWEW, TCHIKEW, he makes it soft, he softens it
+« YOSKÂBISKISIW, ok, (a. a.) he is soft, hardly solid (metal)
+« YOSKÂBISKAW, a, (a. in.) idem
+« YOSKÂSKUSIW, ok, (a. a.) idem (wood)
+« YOSKÂSKWAN, wa, (a. in.) idem
+
+YOS
+
+« YOSKINEW, (v. a.) NAM, NIWEW, NIKEW, he softens it with his hand
+« YOSKISKAWEW, (v. a.) KAM, KÂKEW, KÂTCHIKEW, he softs it with his feet
+« YOSKITTAK, wa, (n. f.) rotten, decayed wood
+« YOSKITTAKAW, (v. in.) there is rotten wood
+YOSPÂTISIW, ok, (a. a.) he is sweet, friendly
+« YOSPÂTAN, wa, (a. in.) it is sweet
+« YOSPÂTISIWIN, a, (n. f.) sweetness, friendliness
+« YOSPISIW, ok, (a. a.) he is soft, tender
+« YOSPAW, a, (a. in.) idem
+« YOSPISIWIN, a, (n. f.) softness, tenderness
+« YOSPISIHEW, etc., (v. a.) he softens him, he tames him
+« YOSKITEHEW, ok, (a. a.) he has a tender heart
+
+663
+
+YOW
+
+« YOSKITEHEWIN, a, (n. f.) tenderness of heart
+« YOSKITEHESTAWEW, etc., (v. a.) he has a tender heart for him
+x YOTTEHWEW, (v. a.) HAM, HUWEW, HIKEW, he opens it, e.g., a door
+« YOTTENEW, (v. a.) NAM, NIWEW, NIKEW, idem
+« YOTTEWEPAHWEW, (v. a.) HAM, HUWEW, HIKEW, he opens it violently, he shoves it
+« YOTTEKUTEW, a, (a. in.) it is open, e.g., a door
+x YOTIN, (v. im.) it is windy, e.g., tande wettik, where is the wind coming from?
+« OTTIN, wok, (n. f.) the wind
+x YOWÂNAM, wok, (v. n.) it has been a long time since he has passed, his prints are old
+x YOWEW, (v. im.) the wind takes up, it gets windy
+


### PR DESCRIPTION
Added a full manual translation of the LaCombe Dictionary into English, totalling ~11500 entries, formatted as similarly to LaCombe's original style as was practical. This translation includes only the Cree-French lexicon segment, excluding the entirety of the French-Cree section, the introduction to the Cree-French section (which has already been translated), and the grammar and phrasebook section constituting the final ~250 pages of the dictionary, Headwords and some inflectional suffixes are written in capital letters, while glosses and example sentences are in lowercase, with the two being separated by commas. Page numbers and headers have been included, despite their relative redundancy, for ease of comparison with the original document. 